### PR TITLE
Fixed workspace creation, user sign-up improved, added 'profile' dropdown in navbar that shows username

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -1,16 +1,28 @@
 import { TypedResponse } from "@remix-run/node";
 import { Link, NavLink, useNavigate } from "@remix-run/react";
-import { AuthError } from "@supabase/supabase-js";
+import { AuthError, User } from "@supabase/supabase-js";
 import { ModeToggle } from "./mode-toggle";
 import { Button } from "./ui/button";
 import WorkspaceSelectorCombobox from "./WorkspaceSelectorCombobox";
 import { WorkspaceData } from "~/lib/types";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+
+import { FaUserAlt } from "react-icons/fa";
 
 export default function Navbar({
   className,
   handleSignOut,
   workspaces,
   isSignedIn,
+  user,
 }: {
   className?: string;
   handleSignOut: () => Promise<
@@ -20,6 +32,15 @@ export default function Navbar({
   >;
   workspaces: WorkspaceData;
   isSignedIn: boolean;
+  user: JsonifyObject<{
+    access_level: string | null;
+    created_at: string;
+    first_name: string | null;
+    id: string;
+    last_name: string | null;
+    organization: number | null;
+    username: string;
+  }> | null;
 }) {
   // console.log(workspaces);
   const navigate = useNavigate();
@@ -80,6 +101,19 @@ export default function Navbar({
               <p className="block sm:hidden">Login</p>
               <p className="hidden sm:block">Sign In</p>
             </Link>
+          )}
+          {user != null && (
+            <DropdownMenu>
+              <DropdownMenuTrigger>
+                <Button>
+                  <FaUserAlt />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuLabel>My Username:</DropdownMenuLabel>
+                <DropdownMenuLabel>{user.username}</DropdownMenuLabel>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           <ModeToggle />
         </div>

--- a/app/lib/database.server.ts
+++ b/app/lib/database.server.ts
@@ -30,7 +30,8 @@ export async function getUserWorkspaces({
   return { data, error };
 }
 
-export async function createNewWorkspace({
+// THIS FUNCTION IS NOW DEPRECATED
+export async function createNewWorkspaceDeprecated({
   supabaseClient,
   userId,
   name,
@@ -41,11 +42,34 @@ export async function createNewWorkspace({
 }) {
   const { data, error } = await supabaseClient
     .from("workspace")
-    .insert({ owner: userId, name, users: [userId] })
+    .insert({ owner: userId, name })
     .select("id")
     .single();
 
   return { data, error };
+}
+
+export async function createNewWorkspace({
+  supabaseClient,
+  workspaceName,
+}: {
+  supabaseClient: SupabaseClient<Database>;
+  workspaceName: string;
+}) {
+  const { data: insertWorkspaceData, error: insertWorkspaceError } =
+    await supabaseClient.rpc("create_new_workspace", {
+      new_workspace_name: workspaceName,
+    });
+  // console.log("Inside createNewWorkspace: ", insertWorkspaceData);
+
+  if (insertWorkspaceError) {
+    return { data: null, error: insertWorkspaceError };
+  }
+
+  // const { data: insertWorkspaceUsersData, error: insertWorkspaceUsersError } =
+  //   await supabaseClient.from("workspace_users").insert({ workspace });
+
+  return { data: insertWorkspaceData, error: insertWorkspaceError };
 }
 
 export async function getWorkspaceInfo({
@@ -70,78 +94,70 @@ export async function getWorkspaceInfo({
   return { data, error };
 }
 
-// type getTableDataByIdProps = {
-//   supabaseClient: SupabaseClient<Database>;
-//   tableName: string;
-//   rowId?: string;
-//   columnNames?: string[];
-// };
-
-// Too Generic
-// export async function getTableDataById({
-//   supabaseClient,
-//   tableName,
-//   rowId = "",
-//   columnNames,
-// }: getTableDataByIdProps) {
-//   const joinedColumnNames = columnNames?.join(",");
-//   const tableDataQuery = supabaseClient
-//     .from(tableName)
-//     .select(joinedColumnNames || "*");
-//   // .eq("id", rowId);
-
-//   const { data, error } = await tableDataQuery;
-//   // console.log("getTableDataById: ", data);
-
-//   if (error) {
-//     console.log("Error on function getTableDataById: ", error);
-//   }
-
-//   return { data, error };
-// }
-
-export async function getWorkspaceAudiences({
-  supabaseClient,
-  workspaceId
-}: {
-  supabaseClient: SupabaseClient<Database>;
-}) {
-  const { data, error } = await supabaseClient.from("audience").select().eq('workspace', workspaceId);
-
-  if (error) {
-    console.log("Error on function getWorkspaceAudiences");
-  }
-
-  return { data, error };
-}
-
 export async function getWorkspaceCampaigns({
   supabaseClient,
-  workspaceId
+  workspaceId,
 }: {
   supabaseClient: SupabaseClient<Database>;
   workspaceId: string;
 }) {
-  const { data, error } = await supabaseClient.from("campaign").select().eq('workspace', workspaceId);
+  const { data, error } = await supabaseClient.rpc(
+    "get_campaigns_by_workspace",
+    { workspace_id: workspaceId },
+  );
 
   if (error) {
-    console.log("Error on function getWorkspaceAudiences");
+    console.log("Error on function getWorkspaceCampaigns");
   }
 
   return { data, error };
 }
 
-export async function getWorkspaceContacts({
+export async function getWorkspaceUsers({
   supabaseClient,
-  workspaceId
+  workspaceId,
 }: {
   supabaseClient: SupabaseClient<Database>;
+  workspaceId: string;
 }) {
-  const { data, error } = await supabaseClient.from("contact").select().eq('workspace', workspaceId);
-
+  const { data, error } = await supabaseClient.rpc("get_workspace_users", {
+    selected_workspace_id: workspaceId,
+  });
+  // console.log("INSIDE FUNC:", data);
   if (error) {
-    console.log("Error on function getWorkspaceAudiences");
+    console.log("Error on function getWorkspaceUsers", error);
   }
+
+  return { data, error };
+}
+
+export async function addUserToWorkspace({
+  supabaseClient,
+  workspaceId,
+}: {
+  supabaseClient: SupabaseClient<Database>;
+  workspaceId: string;
+}) {
+  return;
+}
+
+export async function testAuthorize({
+  supabaseClient,
+  workspaceId,
+  permission,
+}: {
+  supabaseClient: SupabaseClient<Database>;
+  workspaceId: string;
+  permission: string;
+}) {
+  const { data, error } = await supabaseClient.rpc("authorize", {
+    selected_workspace_id: workspaceId,
+    requested_permission: permission,
+  });
+  console.log("\nXXXXXXXXXXXXXXXXXXXXXXXXX");
+  console.log("Data: ", data);
+  console.log("Error: ", error);
+  console.log("XXXXXXXXXXXXXXXXXXXXXXXXX");
 
   return { data, error };
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -63,6 +63,12 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     token = newToken;
   }
 
+  const { data: userData, error: userError } = await supabase
+    .from("user")
+    .select()
+    .eq("id", session?.user.id ?? "")
+    .single();
+
   const { data: workspaces, error: workspaceQueryError } =
     await getUserWorkspaces({ supabaseClient: supabase });
 
@@ -72,6 +78,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
       session,
       token,
       workspaces,
+      user: userData,
     },
     {
       headers: response.headers,
@@ -80,7 +87,8 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
 };
 
 export default function App() {
-  const { env, session, token, workspaces } = useLoaderData<typeof loader>();
+  const { env, session, token, workspaces, user } =
+    useLoaderData<typeof loader>();
   const device = useTwilioDevice(token);
   const { revalidate } = useRevalidator();
   const supabase = createBrowserClient<Database>(
@@ -132,6 +140,7 @@ export default function App() {
             handleSignOut={signOut}
             workspaces={workspaces}
             isSignedIn={serverAccessToken != null}
+            user={user}
           />
           <Outlet context={{ supabase, env, device }} />
         </ThemeProvider>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -15,89 +15,88 @@ export const meta: MetaFunction = () => {
 export const loader = async ({ request }: { request: Request }) => {
   const { headers, serverSession } =
     await getSupabaseServerClientWithSession(request);
-    return json({ headers });
+  return json({ headers });
 };
 
 export default function Index() {
   return (
-    <main className="mx-auto flex h-full w-full items-center justify-center text-white bg-[url('/Hero')]">
-        <div className="w-400 mx-auto py-40">
-          <h1 className="text-center font-Tabac-Slab text-6xl font-black text-brand-primary">
-            CallCaster
-          </h1>
-          <p className="text-center font-Zilla-Slab text-3xl font-black text-slate-800 dark:text-slate-200">
-            Real-Time Connections, Real Results.
+    <main className="flex h-full w-full items-center justify-center gap-16 px-16 py-32 text-white">
+      <div className="">
+        <h1 className="text-center font-Tabac-Slab text-6xl font-black text-brand-primary">
+          CallCaster
+        </h1>
+        <p className="text-center font-Zilla-Slab text-3xl font-black text-slate-800 dark:text-slate-200">
+          Real-Time Connections, Real Results.
+        </p>
+      </div>
+
+      <div
+        id="login-card"
+        className="flex aspect-square flex-col items-center justify-center gap-5 rounded-md bg-brand-secondary px-24 pb-12 pt-8 shadow-lg dark:border-2 dark:border-white dark:bg-zinc-900 dark:bg-opacity-80 dark:shadow-none"
+      >
+        <h2 className="mb-4 font-Zilla-Slab text-6xl font-bold text-brand-primary dark:text-white">
+          Login
+        </h2>
+
+        <Button
+          variant={"outline"}
+          className="flex min-h-[56px] w-full gap-2 border-2 border-black bg-transparent font-Zilla-Slab text-xl font-semibold text-black dark:border-white dark:text-white dark:hover:bg-white dark:hover:text-black"
+        >
+          <FcGoogle size={"2rem"} />
+          Sign in with Google
+        </Button>
+        <Button
+          variant={"outline"}
+          className="flex min-h-[56px] w-full gap-2 border-2 border-black bg-transparent font-Zilla-Slab text-xl font-semibold text-black dark:border-white dark:text-white dark:hover:bg-white dark:hover:text-black"
+        >
+          <FaGithub size={"2rem"} />
+          Sign in with Github
+        </Button>
+
+        <div className="flex w-full items-center justify-center gap-2">
+          <div className="w-full border border-brand-primary dark:border-brand-secondary" />
+          <p className="font-Zilla-Slab text-xl font-semibold text-brand-primary dark:text-brand-secondary">
+            OR
           </p>
+          <div className="w-full border border-brand-primary dark:border-brand-secondary" />
         </div>
 
-        <div
-          id="login-card"
-          className="flex aspect-square flex-col items-center justify-center gap-5 rounded-md bg-brand-secondary px-28 py-8 shadow-lg dark:border-2 dark:border-white dark:bg-transparent dark:shadow-none"
+        <Form
+          id="homepage-signin-form"
+          method="POST"
+          className="flex w-full flex-col gap-4"
+          action="/signin"
         >
-          <h2 className="mb-4 font-Zilla-Slab text-6xl font-bold text-brand-primary dark:text-white">
-            Login
-          </h2>
-
-          <Button
-            variant={"outline"}
-            className="flex min-h-[56px] w-full gap-2 border-2 border-black bg-transparent font-Zilla-Slab text-xl font-semibold text-black dark:border-white dark:text-white dark:hover:bg-white dark:hover:text-black"
+          <label
+            htmlFor="email"
+            className="flex w-full flex-col font-Zilla-Slab text-2xl font-semibold tracking-[1px] text-black dark:text-white"
           >
-            <FcGoogle size={"2rem"} />
-            Sign in with Google
-          </Button>
-          <Button
-            variant={"outline"}
-            className="flex min-h-[56px] w-full gap-2 border-2 border-black bg-transparent font-Zilla-Slab text-xl font-semibold text-black dark:border-white dark:text-white dark:hover:bg-white dark:hover:text-black"
+            Email
+            <input
+              type="text"
+              name="email"
+              id="email"
+              className="w-full rounded-sm border-2 border-black bg-transparent px-4 py-2 text-black dark:border-white dark:text-white"
+            />
+          </label>
 
+          <label
+            htmlFor="password"
+            className="flex w-full flex-col font-Zilla-Slab text-2xl font-semibold tracking-[1px] text-black dark:text-white"
           >
-            <FaGithub size={"2rem"} />
-            Sign in with Github
-          </Button>
-
-          <div className="flex w-full items-center justify-center gap-2">
-            <div className="w-full border border-brand-primary dark:border-brand-secondary" />
-            <p className="font-Zilla-Slab text-xl font-semibold text-brand-primary dark:text-brand-secondary">
-              OR
-            </p>
-            <div className="w-full border border-brand-primary dark:border-brand-secondary" />
-          </div>
-
-          <Form
-            id="homepage-signin-form"
-            method="POST"
-            className="flex w-full flex-col gap-4"
-            action="/signin"
-          >
-            <label
-              htmlFor="email"
-              className="flex w-full flex-col font-Zilla-Slab text-2xl font-semibold tracking-[1px] text-black dark:text-white"
-            >
-              Email
-              <input
-                type="text"
-                name="email"
-                id="email"
-
-                className="w-full rounded-sm border-2 border-black bg-transparent px-4 py-2 text-black dark:border-white dark:text-white"
-              />
-            </label>
-
-            <label
-              htmlFor="password"
-              className="flex w-full flex-col font-Zilla-Slab text-2xl font-semibold tracking-[1px] text-black dark:text-white"
-            >
-              Password
-              <input
-                type="password"
-                name="password"
-                id="password"
-                className="w-full rounded-sm border-2 border-black bg-transparent px-4 py-2 text-black dark:border-white dark:text-white"
-              />
-            </label>
-          </Form>
-
+            Password
+            <input
+              type="password"
+              name="password"
+              id="password"
+              className="w-full rounded-sm border-2 border-black bg-transparent px-4 py-2 text-black dark:border-white dark:text-white"
+            />
+          </label>
+        </Form>
+        <div className="flex w-full gap-4">
           <Button
-            className="min-h-[48px] rounded-md bg-brand-primary px-16 py-2 font-Zilla-Slab text-3xl font-bold tracking-[1px] text-white
+            size={null}
+            className="w-full rounded-md bg-brand-primary py-2 font-Zilla-Slab text-3xl font-bold tracking-[1px] text-white
             transition-colors duration-150 ease-in-out hover:bg-brand-secondary hover:bg-white hover:text-black"
             type="submit"
             form="homepage-signin-form"
@@ -106,21 +105,27 @@ export default function Index() {
           </Button>
           <Link
             to={"/signup"}
-            className="text-center font-Zilla-Slab text-xl font-bold tracking-[1px] text-black transition-all
-            duration-150 hover:text-brand-primary hover:underline dark:text-brand-secondary dark:hover:text-brand-primary"
+            className="w-full rounded-md bg-gray-300 px-3 py-2 text-center font-Zilla-Slab text-3xl font-bold
+          text-black transition-colors duration-150 ease-in-out hover:bg-gray-700 hover:text-white"
           >
-            Don't Have an Account Yet?
-            <br />
-            Click <span className="text-brand-primary">HERE</span> to Sign-Up!
+            Sign Up
           </Link>
-          <Link
-              to={"/signup"}
-              className="rounded-md bg-gray-300 px-3 py-2 font-bold text-black
-              transition-colors duration-150 ease-in-out hover:bg-gray-700 hover:text-white"
-              >
-              Sign Up
-            </Link> 
         </div>
+        {/* <Link
+          to={"/signup"}
+          className="text-center font-Zilla-Slab text-xl font-bold tracking-[1px] text-black transition-all
+            duration-150 hover:text-brand-primary hover:underline dark:text-brand-secondary dark:hover:text-brand-primary"
+        >
+          Don't Have an Account Yet?
+          <br />
+          Click <span className="text-brand-primary">HERE</span> to Sign-Up!
+        </Link> */}
+      </div>
+      <img
+        alt="background"
+        src="/Hero-1.png"
+        className="absolute left-0 top-[10px] z-[-1] h-screen w-screen overflow-hidden object-cover opacity-10"
+      />
     </main>
   );
 }

--- a/app/routes/workspaces.tsx
+++ b/app/routes/workspaces.tsx
@@ -1,11 +1,22 @@
 import { ActionFunctionArgs, json, redirect } from "@remix-run/node";
-import { Form, Link, useLoaderData } from "@remix-run/react";
-import { useRef } from "react";
+import { Form, Link, useActionData, useLoaderData } from "@remix-run/react";
+import { useEffect, useRef } from "react";
 import { FaPlus } from "react-icons/fa";
 import { FaUserPlus } from "react-icons/fa6";
 import { Button } from "~/components/ui/button";
 import { createNewWorkspace, getUserWorkspaces } from "~/lib/database.server";
 import { getSupabaseServerClientWithSession } from "~/lib/supabase.server";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from "~/components/ui/dialog";
+import { toast, Toaster } from "sonner";
 
 //************LOADER************/
 export const loader = async ({ request }: { request: Request }) => {
@@ -28,20 +39,19 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const formData = await request.formData();
 
-  const name = formData.get("newWorkspaceName") as string;
+  const newWorkspaceName = formData.get("newWorkspaceName") as string;
   const userId = formData.get("userId") as string;
 
-  if (!name || !userId) {
+  if (!newWorkspaceName || !userId) {
     return json(
       { error: "Workspace name or User Id missing!" },
       { status: 400, headers },
     );
   }
 
-  const { data, error } = await createNewWorkspace({
+  const { data: newWorkspaceId, error } = await createNewWorkspace({
     supabaseClient,
-    userId,
-    name,
+    workspaceName: newWorkspaceName,
   });
 
   if (error) {
@@ -52,8 +62,8 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     );
   }
 
-  if (data && data.id) {
-    return redirect(`/workspaces/${data.id}`, { headers });
+  if (newWorkspaceId) {
+    return redirect(`/workspaces/${newWorkspaceId}`, { headers });
   }
 
   return json({ ok: true, error: null }, { headers });
@@ -64,11 +74,18 @@ export default function Workspaces() {
   const { workspaces, userId } = useLoaderData<typeof loader>();
   // console.log(workspaces);
 
+  const actionData = useActionData<typeof action>();
+  useEffect(() => {
+    if (actionData?.error) {
+      toast.error(actionData?.error);
+    }
+  }, [actionData]);
+
   const dialogRef = useRef<HTMLDialogElement>(null);
 
   return (
     <main className="mx-auto flex h-full w-full flex-col items-center gap-16 py-16">
-      <h1 className="text-center font-Tabac-Slab text-4xl ">
+      <h1 className="text-center font-Zilla-Slab text-6xl font-bold text-brand-primary dark:text-white">
         Your Workspaces
       </h1>
       <div className="flex flex-row flex-wrap gap-4">
@@ -77,7 +94,7 @@ export default function Workspaces() {
             <Link
               to={`/workspaces/${workspace.id}`}
               key={workspace.id}
-              className="flex flex-col items-center gap-4 rounded-md border bg-card px-4 py-8 text-center min-w-60"
+              className="flex min-w-60 flex-col items-center gap-4 rounded-md border bg-card px-4 py-8 text-center"
             >
               <h5 className="font-Zilla-Slab text-2xl text-white">
                 {workspace.name}
@@ -85,36 +102,96 @@ export default function Workspaces() {
               <p className="text-white">Workspace Description</p>
             </Link>
           ))}
-        <Button
-          variant="outline"
-          className="h-full min-h-fit border border-white px-4 py-8 min-w-60"
-          onClick={() => dialogRef.current?.showModal()}
-        >
-          <div className="hidden dark:block">
-            <FaPlus
-              size="72px"
-              color="white"
-              style={{
-                border: "2px solid white",
-                borderRadius: "50%",
-                padding: "0.75rem",
-              }}
-            />
-          </div>
-          <div className="block dark:hidden">
-            <FaPlus
-              size="72px"
-              color="black"
-              style={{
-                border: "2px solid black",
-                borderRadius: "50%",
-                padding: "0.75rem",
-              }}
-            />
-          </div>
-        </Button>
+
+        <Dialog>
+          <DialogTrigger>
+            <Button
+              variant="outline"
+              className="h-full min-h-fit min-w-60 border border-white px-4 py-8"
+            >
+              <div className="hidden dark:block">
+                <FaPlus
+                  size="72px"
+                  color="white"
+                  style={{
+                    border: "2px solid white",
+                    borderRadius: "50%",
+                    padding: "0.75rem",
+                  }}
+                />
+              </div>
+              <div className="block dark:hidden">
+                <FaPlus
+                  size="72px"
+                  color="black"
+                  style={{
+                    border: "2px solid black",
+                    borderRadius: "50%",
+                    padding: "0.75rem",
+                  }}
+                />
+              </div>
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="bg-brand-secondary dark:bg-inherit">
+            <DialogHeader>
+              <DialogTitle>
+                <h3 className="text-center font-Zilla-Slab text-4xl font-black">
+                  Add a New Workspace
+                </h3>
+              </DialogTitle>
+              <DialogDescription>
+                <p className="hidden">Add a New Workspace to Your Account</p>
+              </DialogDescription>
+            </DialogHeader>
+
+            <Form
+              className="flex w-full flex-col gap-4"
+              method="POST"
+              onSubmit={() => dialogRef.current?.close()}
+              name="newWorkspace"
+            >
+              <label htmlFor="newWorkspaceName" className="flex flex-col gap-2">
+                Enter your Workspace Name
+                <input
+                  type="text"
+                  name="newWorkspaceName"
+                  id="newWorkspaceName"
+                  className="rounded-sm border-2 border-black bg-transparent px-4 py-2 text-xl dark:border-white"
+                  required
+                />
+              </label>
+
+              <input type="hidden" name="userId" value={userId.id} />
+              {/* <p className="flex items-center gap-4 font-bold">
+                Invite Workspace Members:{" "}
+                <Button className="" type="button">
+                  <FaUserPlus size="24px" />
+                </Button>
+              </p> */}
+              <div className="flex gap-4">
+                <Button
+                  variant="default"
+                  className="w-full text-xl"
+                  type="submit"
+                >
+                  Create New Workspace
+                </Button>
+                <DialogClose asChild>
+                  <Button
+                    variant="ghost"
+                    className="w-full text-xl"
+                    type="button"
+                  >
+                    Close
+                  </Button>
+                </DialogClose>
+              </div>
+            </Form>
+          </DialogContent>
+        </Dialog>
       </div>
-      <dialog ref={dialogRef} className="rounded-md bg-indigo-400 p-8">
+      {/* <dialog ref={dialogRef} className="rounded-md bg-indigo-400 p-8">
         <div className="flex flex-col gap-4">
           <h3 className="font-Tabac-Slab text-4xl font-black">
             Add a New Workspace
@@ -152,7 +229,8 @@ export default function Workspaces() {
             </Button>
           </Form>
         </div>
-      </dialog>
+      </dialog> */}
+      <Toaster richColors />
     </main>
   );
 }

--- a/app/routes/workspaces_.$id.tsx
+++ b/app/routes/workspaces_.$id.tsx
@@ -1,46 +1,58 @@
 import {
   json,
+  Link,
+  Outlet,
   redirect,
   useLoaderData,
   useNavigate,
-  Outlet,
-  Link,
-  useOutletContext,
 } from "@remix-run/react";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { PlusIcon } from "~/components/Icons";
 import { WorkspaceDropdown } from "~/components/WorkspaceDropdown";
-import { audienceColumns, campaignColumns, contactColumns } from "~/components/WorkspaceTable/columns";
 import {
-  getWorkspaceAudiences,
-  getWorkspaceCampaigns,
-  getWorkspaceContacts,
-  getWorkspaceInfo,
-} from "~/lib/database.server";
+  audienceColumns,
+  campaignColumns,
+  contactColumns,
+} from "~/components/WorkspaceTable/columns";
+import { getWorkspaceCampaigns, getWorkspaceInfo } from "~/lib/database.server";
 import { getSupabaseServerClientWithSession } from "~/lib/supabase.server";
 
 export const loader = async ({ request, params }) => {
-  const { supabaseClient, headers, serverSession } = await getSupabaseServerClientWithSession(request);
+  const { supabaseClient, headers, serverSession } =
+    await getSupabaseServerClientWithSession(request);
 
   const workspaceId = params.id;
   const selected = params.selected || "campaigns";
-  const { data: workspace, error } = await getWorkspaceInfo({ supabaseClient, workspaceId });
+  const { data: workspace, error } = await getWorkspaceInfo({
+    supabaseClient,
+    workspaceId,
+  });
   if (error) {
     console.log(error);
     if (error.code === "PGRST116") {
       return redirect("/workspaces", { headers });
     }
   }
-  const { data: audiences } = await getWorkspaceAudiences({ supabaseClient, workspaceId });
-  const { data: campaigns } = await getWorkspaceCampaigns({ supabaseClient, workspaceId });
-  const { data: contacts } = await getWorkspaceContacts({ supabaseClient, workspaceId });
+  // const { data: audiences } = await getWorkspaceAudiences({
+  //   supabaseClient,
+  //   workspaceId,
+  // });
+  const { data: campaigns } = await getWorkspaceCampaigns({
+    supabaseClient,
+    workspaceId,
+  });
+  // const { data: contacts } = await getWorkspaceContacts({ supabaseClient, workspaceId });
 
-  return json({ workspace, audiences, campaigns, contacts, selected }, { headers });
+  return json(
+    { workspace, audiences, campaigns, contacts, selected },
+    { headers },
+  );
 };
 
 export default function Workspace() {
   const navigate = useNavigate();
-  const { workspace, audiences, campaigns, contacts, selected } = useLoaderData();
+  const { workspace, audiences, campaigns, contacts, selected } =
+    useLoaderData();
   const tables = [
     {
       name: "campaigns",
@@ -59,9 +71,8 @@ export default function Workspace() {
     },
   ];
 
-
   const [selectedTable, setSelectedTable] = useState(() =>
-    tables.find((table) => table.name === selected)
+    tables.find((table) => table.name === selected),
   );
 
   useEffect(() => {
@@ -93,7 +104,9 @@ export default function Workspace() {
         };
         break;
       default:
-        console.log(`tableName: ${tableName} does not correspond to any workspace tables`);
+        console.log(
+          `tableName: ${tableName} does not correspond to any workspace tables`,
+        );
         return;
     }
     setSelectedTable(newTable);
@@ -115,7 +128,7 @@ export default function Workspace() {
         </div>
       </div>
       <div className="flex">
-        <div className="flex w-60 min-w-60 flex-col border-2 border-solid border-slate-800 bg-cyan-50 h-[800px] overflow-scroll">
+        <div className="flex h-[800px] w-60 min-w-60 flex-col overflow-scroll border-2 border-solid border-slate-800 bg-cyan-50">
           {selectedTable.data?.map((row) => (
             <Link
               to={`${selectedTable.name}/${row.id}`}
@@ -126,14 +139,17 @@ export default function Workspace() {
                 {selectedTable.name === "campaigns"
                   ? row.title
                   : selectedTable.name === "audiences"
-                  ? row.name || `${selectedTable.name} ${row.id}`
-                  : selectedTable.name === "contacts"
-                  ? `${row.firstname} ${row.surname}`
-                  : ""}
+                    ? row.name || `${selectedTable.name} ${row.id}`
+                    : selectedTable.name === "contacts"
+                      ? `${row.firstname} ${row.surname}`
+                      : ""}
               </h3>
             </Link>
           ))}
-          <Link to={`${selectedTable.name}/new`} className="flex justify-center p-4">
+          <Link
+            to={`${selectedTable.name}/new`}
+            className="flex justify-center p-4"
+          >
             <PlusIcon fill="#333" width="25px" />
           </Link>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "callcaster-1",
+  "name": "callcaster",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
I fixed the workspace creation workflow by using a postgres function to first create the new workspace and then add the creating user as the workspace owner on the `workspace_users`. This function (create_new_workspace) has to be a security definer function in order to bypass the SELECT RLS policy on `workspace`. 

The sign-up page has also been updated to include the first_name and last_name fields, and a username will automatically be added to each user based on their email which will make it easier for us to manage users on the backend. I also added a small 'profile' dropdown that renders in the navbar when the user is signed in. Right now it just shows the user's username, which will be useful for adding users to workspaces.

For some reason there's a lot of conflicts in this merge, especially in database.server.ts. The only thing that is required for database.server.ts is for createNewWorkspace to be changed to createNewWorkspaceDeprecated and createNewWorkspace. No changes from my PR are necessary for `/workspaces/id`, I did not make any changes to that file. 