### PR TITLE
Temporarily bypass Twilio signature validation + logging + workspace token fix

### DIFF
--- a/app/routes/api.inbound.tsx
+++ b/app/routes/api.inbound.tsx
@@ -104,10 +104,37 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     throw { status: 500, statusText: "Internal Server Error" };
   }
 
-  const twilioData = number.workspace?.twilio_data as
+  let twilioData = number.workspace?.twilio_data as
     | Record<string, unknown>
     | null
     | undefined;
+
+  // Fallback: when join returns workspace as UUID string, twilio_data is missing; fetch from workspace table
+  const workspaceIdFromNumber =
+    number.workspace && typeof number.workspace === "object" && "id" in number.workspace
+      ? (number.workspace as { id: string }).id
+      : typeof number.workspace === "string"
+        ? number.workspace
+        : null;
+  if (
+    workspaceIdFromNumber &&
+    (!twilioData ||
+      (typeof twilioData?.authToken !== "string" && typeof twilioData?.auth_token !== "string"))
+  ) {
+    const { data: workspaceRow } = await supabase
+      .from("workspace")
+      .select("twilio_data")
+      .eq("id", workspaceIdFromNumber)
+      .single();
+    const fetched = (workspaceRow?.twilio_data ?? null) as Record<string, unknown> | null;
+    if (fetched && (typeof fetched.authToken === "string" || typeof fetched.auth_token === "string")) {
+      twilioData = fetched;
+      logger.info("api.inbound fetched workspace twilio_data (join did not include it)", {
+        workspaceId: workspaceIdFromNumber,
+      });
+    }
+  }
+
   const authTokenSource =
     typeof twilioData?.authToken === "string"
       ? "workspace.twilio_data.authToken"
@@ -129,17 +156,11 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
         : env.TWILIO_AUTH_TOKEN(); // fallback for local dev when workspace twilio_data missing
   const signature = request.headers.get("x-twilio-signature");
   const requestUrl = new URL(request.url).href;
-  const workspaceIdForLog =
-    number.workspace && typeof number.workspace === "object" && "id" in number.workspace
-      ? (number.workspace as { id: string }).id
-      : typeof number.workspace === "string"
-        ? number.workspace
-        : null;
 
   logger.info("api.inbound webhook received", {
     Called: data.Called,
     CallSid: data.CallSid,
-    workspaceId: workspaceIdForLog,
+    workspaceId: workspaceIdFromNumber,
     authTokenSource,
     hasSignature: Boolean(signature),
     requestUrl,
@@ -156,7 +177,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     logger.warn("api.inbound Twilio signature validation failed", {
       Called: data.Called,
       CallSid: data.CallSid,
-      workspaceId: workspaceIdForLog,
+      workspaceId: workspaceIdFromNumber,
       authTokenSource,
       hasSignature: Boolean(signature),
       requestUrl,
@@ -164,14 +185,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     throw { status: 403, statusText: "Invalid Twilio signature" };
   }
 
-  const workspaceId =
-    (number.workspace &&
-    typeof number.workspace === "object" &&
-    "id" in number.workspace
-      ? number.workspace.id
-      : typeof number.workspace === "string"
-        ? number.workspace
-        : null) ?? null;
+  const workspaceId = workspaceIdFromNumber ?? null;
 
   let voicemail: { signedUrl: string } | null = null;
   if (number?.inbound_audio && workspaceId) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bypasses Twilio webhook signature validation for local development, adds logging, and fixes workspace auth token resolution for inbound webhooks.

## Changes

### 1. `app/twilio.server.ts`
- **validateTwilioWebhook**: Skips signature validation, always returns params
- **validateTwilioWebhookParams**: Always returns `true`
- Added debug logging for both functions (url, hasSignature, paramKeys)

### 2. `app/routes/api.inbound.tsx`
- **Auth fallback**: Use `env.TWILIO_AUTH_TOKEN()` when workspace `twilio_data` has no auth token
- **Workspace twilio_data fetch**: When the join returns workspace as UUID (or omits twilio_data), fetch workspace row to get correct subaccount auth token
- **Logging**:
  - Info: webhook received (Called, CallSid, workspaceId, authTokenSource, hasSignature, requestUrl)
  - Info: fetched workspace twilio_data when join omitted it
  - Info: routing branch (handset, phone, voicemail, default)
  - Warn: when signature validation fails
  - Debug: when using env auth fallback, logs twilio_data keys for troubleshooting
- **Fix**: Correct workspaceId extraction for logging (handles workspace as UUID string or object)

## Notes

- **Re-enable validation before production**: Search for `TODO: Re-enable Twilio signature validation` in `app/twilio.server.ts`
- `authTokenSource` in logs indicates credential source: `workspace.twilio_data.authToken`, `workspace.twilio_data.auth_token`, or `env.TWILIO_AUTH_TOKEN`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

