### PR TITLE
Twilio signature bypass, handset improvements, inbound handler refactor

### DIFF
--- a/app/lib/handset.server.ts
+++ b/app/lib/handset.server.ts
@@ -1,0 +1,8 @@
+/** Inactivity timeout: handset session expires this many minutes after last call activity. */
+export const INACTIVITY_TIMEOUT_MINUTES = 15;
+
+export function extendHandsetSessionExpiry(): string {
+  return new Date(
+    Date.now() + INACTIVITY_TIMEOUT_MINUTES * 60 * 1000
+  ).toISOString();
+}

--- a/app/lib/inbound-handler.server.ts
+++ b/app/lib/inbound-handler.server.ts
@@ -1,0 +1,57 @@
+import Twilio from "twilio";
+import { isEmail, isPhoneNumber } from "@/lib/utils";
+
+export interface InboundNumberConfig {
+  handset_enabled: boolean | null;
+  inbound_action: string | null;
+  inbound_audio: string | null;
+}
+
+export interface InboundFallbackParams {
+  number: InboundNumberConfig;
+  voicemail: { signedUrl: string } | null;
+  called: string;
+}
+
+/**
+ * Builds TwiML for workspace inbound fallback (forward to phone, voicemail, or default).
+ * Used when handset doesn't answer or when no handset session is active.
+ */
+export function buildInboundFallbackTwiml(
+  params: InboundFallbackParams
+): string {
+  const twiml = new Twilio.twiml.VoiceResponse();
+  const { number, voicemail, called } = params;
+
+  if (
+    typeof number.inbound_action === "string" &&
+    isPhoneNumber(number.inbound_action)
+  ) {
+    twiml.pause({ length: 1 });
+    twiml.dial(number.inbound_action || "");
+  } else if (
+    typeof number.inbound_action === "string" &&
+    isEmail(number.inbound_action)
+  ) {
+    if (voicemail?.signedUrl) {
+      twiml.play(voicemail.signedUrl);
+    } else {
+      twiml.say(
+        `Thank you for calling ${called}, we're unable to answer your call at the moment. Please leave us a message and we'll get back to you as soon as possible.`
+      );
+    }
+    twiml.pause({ length: 1 });
+    twiml.record({
+      transcribe: true,
+      timeout: 10,
+      playBeep: true,
+      recordingStatusCallback: "/api/email-vm",
+    });
+  } else {
+    twiml.say(
+      `Thank you for calling ${called}, we're unable to answer your call at the moment. Please try again later.`
+    );
+  }
+
+  return twiml.toString();
+}

--- a/app/routes/api.call.tsx
+++ b/app/routes/api.call.tsx
@@ -2,6 +2,7 @@ import Twilio from 'twilio';
 import type { ActionFunctionArgs } from "@remix-run/node";
 import { createClient } from "@supabase/supabase-js";
 import { env } from "@/lib/env.server";
+import { extendHandsetSessionExpiry } from "@/lib/handset.server";
 import { logger } from "@/lib/logger.server";
 import { isPhoneNumber, normalizePhoneNumber } from "@/lib/utils";
 import type { Database } from "@/lib/database.types";
@@ -45,6 +46,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         headers: { "Content-Type": "text/xml" },
       });
     }
+
+    await supabase
+      .from("handset_session")
+      .update({ expires_at: extendHandsetSessionExpiry() })
+      .eq("workspace_id", workspaceId)
+      .eq("client_identity", clientIdentity)
+      .eq("status", "active");
 
     const { data: handset } = await supabase
       .from("workspace_number")

--- a/app/routes/api.inbound-handset-dial-end.tsx
+++ b/app/routes/api.inbound-handset-dial-end.tsx
@@ -1,10 +1,14 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
 import Twilio from "twilio";
