### PR TITLE
fix(auth): generate uuid user ids so fresh signups work

### DIFF
--- a/app/server/auth-instance.ts
+++ b/app/server/auth-instance.ts
@@ -25,6 +25,13 @@ function createAuth() {
         auth_two_factor: authSchema.authTwoFactor,
       },
     }),
+    advanced: {
+      database: {
+        // Domain tables key users by uuid (e.g. create_new_workspace casts
+        // $2::uuid), so auth ids must be uuids, not Better Auth's nanoids.
+        generateId: () => crypto.randomUUID(),
+      },
+    },
     plugins: [
       twoFactor({
         twoFactorTable: "auth_two_factor",


### PR DESCRIPTION
New-user signup crashes with `invalid input syntax for type uuid` on every domain lookup: Better Auth's default id generator mints 32-char nanoids for `auth_user.id` (a `text` column, so signup itself succeeds), but the domain layer keys users by uuid — `create_new_workspace($1, $2::uuid)`, the `user` table lookups, etc.

Migrated users kept their Supabase-era uuid ids, and signup was gated off until today, so this never surfaced before.

Fix: `advanced.database.generateId: () => crypto.randomUUID()` on the Better Auth instance (supported shape in better-auth 1.6.x, verified by typecheck).

Verified: typecheck, lint, `signup.route.test.ts` + `platform-auth.test.ts` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)