### PR TITLE
Introduces Numbers path

### DIFF
--- a/app/lib/database.server.ts
+++ b/app/lib/database.server.ts
@@ -61,8 +61,15 @@ export async function createNewWorkspace({
     await supabaseClient.rpc("create_new_workspace", {
       new_workspace_name: workspaceName,
     });
-  // console.log("Inside createNewWorkspace: ", insertWorkspaceData);
-
+  const registeredAccount = await fetch(`${process.env.BASE_URL}/api/workspace`, {
+    body: JSON.stringify({ workspace_id: insertWorkspaceData }),
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  })
+    .then((res) => res.json())
+    .catch((e) => console.error(e));
   if (insertWorkspaceError) {
     return { data: null, error: insertWorkspaceError };
   }
@@ -70,7 +77,7 @@ export async function createNewWorkspace({
   // const { data: insertWorkspaceUsersData, error: insertWorkspaceUsersError } =
   //   await supabaseClient.from("workspace_users").insert({ workspace });
 
-  return { data: insertWorkspaceData, error: insertWorkspaceError };
+  return { data: registeredAccount.id, error: insertWorkspaceError };
 }
 
 export async function getWorkspaceInfo({

--- a/app/routes/api.numbers.jsx
+++ b/app/routes/api.numbers.jsx
@@ -1,0 +1,68 @@
+import Twilio from 'twilio';
+import { createClient } from '@supabase/supabase-js';
+
+export const loader = async ({ request }) => {
+    const twilio = new Twilio.Twilio(process.env.TWILIO_SID, process.env.TWILIO_AUTH_TOKEN);
+    const url = new URL(request.url);
+    const params = url.searchParams;
+    const areaCode = params.get('areaCode')
+    try {
+        const locals = await twilio.availablePhoneNumbers('CA').local.list({
+            areaCode,
+            limit: 10
+        })
+        return new Response(JSON.stringify(locals), {
+            headers: {
+                "Content-Type": "application/json"
+            },
+            status: 200
+        })
+
+    } catch (error) {
+        console.error('Fetching numbers failed', error);
+        return new Response(JSON.stringify({ error }), {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            status: 500
+        });
+    }
+}
+
+export const action = async ({ request }) => {
+    const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+    const { phoneNumber, workspace_id } = await request.json();
+    try {
+        const { data, error } = await supabase.from('workspace').select('twilio_data').eq('id', workspace_id).single();
+        if (error) throw error;
+        const twilio = new Twilio.Twilio(data.twilio_data.sid, data.twilio_data.authToken);
+        const number = await twilio.incomingPhoneNumbers.create({
+            phoneNumber
+        });
+        const { data: newNumber, error: newNumberError } = await supabase
+        .from('workspace_number')
+        .insert({
+            workspace: workspace_id,
+            friendly_name: number.friendlyName,
+            phone_number: number.phoneNumber,
+            capabilities: number.capabilities
+        })
+        .select().single();
+        if (newNumberError) throw newNumberError;
+        return new Response(JSON.stringify({ newNumber }), {
+            headers: {
+                "Content-Type": "application/json"
+            },
+            status: 201
+        })
+    } catch (error) {
+        console.error('Failed to register number', error);
+        return new Response(JSON.stringify({ error }), {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            status: 500
+        });
+
+    }
+}

--- a/app/routes/api.workspace.jsx
+++ b/app/routes/api.workspace.jsx
@@ -1,0 +1,41 @@
+import Twilio from 'twilio';
+import { createClient } from '@supabase/supabase-js';
+
+const createSubaccount = async ({ workspace_id }) => {
+    const twilio = new Twilio.Twilio(process.env.TWILIO_SID, process.env.TWILIO_AUTH_TOKEN);
+    const account = await twilio.api.v2010.accounts.create({
+        friendlyName: workspace_id
+    }).catch((error) => {
+        console.error('Error creating subaccount', error)
+    });
+    return account
+};
+
+const updateWorkspace = async ({ workspace_id, update }) => {
+    const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_KEY);
+    const { data, error } = await supabase.from('workspace').update({ twilio_data: update }).eq('id', workspace_id).select().single();
+    if (error) throw { workspace_error: error };
+    return data;
+}
+
+export const action = async ({ request }) => {
+    const { workspace_id } = await request.json();
+    try {
+        const update = await createSubaccount({ workspace_id });
+        const updated = await updateWorkspace({ workspace_id, update });
+        return new Response(JSON.stringify({ ...updated }), {
+            headers: {
+                "Content-Type": "application/json"
+            },
+            status: 200
+        })
+    } catch (error) {
+        console.error('Subaccount failed', error);
+        return new Response(JSON.stringify({ error }), {
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            status: 500
+        });
+    }
+}


### PR DESCRIPTION
Major Change (not breaking)

- Introduces sub-account creation through Twilio, tied to the workspace (not fully implemented at this time).
- Introduces routes to look up and purchase local numbers:
-- `GET /api/numbers?areaCode=416` with optional area code will return an Array of 10: 
```json
[
  {
    "friendlyName": "(548) 490-8125",
    "phoneNumber": "+15484908125",
    "lata": "888",
    "locality": "Kitchenerwaterloo",
    "rateCenter": "KITCHEWTRL",
    "latitude": null,
    "longitude": null,
    "region": "ON",
    "postalCode": null,
    "isoCountry": "CA",
    "addressRequirements": "none",
    "beta": false,
    "capabilities": {
      "voice": true,
      "SMS": true,
      "MMS": true
    }
  },
{...},
]
```
-- `POST /api/numbers` with a request:
```json
"workspace_id":uuid,
"phoneNumber":"+15484908125"
```
which will return:

```json
{
  "newNumber": {
    "id": int8,
    "created_at": timestampz,
    "workspace": uuid,
    "friendly_name": "(548) 490-8125",
    "phone_number": "+15484908125",
    "capabilities": {
      "fax": false,
      "mms": true,
      "sms": true,
      "voice": true
    }
  }
}
```

This is also stored in the workplace_number.

---
## UPCOMING BREAKING CHANGE
All active workspaces will need to have subaccounts associated with them, as well as a phone number. In order to make use of subaccount numbers and billing, all calls must be authenticated with the workspace.twilio_data.sid and workspace.twilio_data.auth_token (see `api.numbers.jsx:38`). 

This process must be discussed in upcoming tech team.
