### PR TITLE
Temporarily bypass Twilio signature validation + logging

### DIFF
--- a/app/routes/api.inbound.tsx
+++ b/app/routes/api.inbound.tsx
@@ -114,6 +114,13 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
       : typeof twilioData?.auth_token === "string"
         ? "workspace.twilio_data.auth_token"
         : "env.TWILIO_AUTH_TOKEN";
+  if (authTokenSource === "env.TWILIO_AUTH_TOKEN" && twilioData) {
+    logger.debug("api.inbound using env fallback; twilio_data keys", {
+      twilioDataKeys: Object.keys(twilioData),
+      hasAuthToken: "authToken" in twilioData,
+      hasAuth_token: "auth_token" in twilioData,
+    });
+  }
   const authToken =
     typeof twilioData?.authToken === "string"
       ? twilioData.authToken
@@ -122,11 +129,17 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
         : env.TWILIO_AUTH_TOKEN(); // fallback for local dev when workspace twilio_data missing
   const signature = request.headers.get("x-twilio-signature");
   const requestUrl = new URL(request.url).href;
+  const workspaceIdForLog =
+    number.workspace && typeof number.workspace === "object" && "id" in number.workspace
+      ? (number.workspace as { id: string }).id
+      : typeof number.workspace === "string"
+        ? number.workspace
+        : null;
 
   logger.info("api.inbound webhook received", {
     Called: data.Called,
     CallSid: data.CallSid,
-    workspaceId: number.workspace?.id,
+    workspaceId: workspaceIdForLog,
     authTokenSource,
     hasSignature: Boolean(signature),
     requestUrl,
@@ -143,7 +156,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     logger.warn("api.inbound Twilio signature validation failed", {
       Called: data.Called,
       CallSid: data.CallSid,
-      workspaceId: number.workspace?.id,
+      workspaceId: workspaceIdForLog,
       authTokenSource,
       hasSignature: Boolean(signature),
       requestUrl,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bypasses Twilio webhook signature validation for local development and adds logging to debug inbound webhook flow.

## Changes

### 1. `app/twilio.server.ts`
- **validateTwilioWebhook**: Skips signature validation, always returns params
- **validateTwilioWebhookParams**: Always returns `true`
- Added debug logging for both functions (url, hasSignature, paramKeys)

### 2. `app/routes/api.inbound.tsx`
- **Auth fallback**: Use `env.TWILIO_AUTH_TOKEN()` when workspace `twilio_data` has no auth token
- **Logging**:
  - Info: webhook received (Called, CallSid, workspaceId, authTokenSource, hasSignature, requestUrl)
  - Info: routing branch (handset, phone, voicemail, default)
  - Warn: when signature validation fails
  - Debug: when using env auth fallback, logs twilio_data keys for troubleshooting
- **Fix**: Correct workspaceId extraction for logging (handles workspace as UUID string or object)

## Notes

- **Re-enable validation before production**: Search for `TODO: Re-enable Twilio signature validation` in `app/twilio.server.ts`
- `authTokenSource` in logs indicates credential source: `workspace.twilio_data.authToken`, `workspace.twilio_data.auth_token`, or `env.TWILIO_AUTH_TOKEN`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

