### PR TITLE
Fix false “valid time window” errors for campaign calling hours

### DIFF
--- a/app/lib/campaign-readiness.ts
+++ b/app/lib/campaign-readiness.ts
@@ -22,6 +22,38 @@ type CampaignReadinessOptions = {
 
 type NormalizedSchedule = Record<string, ScheduleDay>;
 
+/** Minutes since midnight for "HH:mm" / "H:mm" in 24h form; null if malformed. */
+function parseClockMinutes(time: string): number | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
+  if (!match) return null;
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (
+    !Number.isInteger(hours) ||
+    !Number.isInteger(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+  return hours * 60 + minutes;
+}
+
+function isValidCallingInterval(interval: ScheduleInterval): boolean {
+  const startMinutes = parseClockMinutes(interval.start);
+  const endMinutes = parseClockMinutes(interval.end);
+  if (startMinutes === null || endMinutes === null) {
+    return false;
+  }
+  if (startMinutes === endMinutes) {
+    return false;
+  }
+  // Matches `isWithinCallingHours` in campaign.server: end before start means overnight.
+  return true;
+}
+
 function parseSchedule(schedule: Campaign["schedule"]): NormalizedSchedule | null {
   if (!schedule) return null;
 
@@ -80,12 +112,15 @@ function getScheduleValidation(schedule: Campaign["schedule"]) {
       return;
     }
 
-    const hasValidIntervals = day.intervals.some((interval) => interval.start < interval.end);
+    const hasValidIntervals = day.intervals.some((interval) => isValidCallingInterval(interval));
     if (hasValidIntervals) {
       hasCallingHours = true;
     }
 
-    if (!hasValidIntervals || day.intervals.some((interval) => interval.start >= interval.end)) {
+    if (
+      !hasValidIntervals ||
+      day.intervals.some((interval) => !isValidCallingInterval(interval))
+    ) {
       hasInvalidIntervals = true;
     }
   });

--- a/test/campaign-readiness.test.ts
+++ b/test/campaign-readiness.test.ts
@@ -34,6 +34,58 @@ describe("app/lib/campaign-readiness.ts", () => {
     );
   });
 
+  test("accepts overnight windows and UTC-shifted same-calendar-day spans", () => {
+    const overnight = getCampaignReadiness(
+      {
+        type: "message",
+        caller_id: "+15555550100",
+        start_date: "2026-03-10T10:00:00.000Z",
+        end_date: "2026-03-11T10:00:00.000Z",
+        schedule: {
+          monday: {
+            active: true,
+            intervals: [{ start: "23:00", end: "02:00" }],
+          },
+        },
+      } as any,
+      {
+        body_text: "Hello there",
+        message_media: [],
+      } as any,
+      { queueCount: 1 },
+    );
+
+    expect(overnight.startIssues).not.toContain(
+      "Each active calling day needs at least one valid time window",
+    );
+    expect(overnight.startIssues).not.toContain("Calling hours are required");
+
+    const utcSpan = getCampaignReadiness(
+      {
+        type: "message",
+        caller_id: "+15555550100",
+        start_date: "2026-03-10T10:00:00.000Z",
+        end_date: "2026-03-11T10:00:00.000Z",
+        schedule: {
+          monday: {
+            active: true,
+            intervals: [{ start: "05:00", end: "04:59" }],
+          },
+        },
+      } as any,
+      {
+        body_text: "Hello there",
+        message_media: [],
+      } as any,
+      { queueCount: 1 },
+    );
+
+    expect(utcSpan.startIssues).not.toContain(
+      "Each active calling day needs at least one valid time window",
+    );
+    expect(utcSpan.startIssues).not.toContain("Calling hours are required");
+  });
+
   test("flags invalid date order and invalid active schedule intervals", () => {
     const readiness = getCampaignReadiness(
       {
@@ -44,7 +96,7 @@ describe("app/lib/campaign-readiness.ts", () => {
         schedule: {
           monday: {
             active: true,
-            intervals: [{ start: "21:00", end: "13:00" }],
+            intervals: [{ start: "13:00", end: "13:00" }],
           },
         },
       } as any,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Campaign readiness was rejecting valid schedules because it compared interval `start` and `end` as plain strings. After the UI converts local times to UTC, an “all day” window can look like `05:00`–`04:59` in UTC, which string ordering incorrectly flags as invalid. Overnight windows (e.g. `23:00`–`02:00`) were also misclassified.

## Changes

- Parse `HH:mm` intervals and treat a window as valid when start ≠ end (matching the overnight semantics already used in `isWithinCallingHours` in `campaign.server.ts`).
- Reject only malformed times or zero-length intervals.
- Add regression tests for overnight and UTC-shifted spans; adjust the invalid-interval test to use identical start/end.

## Testing

- `npx vitest run test/campaign-readiness.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da5a3155-34c7-4a78-a24a-24f4a6d13038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da5a3155-34c7-4a78-a24a-24f4a6d13038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

