### PR TITLE
Temporarily bypass Twilio signature validation

### DIFF
--- a/app/twilio.server.ts
+++ b/app/twilio.server.ts
@@ -15,19 +15,9 @@ export async function validateTwilioWebhook(
   request: Request,
   authToken: string
 ): Promise<{ params: Record<string, string> } | Response> {
-  const signature = request.headers.get("x-twilio-signature");
-  if (!signature) {
-    return json({ error: "Missing Twilio signature" }, { status: 403 });
-  }
-
-  const url = new URL(request.url).href;
+  // TODO: Re-enable Twilio signature validation
   const formData = await request.formData();
   const params = Object.fromEntries(formData.entries()) as Record<string, string>;
-
-  const isValid = Twilio.validateRequest(authToken, signature, url, params);
-  if (!isValid) {
-    return json({ error: "Invalid Twilio signature" }, { status: 403 });
-  }
   return { params };
 }
 
@@ -36,13 +26,13 @@ export async function validateTwilioWebhook(
  * Use when the route must look up workspace auth token from params (e.g. CallSid) first.
  */
 export function validateTwilioWebhookParams(
-  params: Record<string, string>,
-  signature: string | null,
-  url: string,
-  authToken: string
+  _params: Record<string, string>,
+  _signature: string | null,
+  _url: string,
+  _authToken: string
 ): boolean {
-  if (!signature) return false;
-  return Twilio.validateRequest(authToken, signature, url, params);
+  // TODO: Re-enable Twilio signature validation
+  return true; // if (!signature) return false; return Twilio.validateRequest(...)
 }
 
 declare global {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bypasses Twilio webhook signature validation for local development. All routes using `validateTwilioWebhook` and `validateTwilioWebhookParams` from `~/twilio.server` will accept requests without validating the `X-Twilio-Signature` header.

**Note:** Re-enable validation before deploying to production. Search for `TODO: Re-enable Twilio signature validation` in `app/twilio.server.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

