### PR TITLE
Invite patch

### DIFF
--- a/app/routes/accept-invite.tsx
+++ b/app/routes/accept-invite.tsx
@@ -146,12 +146,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     const userId = serverSession?.user?.id;
     const invitationIds = formData.getAll("invitation_id") as string[];
 
-    const { error } = await acceptWorkspaceInvitations(
+    const { errors } = await acceptWorkspaceInvitations(
       supabaseClient,
       invitationIds,
       userId,
     );
-    if (error) return json({ error }, { headers });
+    if (errors) return json({ errors }, { headers });
     return json({ success: true }, { headers });
   }
 


### PR DESCRIPTION
Invites collects errors rather than throws. Enables successful acceptance for non-failing rows.

Closes #622