### PR TITLE
Fix ACD router Deno coverage

### DIFF
--- a/supabase/functions/__tests__/acd_router_test.ts
+++ b/supabase/functions/__tests__/acd_router_test.ts
@@ -6,6 +6,14 @@ import {
   makeQueueName,
   parseQueueIdFromName,
 } from "../_shared/acd-utils.ts";
+import {
+  claimAgentForQueue as claimAgentForQueueRouter,
+  loadWorkspaceTwilioCredentials as loadWorkspaceTwilioCredentialsRouter,
+  lookupQueue as lookupQueueRouter,
+  nextQueueOffer as nextQueueOfferRouter,
+  releaseAgent as releaseAgentRouter,
+} from "../_shared/acd-router.ts";
+import { handleRequest } from "../acd-router/index.ts";
 
 Deno.test("makeQueueName and parseQueueIdFromName round-trip", () => {
   const id = 42;
@@ -45,4 +53,127 @@ Deno.test("buildAgentBridgeTwiml returns Dequeue TwiML", () => {
 Deno.test("buildAgentBridgeTwiml escapes XML special chars in queue name", () => {
   const twiml = buildAgentBridgeTwiml("inbound_q_1&2");
   assertEquals(twiml.includes("<Queue>inbound_q_1&amp;2</Queue>"), true);
+});
+
+function createFakeSupabase(args: {
+  tableData?: Record<string, unknown> | null;
+  rpcData?: unknown[] | null;
+  rpcError?: unknown;
+}) {
+  const rpcCalls: Array<{ name: string; params: Record<string, unknown> }> = [];
+  const client = {
+    from() {
+      return {
+        select() {
+          return {
+            eq() {
+              return {
+                maybeSingle() {
+                  return Promise.resolve({ data: args.tableData ?? null });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    rpc(name: string, params: Record<string, unknown>) {
+      rpcCalls.push({ name, params });
+      return Promise.resolve({ data: args.rpcData ?? null, error: args.rpcError ?? null });
+    },
+  };
+  return { client, rpcCalls };
+}
+
+Deno.test("acd-router shared helpers read queue and credentials", async () => {
+  const queue = {
+    id: 7,
+    workspace_id: "workspace-1",
+    name: "Support",
+    hold_audio: "https://example.com/hold.mp3",
+  };
+  const queueSupabase = createFakeSupabase({ tableData: queue });
+  assertEquals(await lookupQueueRouter(queueSupabase.client as never, 7), queue);
+
+  const credentialsSupabase = createFakeSupabase({
+    tableData: { twilio_data: { account_sid: "AC123", auth_token: "secret" } },
+  });
+  assertEquals(
+    await loadWorkspaceTwilioCredentialsRouter(credentialsSupabase.client as never, "workspace-1"),
+    { accountSid: "AC123", authToken: "secret" },
+  );
+
+  const missingCredentialsSupabase = createFakeSupabase({ tableData: { twilio_data: null } });
+  assertEquals(
+    await loadWorkspaceTwilioCredentialsRouter(missingCredentialsSupabase.client as never, "workspace-1"),
+    null,
+  );
+});
+
+Deno.test("acd-router shared helpers wrap queue RPCs", async () => {
+  const claimSupabase = createFakeSupabase({
+    rpcData: [{ agent_user_id: "agent-1", entry_id: 99 }],
+  });
+  assertEquals(
+    await claimAgentForQueueRouter({
+      supabase: claimSupabase.client as never,
+      queueId: 7,
+      workspaceId: "workspace-1",
+      callSid: "CA123",
+      callerNumber: "+15551234567",
+    }),
+    { agentUserId: "agent-1", entryId: 99 },
+  );
+  assertEquals(claimSupabase.rpcCalls[0]?.name, "claim_inbound_queue_entry");
+
+  const noClaimSupabase = createFakeSupabase({ rpcData: [] });
+  assertEquals(
+    await claimAgentForQueueRouter({
+      supabase: noClaimSupabase.client as never,
+      queueId: 7,
+      workspaceId: "workspace-1",
+      callSid: "CA123",
+      callerNumber: "+15551234567",
+    }),
+    null,
+  );
+
+  const nextSupabase = createFakeSupabase({ rpcData: [{ call_sid: "CA456", entry_id: 100 }] });
+  assertEquals(
+    await nextQueueOfferRouter({
+      supabase: nextSupabase.client as never,
+      queueId: 7,
+      agentUserId: "agent-1",
+      workspaceId: "workspace-1",
+    }),
+    { callSid: "CA456", entryId: 100 },
+  );
+  assertEquals(nextSupabase.rpcCalls[0]?.name, "next_inbound_queue_offer");
+
+  const releaseSupabase = createFakeSupabase({});
+  await releaseAgentRouter(releaseSupabase.client as never, 99, "declined");
+  assertEquals(releaseSupabase.rpcCalls[0], {
+    name: "release_inbound_offer",
+    params: { p_entry_id: 99, p_outcome: "declined" },
+  });
+});
+
+Deno.test("acd-router edge handleRequest returns TwiML and JSON for simple paths", async () => {
+  Deno.env.set("SUPABASE_URL", "http://localhost");
+  Deno.env.set("SUPABASE_SERVICE_ROLE_KEY", "test-service-role");
+
+  const waitResponse = await handleRequest(
+    new Request("http://localhost/functions/v1/acd-router?queue_id=0"),
+  );
+  assertEquals(await waitResponse.text(), buildHoldMusicTwiml({ holdAudio: null, queueName: "" }));
+
+  const bridgeResponse = await handleRequest(
+    new Request("http://localhost/functions/v1/acd-router/agent-bridge?queue_name=inbound_q_7"),
+  );
+  assertEquals(await bridgeResponse.text(), buildAgentBridgeTwiml("inbound_q_7"));
+
+  const statusResponse = await handleRequest(
+    new Request("http://localhost/functions/v1/acd-router/agent-status"),
+  );
+  assertEquals(await statusResponse.json(), { ok: true });
 });

--- a/supabase/functions/_shared/acd-router.ts
+++ b/supabase/functions/_shared/acd-router.ts
@@ -1,5 +1,4 @@
 import type { SupabaseClient } from "npm:@supabase/supabase-js@^2.39.6";
-import twilio from "npm:twilio@^4.23.0";
 export type { QueueRecord, TwilioCredentials } from "./acd-utils.ts";
 export { buildAgentBridgeTwiml, buildHoldMusicTwiml, makeQueueName, parseQueueIdFromName } from "./acd-utils.ts";
 import { buildHoldMusicTwiml, makeQueueName, type QueueRecord, type TwilioCredentials } from "./acd-utils.ts";
@@ -67,6 +66,7 @@ export async function dialAgent(args: {
   workspaceId: string;
   callerNumber: string;
 }): Promise<void> {
+  const { default: twilio } = await import("npm:twilio@^4.23.0");
   const client = twilio(args.twilioCredentials.accountSid, args.twilioCredentials.authToken);
   const queueName = makeQueueName(args.queueId);
   const agentBridgeUrl = `${args.baseUrl}/functions/v1/acd-router/agent-bridge?queue_name=${queueName}&entry_id=${args.entryId}`;
@@ -123,4 +123,3 @@ export async function nextQueueOffer(args: {
   if (!data || data.length === 0) return null;
   return { callSid: data[0].call_sid, entryId: data[0].entry_id };
 }
-

--- a/supabase/functions/_shared/acd-router.ts
+++ b/supabase/functions/_shared/acd-router.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "npm:@supabase/supabase-js@^2.39.6";
-import { Twilio } from "npm:twilio@^4.23.0";
+import twilio from "npm:twilio@^4.23.0";
 export type { QueueRecord, TwilioCredentials } from "./acd-utils.ts";
 export { buildAgentBridgeTwiml, buildHoldMusicTwiml, makeQueueName, parseQueueIdFromName } from "./acd-utils.ts";
 import { buildHoldMusicTwiml, makeQueueName, type QueueRecord, type TwilioCredentials } from "./acd-utils.ts";
@@ -67,7 +67,7 @@ export async function dialAgent(args: {
   workspaceId: string;
   callerNumber: string;
 }): Promise<void> {
-  const client = new Twilio(args.twilioCredentials.accountSid, args.twilioCredentials.authToken);
+  const client = twilio(args.twilioCredentials.accountSid, args.twilioCredentials.authToken);
   const queueName = makeQueueName(args.queueId);
   const agentBridgeUrl = `${args.baseUrl}/functions/v1/acd-router/agent-bridge?queue_name=${queueName}&entry_id=${args.entryId}`;
   const agentStatusUrl = `${args.baseUrl}/functions/v1/acd-router/agent-status?entry_id=${args.entryId}&queue_id=${args.queueId}`;
@@ -123,5 +123,4 @@ export async function nextQueueOffer(args: {
   if (!data || data.length === 0) return null;
   return { callSid: data[0].call_sid, entryId: data[0].entry_id };
 }
-
 


### PR DESCRIPTION
## Summary
- Fix ACD router Twilio import for Deno/npm compatibility
- Add Deno coverage tests for ACD router shared helpers and simple Edge Function paths

## Verification
- npm run test:coverage
- npm run typecheck
- npm run lint