### PR TITLE
Workspace members now displayed by their email

### DIFF
--- a/app/components/Workspace/TeamMember.tsx
+++ b/app/components/Workspace/TeamMember.tsx
@@ -66,7 +66,7 @@ export default function TeamMember({
     <div className="flex w-full justify-between rounded-md border-2 border-black bg-transparent p-2 text-xl shadow-sm dark:border-white">
       <div className="flex items-center gap-2">
         <div className={iconStyles} />
-        <p className="font-semibold">{memberName}</p>
+        <p className="pr-4 font-semibold">{member.username}</p>
       </div>
       <div className="flex items-center gap-2">
         <p className={roleTextStyles}>{capitalize(memberRole)}</p>

--- a/app/routes/workspaces_.$id_.settings.tsx
+++ b/app/routes/workspaces_.$id_.settings.tsx
@@ -311,7 +311,7 @@ export default function WorkspaceSettings() {
         </Button>
       </div>
 
-      <div className="flex flex-wrap">
+      <div className="flex flex-wrap justify-center">
         <div className="m-8 flex w-fit flex-col gap-4 rounded-sm bg-brand-secondary px-8 pb-10 pt-6 dark:border-2 dark:border-white dark:bg-transparent dark:text-white">
           <h3 className="text-center font-Zilla-Slab text-4xl font-bold">
             Manage Team Members
@@ -414,16 +414,18 @@ export default function WorkspaceSettings() {
               </ul>
             </div>
           </div>
-          {hasAccess && <div className="">
-            <Button
-              asChild
-              className="h-full w-full font-Zilla-Slab text-2xl font-semibold"
-            >
-              <NavLink to={"./numbers"} relative="path">
-                Manage Numbers
-              </NavLink>
-            </Button>
-          </div>}
+          {hasAccess && (
+            <div className="">
+              <Button
+                asChild
+                className="h-full w-full font-Zilla-Slab text-2xl font-semibold"
+              >
+                <NavLink to={"./numbers"} relative="path">
+                  Manage Numbers
+                </NavLink>
+              </Button>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
On the workspace settings page, members are now identified by their email.
Also centered the cards on the settings page.