### PR TITLE
fix(billing): loud guard when Stripe key mode mismatches NODE_ENV

### DIFF
--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -6,6 +6,7 @@
  */
 
 import { resolveObjectStorageEnvRequired } from "./object-storage-config";
+import { logger } from "./logger.server";
 
 type EnvConfig = {
   DATABASE_URL: string;
@@ -97,6 +98,57 @@ function getEnv<K extends keyof EnvConfig>(
   );
 }
 
+/** Stripe secret-key mode, derived from the key prefix (`sk_test_` / `sk_live_`). */
+export type StripeKeyMode = 'test' | 'live' | 'unknown';
+
+/** Detects the Stripe key mode from a secret (or restricted) key's prefix. */
+export function getStripeKeyMode(
+  secretKey: string | null | undefined,
+): StripeKeyMode {
+  if (!secretKey) return 'unknown';
+  if (secretKey.startsWith('sk_test_') || secretKey.startsWith('rk_test_')) {
+    return 'test';
+  }
+  if (secretKey.startsWith('sk_live_') || secretKey.startsWith('rk_live_')) {
+    return 'live';
+  }
+  return 'unknown';
+}
+
+let stripeKeyModeMismatchLogged = false;
+
+/**
+ * Guard for issue #1027: production running with a Stripe TEST-mode key sends
+ * real users to a test-mode Checkout where every real card is declined
+ * ("Your request was in test mode, but used a non test card"). Make that
+ * misconfiguration loud at boot instead of a confusing decline at card entry.
+ *
+ * Logs a prominent structured error once per process. Never throws —
+ * production must not go down over this. Returns true when the mismatch is
+ * present (NODE_ENV === "production" with a test-mode STRIPE_SECRET_KEY).
+ */
+export function warnIfStripeKeyModeMismatch(): boolean {
+  const keyMode = getStripeKeyMode(process.env.STRIPE_SECRET_KEY);
+  const mismatch = process.env.NODE_ENV === 'production' && keyMode === 'test';
+
+  if (mismatch && !stripeKeyModeMismatchLogged) {
+    stripeKeyModeMismatchLogged = true;
+    logger.error(
+      'STRIPE MISCONFIGURATION: STRIPE_SECRET_KEY is a TEST-mode key while NODE_ENV is "production"',
+      {
+        guard: 'stripe-key-mode-mismatch',
+        keyMode,
+        nodeEnv: process.env.NODE_ENV,
+        impact:
+          'Stripe Checkout runs in test mode; real cards are declined and credit purchases fail.',
+        fix: 'Set STRIPE_SECRET_KEY (and matching STRIPE_WEBHOOK_SECRET) to live-mode values in the production environment.',
+      },
+    );
+  }
+
+  return mismatch;
+}
+
 // Validate environment variables on module load
 // This will throw an error immediately if required vars are missing
 if (typeof window === 'undefined') {
@@ -109,6 +161,8 @@ if (typeof window === 'undefined') {
       console.error('Environment validation error:', error);
     }
   }
+  // Boot-time guard: loud structured error if prod is on a Stripe test key.
+  warnIfStripeKeyModeMismatch();
 }
 
 /**
@@ -135,7 +189,12 @@ export const env = {
   // Trailing slash stripped centrally: 23 of 29 call sites string-template
   // Twilio callback URLs from this value, and `https://host//api/...` 404s.
   BASE_URL: () => getEnv('BASE_URL').replace(/\/+$/, ''),
-  STRIPE_SECRET_KEY: () => getEnv('STRIPE_SECRET_KEY'),
+  STRIPE_SECRET_KEY: () => {
+    // Re-check at every Stripe-client init (once-logged) in case env vars
+    // were injected after module load.
+    warnIfStripeKeyModeMismatch();
+    return getEnv('STRIPE_SECRET_KEY');
+  },
   STRIPE_WEBHOOK_SECRET: () => getEnv('STRIPE_WEBHOOK_SECRET'),
   RESEND_API_KEY: () => getEnv('RESEND_API_KEY'),
   /** Ops-alert recipient for Twilio compliance jobs needing docs / failing terminally. Falls back to the platform compliance inbox. */

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -6,7 +6,6 @@
  */
 
 import { resolveObjectStorageEnvRequired } from "./object-storage-config";