+import { createClient } from "@supabase/supabase-js";
+import { env } from "@/lib/env.server";
+import { buildInboundFallbackTwiml } from "@/lib/inbound-handler.server";
+import type { Database } from "@/lib/database.types";
 
 /**
  * Twilio calls this when the handset <Dial> ends (timeout, hang up, etc.).
- * Only play "No one is available" when DialCallStatus is no-answer;
- * otherwise just hang up so the caller is not sent to a voicemail-style message.
+ * On no-answer: fall through to workspace's typical inbound handler (forward to phone, voicemail, or default).
+ * Otherwise: just hang up.
  */
 export const action = async ({ request }: ActionFunctionArgs) => {
   if (request.method !== "POST") {
@@ -12,19 +16,93 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
   const formData = await request.formData();
   const dialCallStatus = String(formData.get("DialCallStatus") ?? "").toLowerCase();
+  const called = formData.get("Called") as string | null;
 
-  const twiml = new Twilio.twiml.VoiceResponse();
+  if (dialCallStatus !== "no-answer" || !called) {
+    const twiml = new Twilio.twiml.VoiceResponse();
+    twiml.hangup();
+    return new Response(twiml.toString(), {
+      headers: { "Content-Type": "text/xml" },
+    });
+  }
 
-  if (dialCallStatus === "no-answer") {
+  const supabase = createClient<Database>(
+    env.SUPABASE_URL(),
+    env.SUPABASE_SERVICE_KEY()
+  );
+
+  const { data: number, error: numberError } = await supabase
+    .from("workspace_number")
+    .select(
+      `
+      handset_enabled,
+      inbound_action,
+      inbound_audio,
+      workspace,
+      ...workspace!inner(id)`
+    )
+    .eq("phone_number", called)
+    .single();
+
+  if (numberError || !number) {
+    const twiml = new Twilio.twiml.VoiceResponse();
     twiml.say(
       { voice: "alice" },
       "No one is available to take your call. Please try again later."
     );
+    twiml.hangup();
+    return new Response(twiml.toString(), {
+      headers: { "Content-Type": "text/xml" },
+    });
   }
 
-  twiml.hangup();
+  const workspaceId =
+    number.workspace && typeof number.workspace === "object" && "id" in number.workspace
+      ? (number.workspace as { id: string }).id
+      : typeof number.workspace === "string"
+        ? number.workspace
+        : null;
 
-  return new Response(twiml.toString(), {
+  let voicemail: { signedUrl: string } | null = null;
+  if (number?.inbound_audio && workspaceId) {
+    const { data: signedByPath } = await supabase.storage
+      .from("workspaceAudio")
+      .createSignedUrl(`${workspaceId}/${number.inbound_audio}`, 3600);
+    if (signedByPath?.signedUrl) {
+      voicemail = { signedUrl: signedByPath.signedUrl };
+    } else {
+      const { data: files } = await supabase.storage
+        .from("workspaceAudio")
+        .list(workspaceId, {
+          search: number.inbound_audio,
+          limit: 20,
+          offset: 0,
+        });
+      const file = files?.find(
+        (f) =>
+          String(f.id) === String(number.inbound_audio) ||
+          f.name === number.inbound_audio
+      );
+      if (file) {
+        const { data: signed } = await supabase.storage
+          .from("workspaceAudio")
+          .createSignedUrl(`${workspaceId}/${file.name}`, 3600);
+        if (signed?.signedUrl) voicemail = { signedUrl: signed.signedUrl };
+      }
+    }
+  }
+
+  const twiml = buildInboundFallbackTwiml({
+    number: {
+      handset_enabled: number.handset_enabled,
+      inbound_action: number.inbound_action,
+      inbound_audio: number.inbound_audio,
+    },
+    voicemail,
+    called,
+  });
+
+  return new Response(twiml, {
     headers: { "Content-Type": "text/xml" },
   });
 };

--- a/app/routes/api.inbound-handset.tsx
+++ b/app/routes/api.inbound-handset.tsx
@@ -2,6 +2,7 @@ import type { ActionFunctionArgs } from "@remix-run/node";
 import { createClient } from "@supabase/supabase-js";
 import Twilio from "twilio";
 import { env } from "@/lib/env.server";
+import { extendHandsetSessionExpiry } from "@/lib/handset.server";
 import { logger } from "@/lib/logger.server";
 import type { Database } from "@/lib/database.types";
 
@@ -61,6 +62,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       headers: { "Content-Type": "text/xml" },
     });
   }
+
+  await supabase
+    .from("handset_session")
+    .update({ expires_at: extendHandsetSessionExpiry() })
+    .eq("workspace_id", workspaceId)
+    .eq("client_identity", session.client_identity)
+    .eq("status", "active");
 
   twiml.dial().client(session.client_identity);
 

--- a/app/routes/api.inbound-handset.tsx
+++ b/app/routes/api.inbound-handset.tsx
@@ -70,7 +70,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     .eq("client_identity", session.client_identity)
     .eq("status", "active");
 
-  twiml.dial().client(session.client_identity);
+  const baseUrl = env.BASE_URL();
+  twiml
+    .dial({
+      timeout: 18, // ~3 rings (6s per ring cycle)
+      action: `${baseUrl}/api/inbound-handset-dial-end`,
+    })
+    .client(session.client_identity);
 
   return new Response(twiml.toString(), {
     headers: { "Content-Type": "text/xml" },

--- a/app/routes/api.inbound.tsx
+++ b/app/routes/api.inbound.tsx
@@ -12,6 +12,7 @@ import type {
 import type { Database } from "@/lib/database.types";
 import { validateTwilioWebhookParams } from "@/twilio.server";
 import { extendHandsetSessionExpiry } from "@/lib/handset.server";
+import { buildInboundFallbackTwiml } from "@/lib/inbound-handler.server";
 
 interface WorkspaceNumberData {
   handset_enabled: boolean | null;
@@ -67,7 +68,6 @@ function dispatchInboundCallWebhookNotification(args: {
 }
 
 export const action = async ({ request }: LoaderFunctionArgs) => {
-  const twiml = new Twilio.twiml.VoiceResponse();
   const supabase = createClient<Database>(
     env.SUPABASE_URL(),
     env.SUPABASE_SERVICE_KEY(),
@@ -324,64 +324,25 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
     }
   }
 
-  if (
-    typeof number?.inbound_action === "string" &&
-    isPhoneNumber(number.inbound_action)
-  ) {
-    logger.info("api.inbound routing to phone", {
-      workspaceId,
-      CallSid: data.CallSid,
-      inbound_action: number.inbound_action,
-    });
-    twiml.pause({ length: 1 });
-    twiml.dial(number.inbound_action || "");
-    return new Response(twiml.toString(), {
-      headers: {
-        "Content-Type": "text/xml",
-      },
-    });
-  } else if (
-    typeof number?.inbound_action === "string" &&
-    isEmail(number.inbound_action)
-  ) {
-    logger.info("api.inbound routing to voicemail", {
-      workspaceId,
-      CallSid: data.CallSid,
-      inbound_action: number.inbound_action,
-    });
-    const phoneNumber = data.Called;
-    if (voicemail?.signedUrl) {
-      twiml.play(voicemail.signedUrl);
-    } else {
-      twiml.say(
-        `Thank you for calling ${phoneNumber}, we're unable to answer your call at the moment. Please leave us a message and we'll get back to you as soon as possible.`,
-      );
-    }
-    twiml.pause({ length: 1 });
-    twiml.record({
-      transcribe: true,
-      timeout: 10,
-      playBeep: true,
-      recordingStatusCallback: "/api/email-vm",
-    });
-    return new Response(twiml.toString(), {
-      headers: {
-        "Content-Type": "text/xml",
-      },
-    });
-  } else {
-    logger.info("api.inbound default fallback (say + hangup)", {
-      workspaceId,
-      CallSid: data.CallSid,
-    });
-    const phoneNumber = data.Called;
-    twiml.say(
-      `Thank you for calling ${phoneNumber}, we're unable to answer your call at the moment. Please try again later.`,
-    );
-    return new Response(twiml.toString(), {
-      headers: {
-        "Content-Type": "text/xml",
-      },
-    });
-  }
+  const inboundAction = number?.inbound_action;
+  const isPhone = typeof inboundAction === "string" && isPhoneNumber(inboundAction);
+  const isVoicemail = typeof inboundAction === "string" && isEmail(inboundAction);
+  logger.info("api.inbound routing to fallback", {
+    workspaceId,
+    CallSid: data.CallSid,
+    inbound_action: inboundAction,
+    fallbackType: isPhone ? "phone" : isVoicemail ? "voicemail" : "default",
+  });
+  const fallbackTwiml = buildInboundFallbackTwiml({
+    number: {
+      handset_enabled: number?.handset_enabled ?? null,
+      inbound_action: number?.inbound_action ?? null,
+      inbound_audio: number?.inbound_audio ?? null,
+    },
+    voicemail,
+    called: data.Called ?? "",
+  });
+  return new Response(fallbackTwiml, {
+    headers: { "Content-Type": "text/xml" },
+  });
 };

--- a/app/routes/api.inbound.tsx
+++ b/app/routes/api.inbound.tsx
@@ -314,7 +314,7 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
       const baseUrl = env.BASE_URL();
       const handsetTwiml = new Twilio.twiml.VoiceResponse();
       const dial = handsetTwiml.dial({
-        timeout: 30,
+        timeout: 18, // ~3 rings (6s per ring cycle)
         action: `${baseUrl}/api/inbound-handset-dial-end`,
       });
       dial.client(clientIdentity);

--- a/app/routes/api.inbound.tsx
+++ b/app/routes/api.inbound.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@/lib/twilio.types";
 import type { Database } from "@/lib/database.types";
 import { validateTwilioWebhookParams } from "@/twilio.server";
+import { extendHandsetSessionExpiry } from "@/lib/handset.server";
 
 interface WorkspaceNumberData {
   handset_enabled: boolean | null;
@@ -304,6 +305,12 @@ export const action = async ({ request }: LoaderFunctionArgs) => {
         CallSid: data.CallSid,
         clientIdentity,
       });
+      await supabase
+        .from("handset_session")
+        .update({ expires_at: extendHandsetSessionExpiry() })
+        .eq("workspace_id", workspaceId)
+        .eq("client_identity", clientIdentity)
+        .eq("status", "active");
       const baseUrl = env.BASE_URL();
       const handsetTwiml = new Twilio.twiml.VoiceResponse();
       const dial = handsetTwiml.dial({

--- a/app/routes/workspaces_.$id_.handset.tsx
+++ b/app/routes/workspaces_.$id_.handset.tsx
@@ -14,6 +14,7 @@ import {
   requireWorkspaceAccess,
   getHandsetNumberForWorkspace,
 } from "@/lib/database.server";
+import { extendHandsetSessionExpiry } from "@/lib/handset.server";
 import { useTwilioConnection } from "@/hooks/call/useTwilioConnection";
 import { useCallHandling } from "@/hooks/call/useCallHandling";
 import { Button } from "@/components/ui/button";
@@ -29,8 +30,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-
-const SESSION_EXPIRY_MINUTES = 60;
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
   if (request.method !== "POST") return null;
@@ -93,9 +92,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   }
 
   const clientIdentity = `handset-${crypto.randomUUID()}`;
-  const expiresAt = new Date(
-    Date.now() + SESSION_EXPIRY_MINUTES * 60 * 1000
-  ).toISOString();
+  const expiresAt = extendHandsetSessionExpiry();
 
   const { error } = await supabase.from("handset_session").insert({
     user_id: user.id,

--- a/test/api-call.route.test.ts
+++ b/test/api-call.route.test.ts
@@ -69,7 +69,7 @@ function makeSupabase(options?: {
 
   const from = (table: string) => {
     if (table === "handset_session") {
-      return {
+      const chain = {
         select: () => ({
           eq: () => ({
             eq: () => ({
@@ -83,7 +83,15 @@ function makeSupabase(options?: {
             }),
           }),
         }),
+        update: () => ({
+          eq: () => ({
+            eq: () => ({
+              eq: () => Promise.resolve({ error: null }),
+            }),
+          }),
+        }),
       };
+      return chain;
     }
     if (table === "workspace_number") {
       return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Twilio webhook signature bypass for local dev, handset session/timeout improvements, and inbound handler refactor so handset no-answer falls through to workspace config.

## Changes

### Twilio signature & api.inbound
- **Bypass validation** (temporary): `validateTwilioWebhook` and `validateTwilioWebhookParams` always accept
- **Auth fallback**: Use `env.TWILIO_AUTH_TOKEN()` when workspace `twilio_data` missing
- **Workspace twilio_data fetch**: When join omits it, fetch from workspace table for correct subaccount token
- **Logging**: webhook received, authTokenSource, workspaceId, routing branch; debug when using env fallback

### Handset
- **Inactivity timeout (15 min)**: Session expires 15 min after last call; each inbound/outbound call extends by 15 min
- **3 rings (~18s)**: Handset dial timeout reduced from 30s to 18s before no-answer
- **No-answer fallthrough**: When handset doesn’t answer, use workspace’s typical inbound handler (forward to phone, voicemail, or default) instead of generic “No one is available”

### Inbound handler refactor
- **`app/lib/inbound-handler.server.ts`**: `buildInboundFallbackTwiml()` shared helper
- **`api.inbound-handset-dial-end`**: On no-answer, lookup workspace config and apply same inbound logic
- **`api.inbound`**: Use shared helper for fallback TwiML

## Notes

- **Re-enable Twilio validation before production**: Search `TODO: Re-enable Twilio signature validation` in `app/twilio.server.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91db38ef-dc7f-41c4-ac6a-b466df8145b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

