### PR TITLE
Temporarily bypass Twilio signature validation

### DIFF
--- a/app/routes/api.inbound.tsx
+++ b/app/routes/api.inbound.tsx
@@ -113,11 +113,10 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
       ? twilioData.authToken
       : typeof twilioData?.auth_token === "string"
         ? twilioData.auth_token
-        : null;
+        : env.TWILIO_AUTH_TOKEN(); // fallback for local dev when workspace twilio_data missing
   const signature = request.headers.get("x-twilio-signature");
   const requestUrl = new URL(request.url).href;
   if (
-    !authToken ||
     !validateTwilioWebhookParams(
       data as Record<string, string>,
       signature,

--- a/app/routes/api.inbound.tsx
+++ b/app/routes/api.inbound.tsx
@@ -108,6 +108,12 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     | Record<string, unknown>
     | null
     | undefined;
+  const authTokenSource =
+    typeof twilioData?.authToken === "string"
+      ? "workspace.twilio_data.authToken"
+      : typeof twilioData?.auth_token === "string"
+        ? "workspace.twilio_data.auth_token"
+        : "env.TWILIO_AUTH_TOKEN";
   const authToken =
     typeof twilioData?.authToken === "string"
       ? twilioData.authToken
@@ -116,6 +122,16 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
         : env.TWILIO_AUTH_TOKEN(); // fallback for local dev when workspace twilio_data missing
   const signature = request.headers.get("x-twilio-signature");
   const requestUrl = new URL(request.url).href;
+
+  logger.info("api.inbound webhook received", {
+    Called: data.Called,
+    CallSid: data.CallSid,
+    workspaceId: number.workspace?.id,
+    authTokenSource,
+    hasSignature: Boolean(signature),
+    requestUrl,
+  });
+
   if (
     !validateTwilioWebhookParams(
       data as Record<string, string>,
@@ -124,6 +140,14 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
       authToken,
     )
   ) {
+    logger.warn("api.inbound Twilio signature validation failed", {
+      Called: data.Called,
+      CallSid: data.CallSid,
+      workspaceId: number.workspace?.id,
+      authTokenSource,
+      hasSignature: Boolean(signature),
+      requestUrl,
+    });
     throw { status: 403, statusText: "Invalid Twilio signature" };
   }
 
@@ -248,6 +272,11 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
       });
     }
     if (clientIdentity) {
+      logger.info("api.inbound routing to handset", {
+        workspaceId,
+        CallSid: data.CallSid,
+        clientIdentity,
+      });
       const baseUrl = env.BASE_URL();
       const handsetTwiml = new Twilio.twiml.VoiceResponse();
       const dial = handsetTwiml.dial({
@@ -265,6 +294,11 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     typeof number?.inbound_action === "string" &&
     isPhoneNumber(number.inbound_action)
   ) {
+    logger.info("api.inbound routing to phone", {
+      workspaceId,
+      CallSid: data.CallSid,
+      inbound_action: number.inbound_action,
+    });
     twiml.pause({ length: 1 });
     twiml.dial(number.inbound_action || "");
     return new Response(twiml.toString(), {
@@ -276,6 +310,11 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     typeof number?.inbound_action === "string" &&
     isEmail(number.inbound_action)
   ) {
+    logger.info("api.inbound routing to voicemail", {
+      workspaceId,
+      CallSid: data.CallSid,
+      inbound_action: number.inbound_action,
+    });
     const phoneNumber = data.Called;
     if (voicemail?.signedUrl) {
       twiml.play(voicemail.signedUrl);
@@ -297,6 +336,10 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
       },
     });
   } else {
+    logger.info("api.inbound default fallback (say + hangup)", {
+      workspaceId,
+      CallSid: data.CallSid,
+    });
     const phoneNumber = data.Called;
     twiml.say(
       `Thank you for calling ${phoneNumber}, we're unable to answer your call at the moment. Please try again later.`,

--- a/app/twilio.server.ts
+++ b/app/twilio.server.ts
@@ -1,6 +1,7 @@
 import Twilio from "twilio";
 import { json } from "@remix-run/node";
 import { env } from "@/lib/env.server";
+import { logger } from "@/lib/logger.server";
 
 /**
  * Validates that a request came from Twilio using the X-Twilio-Signature header.
@@ -18,6 +19,11 @@ export async function validateTwilioWebhook(
   // TODO: Re-enable Twilio signature validation
   const formData = await request.formData();
   const params = Object.fromEntries(formData.entries()) as Record<string, string>;
+  logger.debug("validateTwilioWebhook", {
+    url: new URL(request.url).href,
+    hasSignature: Boolean(request.headers.get("x-twilio-signature")),
+    paramKeys: Object.keys(params),
+  });
   return { params };
 }
 
@@ -32,6 +38,11 @@ export function validateTwilioWebhookParams(
   _authToken: string
 ): boolean {
   // TODO: Re-enable Twilio signature validation
+  logger.debug("validateTwilioWebhookParams", {
+    url: _url,
+    hasSignature: Boolean(_signature),
+    paramKeys: Object.keys(_params),
+  });
   return true; // if (!signature) return false; return Twilio.validateRequest(...)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bypasses Twilio webhook signature validation for local development.

**Changes:**
1. `app/twilio.server.ts`: `validateTwilioWebhook` and `validateTwilioWebhookParams` no longer validate signatures (always accept).
2. `app/routes/api.inbound.tsx`: Use main account `TWILIO_AUTH_TOKEN` from env when workspace `twilio_data` is missing, so `/api/inbound` no longer returns 403 when the workspace has no Twilio credentials configured.

**Note:** Re-enable validation before deploying to production. Search for `TODO: Re-enable Twilio signature validation` in `app/twilio.server.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