-import { logger } from "./logger.server";
 
 type EnvConfig = {
   DATABASE_URL: string;
@@ -133,7 +132,7 @@ export function warnIfStripeKeyModeMismatch(): boolean {
 
   if (mismatch && !stripeKeyModeMismatchLogged) {
     stripeKeyModeMismatchLogged = true;
-    logger.error(
+    console.error(
       'STRIPE MISCONFIGURATION: STRIPE_SECRET_KEY is a TEST-mode key while NODE_ENV is "production"',
       {
         guard: 'stripe-key-mode-mismatch',

--- a/test/env.server.test.ts
+++ b/test/env.server.test.ts
@@ -1,7 +1,20 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+// env.server imports ./logger.server (relative), not the @/ alias mocked in setup.node.ts.
+vi.mock("../app/lib/logger.server", () => ({
+  logger: mockLogger,
+}));
+
 function seedRequiredEnv() {
   process.env.NODE_ENV = "test";
+  process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
   process.env.BASE_URL = "http://localhost";
   process.env.BETTER_AUTH_SECRET = "test-better-auth-secret";
   process.env.TWILIO_SID = "d";
@@ -11,11 +24,17 @@ function seedRequiredEnv() {
   process.env.STRIPE_SECRET_KEY = "sk";
   process.env.RESEND_API_KEY = "re";
   process.env.TWILIO_COMPLIANCE_NOTIFY_EMAIL = "compliance@callcaster.ca";
+  process.env.S3_ENDPOINT = "http://localhost:9000";
+  process.env.S3_REGION = "us-east-1";
+  process.env.S3_ACCESS_KEY_ID = "test-access-key";
+  process.env.S3_SECRET_ACCESS_KEY = "test-secret-key";
+  process.env.S3_BUCKET = "callcaster-test";
 }
 
 describe("env.server", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    mockLogger.error.mockClear();
     seedRequiredEnv();
   });
 
@@ -153,12 +172,10 @@ describe("env.server", () => {
     process.env.STRIPE_SECRET_KEY = "sk_test_abc123";
 
     try {
-      // Module load runs the boot-time guard (logger.server is mocked in setup.node.ts).
+      // Module load runs the boot-time guard.
       const mod = await import("../app/lib/env.server");
-      const { logger } = await import("../app/lib/logger.server");
-      const errorMock = vi.mocked(logger.error);
 
-      const guardCalls = errorMock.mock.calls.filter(
+      const guardCalls = mockLogger.error.mock.calls.filter(
         ([message]) =>
           typeof message === "string" &&
           message.includes("STRIPE MISCONFIGURATION"),
@@ -174,7 +191,7 @@ describe("env.server", () => {
       expect(mod.warnIfStripeKeyModeMismatch()).toBe(true);
       expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_test_abc123");
       expect(
-        errorMock.mock.calls.filter(
+        mockLogger.error.mock.calls.filter(
           ([message]) =>
             typeof message === "string" &&
             message.includes("STRIPE MISCONFIGURATION"),
@@ -193,10 +210,9 @@ describe("env.server", () => {
 
     try {
       const mod = await import("../app/lib/env.server");
-      const { logger } = await import("../app/lib/logger.server");
       expect(mod.warnIfStripeKeyModeMismatch()).toBe(false);
       expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_live_abc123");
-      expect(vi.mocked(logger.error)).not.toHaveBeenCalled();
+      expect(mockLogger.error).not.toHaveBeenCalled();
     } finally {
       process.env.NODE_ENV = "test";
     }
@@ -208,10 +224,9 @@ describe("env.server", () => {
     process.env.STRIPE_SECRET_KEY = "sk_test_abc123";
 
     const mod = await import("../app/lib/env.server");
-    const { logger } = await import("../app/lib/logger.server");
     expect(mod.warnIfStripeKeyModeMismatch()).toBe(false);
     expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_test_abc123");
-    expect(vi.mocked(logger.error)).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
   });
 
   test("isSignupOpen is true only when SIGNUP_OPEN is true or 1", async () => {

--- a/test/env.server.test.ts
+++ b/test/env.server.test.ts
@@ -132,6 +132,88 @@ describe("env.server", () => {
     );
   });
 
+  test("getStripeKeyMode detects test, live, and unknown key prefixes", async () => {
+    vi.resetModules();
+    seedRequiredEnv();
+
+    const mod = await import("../app/lib/env.server");
+    expect(mod.getStripeKeyMode("sk_test_abc123")).toBe("test");
+    expect(mod.getStripeKeyMode("rk_test_abc123")).toBe("test");
+    expect(mod.getStripeKeyMode("sk_live_abc123")).toBe("live");
+    expect(mod.getStripeKeyMode("rk_live_abc123")).toBe("live");
+    expect(mod.getStripeKeyMode("whsec_abc123")).toBe("unknown");
+    expect(mod.getStripeKeyMode("")).toBe("unknown");
+    expect(mod.getStripeKeyMode(undefined)).toBe("unknown");
+  });
+
+  test("logs a prominent structured error at boot when production uses a Stripe test key", async () => {
+    vi.resetModules();
+    seedRequiredEnv();
+    process.env.NODE_ENV = "production";
+    process.env.STRIPE_SECRET_KEY = "sk_test_abc123";
+
+    try {
+      // Module load runs the boot-time guard (logger.server is mocked in setup.node.ts).
+      const mod = await import("../app/lib/env.server");
+      const { logger } = await import("../app/lib/logger.server");
+      const errorMock = vi.mocked(logger.error);
+
+      const guardCalls = errorMock.mock.calls.filter(
+        ([message]) =>
+          typeof message === "string" &&
+          message.includes("STRIPE MISCONFIGURATION"),
+      );
+      expect(guardCalls).toHaveLength(1);
+      expect(guardCalls[0][1]).toMatchObject({
+        guard: "stripe-key-mode-mismatch",
+        keyMode: "test",
+        nodeEnv: "production",
+      });
+
+      // Re-checks still report the mismatch but only log once per process.
+      expect(mod.warnIfStripeKeyModeMismatch()).toBe(true);
+      expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_test_abc123");
+      expect(
+        errorMock.mock.calls.filter(
+          ([message]) =>
+            typeof message === "string" &&
+            message.includes("STRIPE MISCONFIGURATION"),
+        ),
+      ).toHaveLength(1);
+    } finally {
+      process.env.NODE_ENV = "test";
+    }
+  });
+
+  test("does not log the Stripe mode guard for live keys in production", async () => {
+    vi.resetModules();
+    seedRequiredEnv();
+    process.env.NODE_ENV = "production";
+    process.env.STRIPE_SECRET_KEY = "sk_live_abc123";
+
+    try {
+      const mod = await import("../app/lib/env.server");
+      const { logger } = await import("../app/lib/logger.server");
+      expect(mod.warnIfStripeKeyModeMismatch()).toBe(false);
+      expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_live_abc123");
+      expect(vi.mocked(logger.error)).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = "test";
+    }
+  });
+
+  test("does not log the Stripe mode guard for test keys outside production", async () => {
+    vi.resetModules();
+    seedRequiredEnv();
+    process.env.STRIPE_SECRET_KEY = "sk_test_abc123";
+
+    const mod = await import("../app/lib/env.server");
+    const { logger } = await import("../app/lib/logger.server");
+    expect(mod.warnIfStripeKeyModeMismatch()).toBe(false);
+    expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_test_abc123");
+    expect(vi.mocked(logger.error)).not.toHaveBeenCalled();
+  });
+
   test("isSignupOpen is true only when SIGNUP_OPEN is true or 1", async () => {
     vi.resetModules();
     seedRequiredEnv();

--- a/test/env.server.test.ts
+++ b/test/env.server.test.ts
@@ -1,17 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-const mockLogger = vi.hoisted(() => ({
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-}));
-
-// env.server imports ./logger.server (relative), not the @/ alias mocked in setup.node.ts.
-vi.mock("../app/lib/logger.server", () => ({
-  logger: mockLogger,
-}));
-
 function seedRequiredEnv() {
   process.env.NODE_ENV = "test";
   process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
@@ -34,7 +22,6 @@ function seedRequiredEnv() {
 describe("env.server", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
-    mockLogger.error.mockClear();
     seedRequiredEnv();
   });
 
@@ -172,10 +159,10 @@ describe("env.server", () => {
     process.env.STRIPE_SECRET_KEY = "sk_test_abc123";
 
     try {
-      // Module load runs the boot-time guard.
+      const err = vi.spyOn(console, "error").mockImplementation(() => {});
       const mod = await import("../app/lib/env.server");
 
-      const guardCalls = mockLogger.error.mock.calls.filter(
+      const guardCalls = err.mock.calls.filter(
         ([message]) =>
           typeof message === "string" &&
           message.includes("STRIPE MISCONFIGURATION"),
@@ -191,12 +178,13 @@ describe("env.server", () => {
       expect(mod.warnIfStripeKeyModeMismatch()).toBe(true);
       expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_test_abc123");
       expect(
-        mockLogger.error.mock.calls.filter(
+        err.mock.calls.filter(
           ([message]) =>
             typeof message === "string" &&
             message.includes("STRIPE MISCONFIGURATION"),
         ),
       ).toHaveLength(1);
+      err.mockRestore();
     } finally {
       process.env.NODE_ENV = "test";
     }
@@ -209,10 +197,18 @@ describe("env.server", () => {
     process.env.STRIPE_SECRET_KEY = "sk_live_abc123";
 
     try {
+      const err = vi.spyOn(console, "error").mockImplementation(() => {});
       const mod = await import("../app/lib/env.server");
       expect(mod.warnIfStripeKeyModeMismatch()).toBe(false);
       expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_live_abc123");
-      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(
+        err.mock.calls.filter(
+          ([message]) =>
+            typeof message === "string" &&
+            message.includes("STRIPE MISCONFIGURATION"),
+        ),
+      ).toHaveLength(0);
+      err.mockRestore();
     } finally {
       process.env.NODE_ENV = "test";
     }
@@ -223,10 +219,18 @@ describe("env.server", () => {
     seedRequiredEnv();
     process.env.STRIPE_SECRET_KEY = "sk_test_abc123";
 
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     const mod = await import("../app/lib/env.server");
     expect(mod.warnIfStripeKeyModeMismatch()).toBe(false);
     expect(mod.env.STRIPE_SECRET_KEY()).toBe("sk_test_abc123");
-    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(
+      err.mock.calls.filter(
+        ([message]) =>
+          typeof message === "string" &&
+          message.includes("STRIPE MISCONFIGURATION"),
+      ),
+    ).toHaveLength(0);
+    err.mockRestore();
   });
 
   test("isSignupOpen is true only when SIGNUP_OPEN is true or 1", async () => {


### PR DESCRIPTION
Addresses the code side of #1027.

With a test-mode key in production, Checkout session creation succeeds and the failure only surfaces as a confusing card decline on Stripe's hosted page — outside our error handling. This adds `getStripeKeyMode()` + `warnIfStripeKeyModeMismatch()` in `env.server.ts`: when `NODE_ENV=production` and the key is test-mode, a structured `stripe-key-mode-mismatch` error is logged once per process (boot + first key read). Never throws — production stays up.

Existing checkout error paths already return fixed user-safe messages (deliberately not routed through `toUserMessage`, which would leak key fragments from raw Stripe errors).

The root fix remains operational: the production environment needs its live-mode Stripe key pair (note: test/live webhook signing secrets are separate).

Verified: typecheck, lint, env.server tests 13/13 (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)