### PR TITLE
feat(coaching): live transcription and coaching pipeline

### DIFF
--- a/app/components/call/CallScreen.Coaching.tsx
+++ b/app/components/call/CallScreen.Coaching.tsx
@@ -1,0 +1,81 @@
+import { Button } from "@/components/ui/button";
+import type {
+  CoachingCueView,
+  CoachingMetricsView,
+  CoachingSessionView,
+} from "@/hooks/call/useCallCoaching";
+
+export function CallScreenCoaching({
+  metrics,
+  cues,
+  session,
+  onAcknowledgeCue,
+}: {
+  metrics: CoachingMetricsView | null;
+  cues: CoachingCueView[];
+  session: CoachingSessionView | null;
+  onAcknowledgeCue: (eventId: string) => void;
+}) {
+  const wpmColor = !metrics
+    ? "text-muted-foreground"
+    : metrics.wpm < 120
+      ? "text-blue-500"
+      : metrics.wpm > 160
+        ? "text-red-500"
+        : "text-green-500";
+
+  return (
+    <div className="flex h-64 flex-col space-y-3 overflow-hidden p-3">
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <div>
+          <div className={`text-2xl font-bold ${wpmColor}`}>{metrics?.wpm ?? "—"}</div>
+          <div className="text-xs text-muted-foreground">WPM</div>
+        </div>
+        <div>
+          <div className="text-2xl font-bold text-foreground">{metrics?.fillerCount ?? "—"}</div>
+          <div className="text-xs text-muted-foreground">Fillers</div>
+        </div>
+        <div>
+          <div className="text-2xl font-bold text-foreground">{metrics?.pauseCount ?? "—"}</div>
+          <div className="text-xs text-muted-foreground">Pauses</div>
+        </div>
+      </div>
+
+      <div className="flex-1 space-y-2 overflow-y-auto">
+        {cues.length === 0 && !session ? (
+          <p className="text-center text-sm text-muted-foreground">
+            Coaching cues appear during the call.
+          </p>
+        ) : null}
+        {cues.map((cue) => (
+          <div
+            key={cue.eventId}
+            className={`rounded-lg border p-3 text-sm ${
+              cue.acknowledgedAt ? "opacity-60" : "border-brand-secondary/40"
+            }`}
+          >
+            <div className="font-semibold">{cue.heading}</div>
+            <p className="mt-1 text-muted-foreground">{cue.suggestion}</p>
+            {!cue.acknowledgedAt ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => onAcknowledgeCue(cue.eventId)}
+              >
+                Got it
+              </Button>
+            ) : null}
+          </div>
+        ))}
+        {session ? (
+          <div className="rounded-lg border border-brand-secondary/40 bg-muted/40 p-3 text-sm">
+            <div className="font-semibold">Session score: {session.score}</div>
+            <p className="mt-1 text-muted-foreground">{session.summary}</p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/components/call/CallScreen.Layout.tsx
+++ b/app/components/call/CallScreen.Layout.tsx
@@ -5,6 +5,7 @@ import { Household } from "@/components/call/CallScreen.Household";
 import { CampaignHeader } from "@/components/call/CallScreen.Header";
 import { PhoneKeypad } from "@/components/call/CallScreen.DTMFPhone";
 import { CampaignDialogs } from "@/components/call/CallScreen.Dialogs";
+import { CallScreenLiveCoachingPanels } from "@/components/call/CallScreen.LiveCoachingPanels";
 import { Button } from "@/components/ui/button";
 import { NavLink } from "react-router";
 import {
@@ -37,6 +38,9 @@ export function CallScreenLayout({
   dialogControls,
   audioControls,
   phoneVerification,
+  featureFlags,
+  callSid,
+  initialCoaching,
 }: CallScreenLayoutProps) {
   const {
     hangUp,
@@ -271,6 +275,12 @@ export function CallScreenLayout({
           completed={completed}
         />
       </div>
+      <CallScreenLiveCoachingPanels
+        workspaceId={workspaceId}
+        callSid={callSid}
+        featureFlags={featureFlags}
+        initialCoaching={initialCoaching}
+      />
       <CampaignDialogs
         isDialogOpen={isDialogOpen}
         setDialog={setDialog}

--- a/app/components/call/CallScreen.LiveCoachingPanels.tsx
+++ b/app/components/call/CallScreen.LiveCoachingPanels.tsx
@@ -1,0 +1,72 @@
+import { CallScreenCoaching } from "@/components/call/CallScreen.Coaching";
+import { CallScreenTranscript } from "@/components/call/CallScreen.Transcript";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useCallCoaching } from "@/hooks/call/useCallCoaching";
+import { liveMediaCapabilities } from "@/lib/live-media-capabilities";
+import type { CallCoachingHydration } from "@/hooks/call/useCallCoaching";
+import type { WorkspaceFeatureFlags } from "@/lib/coaching-schemas";
+
+export function CallScreenLiveCoachingPanels({
+  workspaceId,
+  callSid,
+  featureFlags,
+  initialCoaching,
+}: {
+  workspaceId: string;
+  callSid: string | null;
+  featureFlags: WorkspaceFeatureFlags | Record<string, unknown> | null | undefined;
+  /** Loader-supplied state for a call that was already running at mount. */
+  initialCoaching?: CallCoachingHydration | null;
+}) {
+  const { showTranscript, showCoaching } = liveMediaCapabilities(featureFlags);
+  // Called unconditionally (rules of hooks); the hook itself skips the
+  // EventSource when nothing here would render.
+  const coaching = useCallCoaching(
+    workspaceId,
+    callSid,
+    showTranscript || showCoaching,
+    initialCoaching,
+  );
+
+  if (!showTranscript && !showCoaching) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">
+          {showCoaching ? "Live coaching" : "Live transcript"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue={showTranscript ? "transcript" : "coaching"}>
+          <TabsList>
+            {showTranscript ? (
+              <TabsTrigger value="transcript">Transcript</TabsTrigger>
+            ) : null}
+            {showCoaching ? (
+              <TabsTrigger value="coaching">Coaching</TabsTrigger>
+            ) : null}
+          </TabsList>
+          {showTranscript ? (
+            <TabsContent value="transcript">
+              <CallScreenTranscript segments={coaching.segments} />
+            </TabsContent>
+          ) : null}
+          {showCoaching ? (
+            <TabsContent value="coaching">
+              <CallScreenCoaching
+                metrics={coaching.metrics}
+                cues={coaching.cues}
+                session={coaching.session}
+                onAcknowledgeCue={(eventId) => void coaching.acknowledgeCue(eventId)}
+              />
+            </TabsContent>
+          ) : null}
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/components/call/CallScreen.Transcript.tsx
+++ b/app/components/call/CallScreen.Transcript.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import type { TranscriptSegmentView } from "@/hooks/call/useCallCoaching";
+
+const FILLER_PATTERN = /\b(uh|um|like|you know|basically|actually)\b/gi;
+
+function highlightFillers(text: string, fillerCount: number): ReactNode {
+  if (fillerCount === 0) return text;
+
+  const parts = text.split(FILLER_PATTERN);
+  return parts.map((part, index) => {
+    const isFiller = /^(uh|um|like|you know|basically|actually)$/i.test(part);
+    return isFiller ? (
+      <mark key={index} className="rounded bg-yellow-200/60 px-0.5">
+        {part}
+      </mark>
+    ) : (
+      part
+    );
+  });
+}
+
+export function CallScreenTranscript({ segments }: { segments: TranscriptSegmentView[] }) {
+  return (
+    <div className="flex h-64 flex-col overflow-hidden">
+      <div className="flex-1 space-y-2 overflow-y-auto p-3">
+        {segments.length === 0 ? (
+          <p className="pt-8 text-center text-sm text-muted-foreground">
+            Transcript will appear here when the call connects.
+          </p>
+        ) : null}
+        {segments.map((seg) => (
+          <div
+            key={seg.id}
+            className={`text-sm leading-relaxed ${
+              seg.speakerLabel === "agent" ? "text-brand-primary" : "text-foreground"
+            }`}
+          >
+            <span className="mr-2 text-xs font-semibold uppercase">{seg.speakerLabel}</span>
+            <span>{highlightFillers(seg.text, seg.fillerCount)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/components/campaign/CampaignQueueProgress.tsx
+++ b/app/components/campaign/CampaignQueueProgress.tsx
@@ -1,0 +1,66 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+export type CampaignQueueProgressCounts = {
+  completedCount: number;
+  totalCount: number;
+};
+
+export function campaignQueueProgressTooltip(
+  completedCount: number,
+  totalCount: number,
+): string {
+  if (totalCount <= 0) {
+    return "No contacts in queue";
+  }
+
+  const remaining = Math.max(totalCount - completedCount, 0);
+  if (remaining === 0) {
+    return "Queue complete";
+  }
+
+  return `${remaining} left`;
+}
+
+interface CampaignQueueProgressProps extends CampaignQueueProgressCounts {
+  className?: string;
+}
+
+export function CampaignQueueProgress({
+  completedCount,
+  totalCount,
+  className,
+}: CampaignQueueProgressProps) {
+  if (totalCount <= 0) {
+    return null;
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Text
+            as="span"
+            variant="small"
+            data-testid="campaign-queue-progress"
+            className={cn(
+              "tabular-nums normal-case tracking-normal",
+              className,
+            )}
+          >
+            {completedCount} / {totalCount}
+          </Text>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{campaignQueueProgressTooltip(completedCount, totalCount)}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/app/components/campaign/home/CampaignHomeScreen/CampaignHeader.tsx
+++ b/app/components/campaign/home/CampaignHomeScreen/CampaignHeader.tsx
@@ -3,17 +3,23 @@ import { Megaphone } from "lucide-react";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { Heading } from "@/components/ui/typography";
 import type { Enums } from "@/lib/db-types";
+import {
+  CampaignQueueProgress,
+  type CampaignQueueProgressCounts,
+} from "@/components/campaign/CampaignQueueProgress";
 
 type HeaderProps = {
   title: string;
   isDesktop: boolean;
   status: Enums<"campaign_status">;
+  queueProgress?: CampaignQueueProgressCounts | null;
 };
 
 export const CampaignHeader = ({
   title,
   isDesktop = false,
   status,
+  queueProgress,
 }: HeaderProps) => {
   return (
     <div
@@ -30,6 +36,13 @@ export const CampaignHeader = ({
           {title}
         </Heading>
         <StatusBadge status={status} className="ml-2" />
+        {queueProgress?.totalCount ? (
+          <CampaignQueueProgress
+            completedCount={queueProgress.completedCount}
+            totalCount={queueProgress.totalCount}
+            className="ml-1 text-xs font-medium normal-case"
+          />
+        ) : null}
       </NavLink>
     </div>
   );

--- a/app/components/workspace/WorkspaceNav.tsx
+++ b/app/components/workspace/WorkspaceNav.tsx
@@ -29,6 +29,10 @@ import {
 import { useUnreadConversationsCount } from "@/hooks/chats/useUnreadConversationsCount";
 import { MemberRole } from "./TeamMember";
 import { workspacePanelHeightClass } from "./workspace-panel-classes";
+import {
+  CampaignQueueProgress,
+  type CampaignQueueProgressCounts,
+} from "@/components/campaign/CampaignQueueProgress";
 
 function formatUnreadBadgeCount(count: number): string {
   return count > 99 ? "99+" : String(count);
@@ -50,6 +54,7 @@ type CampaignNavSubItem = {
   name: string;
   path: string;
   status?: string | null;
+  campaignId?: string | number;
 };
 
 const NAV_ITEMS: NavItem[] = [
@@ -87,6 +92,7 @@ interface WorkspaceNavProps {
     title?: string | null;
     status?: string | null;
   }>;
+  campaignQueueProgress?: Record<string, CampaignQueueProgressCounts>;
   userRole: MemberRole;
   className?: string;
 }
@@ -94,6 +100,7 @@ interface WorkspaceNavProps {
 const WorkspaceNav = ({
   workspace,
   campaigns,
+  campaignQueueProgress = {},
   userRole,
   className = "",
 }: WorkspaceNavProps) => {
@@ -190,6 +197,7 @@ const WorkspaceNav = ({
                         `Campaign ${String(campaign.id)}`,
                       path: `campaigns/${campaign.id}`,
                       status: campaign.status,
+                      campaignId: campaign.id,
                     })),
                   ]
                 : item.subItems ?? [];
@@ -225,6 +233,10 @@ const WorkspaceNav = ({
                       const subItemTo = subItem.path
                         ? `${baseUrl}/${subItem.path}`
                         : baseUrl;
+                      const progress =
+                        subItem.campaignId != null
+                          ? campaignQueueProgress[String(subItem.campaignId)]
+                          : undefined;
                       return (
                         <NavLink
                           key={subItem.path || subItem.name}
@@ -232,13 +244,24 @@ const WorkspaceNav = ({
                           className={subLinkClass}
                         >
                           <span className="min-w-0 truncate">{subItem.name}</span>
-                          {subItem.status ? (
-                            <span
-                              className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${campaignStatusClass(
-                                subItem.status,
-                              )}`}
-                            >
-                              {formatCampaignStatus(subItem.status)}
+                          {progress?.totalCount || subItem.status ? (
+                            <span className="flex shrink-0 items-center gap-1.5">
+                              {progress?.totalCount ? (
+                                <CampaignQueueProgress
+                                  completedCount={progress.completedCount}
+                                  totalCount={progress.totalCount}
+                                  className="text-[10px] font-semibold uppercase tracking-wide"
+                                />
+                              ) : null}
+                              {subItem.status ? (
+                                <span
+                                  className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${campaignStatusClass(
+                                    subItem.status,
+                                  )}`}
+                                >
+                                  {formatCampaignStatus(subItem.status)}
+                                </span>
+                              ) : null}
                             </span>
                           ) : null}
                         </NavLink>

--- a/app/hooks/call/useCallCoaching.ts
+++ b/app/hooks/call/useCallCoaching.ts
@@ -5,7 +5,10 @@ import {
   COACHING_EVENT_TYPES,
   safeParseCoachingEvent,
 } from "@/lib/coaching-events.shared";
-import { safeParseWorkspaceEventData } from "@/lib/workspace-events.shared";
+import {
+  ACCESS_REVOKED_EVENT,
+  safeParseWorkspaceEventData,
+} from "@/lib/workspace-events.shared";
 
 export type TranscriptSegmentView = {
   id: string;
@@ -100,6 +103,12 @@ export function useCallCoaching(
   // the reset effect does not immediately clobber the hydrated mount.
   const seededSidRef = useRef(callSid);
 
+  /**
+   * @effect Track the active call sid in a ref for the SSE listener, and reset transcript/coaching state when the screen switches to a different call (re-seeding from hydration if the new call has any).
+   * @effect-deps callSid (the active call; a change means the previous call's transcript, cues, metrics and session must not leak into the new one)
+   * @effect-side-effects none — updates callSidRef/seededSidRef and resets local state only
+   * @effect-why-not-loader Reacts to an in-page call switch rather than a navigation; the initial values come from the loader via `hydration`, and this only handles subsequent changes.
+   */
   useEffect(() => {
     callSidRef.current = callSid;
     if (seededSidRef.current === callSid) return;
@@ -112,6 +121,12 @@ export function useCallCoaching(
     setSession(next?.session ?? null);
   }, [callSid]);
 
+  /**
+   * @effect Open an SSE connection to the workspace events endpoint and apply this call's transcript segments, coaching metrics, cues and final session to local state.
+   * @effect-deps workspaceId (which workspace's event stream to open); callSid (which call's events to keep — others are discarded); subscribe (capability gate; false means no connection is opened at all)
+   * @effect-side-effects subscription — opens an EventSource (SSE) connection on mount/dep-change; removes listeners and closes the connection on cleanup, or on a terminal access_revoked frame
+   * @effect-why-not-loader Live server-pushed transcript/coaching events cannot be modeled as request/response; the connection stays open for the call's duration. Initial state is loader-provided via `hydration`.
+   */
   useEffect(() => {
     if (!subscribe || !workspaceId || !callSid) return;
 
@@ -200,13 +215,25 @@ export function useCallCoaching(
       }
     };
 
+    // Workspace access was revoked while this call was live. Close explicitly —
+    // EventSource reconnects after a server-side close, and every retry would be
+    // rejected by the middleware. Live transcript state stays as-is rather than
+    // being cleared: the call screen is about to be navigated away from anyway,
+    // and blanking it mid-call would look like a transcription failure.
+    const handleAccessRevoked = () => {
+      logger.warn("Workspace access revoked; closing coaching SSE");
+      eventSource.close();
+    };
+
     eventSource.addEventListener("workspace_event", handleWorkspaceEvent);
+    eventSource.addEventListener(ACCESS_REVOKED_EVENT, handleAccessRevoked);
     eventSource.onerror = () => {
       logger.debug("Coaching SSE interrupted; EventSource will retry");
     };
 
     return () => {
       eventSource.removeEventListener("workspace_event", handleWorkspaceEvent);
+      eventSource.removeEventListener(ACCESS_REVOKED_EVENT, handleAccessRevoked);
       eventSource.close();
     };
   }, [workspaceId, callSid, subscribe]);

--- a/app/hooks/call/useCallCoaching.ts
+++ b/app/hooks/call/useCallCoaching.ts
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { logger } from "@/lib/logger.client";
+import {
+  COACHING_EVENT_TYPES,
+  safeParseCoachingEvent,
+} from "@/lib/coaching-events.shared";
+import { safeParseWorkspaceEventData } from "@/lib/workspace-events.shared";
+
+export type TranscriptSegmentView = {
+  id: string;
+  speaker: number;
+  speakerLabel: string;
+  text: string;
+  startMs: number;
+  endMs: number;
+  fillerCount: number;
+};
+
+export type CoachingMetricsView = {
+  wpm: number;
+  fillerCount: number;
+  pauseCount: number;
+  longPauseCount: number;
+};
+
+export type CoachingCueView = {
+  eventId: string;
+  type: string;
+  severity: string;
+  heading: string;
+  suggestion: string;
+  acknowledgedAt?: string;
+};
+
+export type CoachingSessionView = {
+  wpmAvg: number;
+  fillerCount: number;
+  pauseCount: number;
+  longPauseCount: number;
+  score: number;
+  summary: string;
+};
+
+/**
+ * Server-rendered state for a call already in flight, from
+ * `getCallCoachingHydration`. Carries its own `callSid` so a stale loader
+ * payload can never be pinned onto a different call.
+ */
+export type CallCoachingHydration = {
+  callSid: string;
+  segments: TranscriptSegmentView[];
+  metrics: CoachingMetricsView | null;
+  cues: CoachingCueView[];
+  session: CoachingSessionView | null;
+};
+
+function hydrationFor(
+  callSid: string | null,
+  hydration: CallCoachingHydration | null | undefined,
+): CallCoachingHydration | null {
+  if (!hydration || !callSid || hydration.callSid !== callSid) return null;
+  return hydration;
+}
+
+/**
+ * Subscribes to live transcript / coaching SSE for a call.
+ *
+ * `subscribe` short-circuits inside the effect rather than at the call site so
+ * callers can keep calling the hook unconditionally (rules of hooks). When it
+ * is false no EventSource is constructed at all — a panel that renders nothing
+ * must not hold an SSE connection open.
+ *
+ * `hydration` seeds state for a call that was already running before this mount
+ * (a reload, or panels enabled mid-call). It is read through a ref so that a
+ * loader revalidation handing back a fresh object identity cannot reset live
+ * state out from under the stream.
+ */
+export function useCallCoaching(
+  workspaceId: string,
+  callSid: string | null,
+  subscribe: boolean = true,
+  hydration?: CallCoachingHydration | null,
+) {
+  const seed = hydrationFor(callSid, hydration);
+  const [segments, setSegments] = useState<TranscriptSegmentView[]>(
+    () => seed?.segments ?? [],
+  );
+  const [metrics, setMetrics] = useState<CoachingMetricsView | null>(
+    () => seed?.metrics ?? null,
+  );
+  const [cues, setCues] = useState<CoachingCueView[]>(() => seed?.cues ?? []);
+  const [session, setSession] = useState<CoachingSessionView | null>(
+    () => seed?.session ?? null,
+  );
+  const callSidRef = useRef(callSid);
+  const hydrationRef = useRef(hydration);
+  hydrationRef.current = hydration;
+  // Seeded above via the useState initialisers; this tracks *changes* only, so
+  // the reset effect does not immediately clobber the hydrated mount.
+  const seededSidRef = useRef(callSid);
+
+  useEffect(() => {
+    callSidRef.current = callSid;
+    if (seededSidRef.current === callSid) return;
+    seededSidRef.current = callSid;
+
+    const next = hydrationFor(callSid, hydrationRef.current);
+    setSegments(next?.segments ?? []);
+    setMetrics(next?.metrics ?? null);
+    setCues(next?.cues ?? []);
+    setSession(next?.session ?? null);
+  }, [callSid]);
+
+  useEffect(() => {
+    if (!subscribe || !workspaceId || !callSid) return;
+
+    const url = `/api/workspaces/${encodeURIComponent(workspaceId)}/events`;
+    const eventSource = new EventSource(url);
+
+    const handleWorkspaceEvent = (message: MessageEvent<string>) => {
+      const record = safeParseWorkspaceEventData(message.data);
+      if (!record) {
+        logger.error("Discarded malformed workspace event frame");
+        return;
+      }
+
+      const parsed = safeParseCoachingEvent(record.event_type, record.payload);
+      if (!parsed.ok) {
+        // Non-coaching events share this stream; only shout about our own.
+        if (!parsed.unknownType) {
+          logger.error(
+            `Discarded invalid ${record.event_type} event: ${parsed.error}`,
+          );
+        }
+        return;
+      }
+
+      const { type, payload } = parsed.event;
+      if (payload.callSid !== callSidRef.current) return;
+
+      switch (type) {
+        case COACHING_EVENT_TYPES.transcriptSegment:
+          setSegments((prev) =>
+            // Hydration and SSE replay overlap: a reconnect with no
+            // Last-Event-ID re-delivers segments we already have.
+            prev.some((existing) => existing.id === payload.segmentId)
+              ? prev
+              : [
+                  ...prev,
+                  {
+                    id: payload.segmentId,
+                    speaker: payload.speaker,
+                    speakerLabel: payload.speakerLabel,
+                    text: payload.text,
+                    startMs: payload.startMs,
+                    endMs: payload.endMs,
+                    fillerCount: payload.fillerCount,
+                  },
+                ],
+          );
+          break;
+        case COACHING_EVENT_TYPES.coachingMetrics:
+          setMetrics({
+            wpm: payload.wpm,
+            fillerCount: payload.fillerCount,
+            pauseCount: payload.pauseCount,
+            longPauseCount: payload.longPauseCount,
+          });
+          break;
+        case COACHING_EVENT_TYPES.coachingCue:
+          setCues((prev) =>
+            // Keeping the existing entry also preserves a hydrated
+            // acknowledgedAt that the replayed event does not carry.
+            prev.some((existing) => existing.eventId === payload.eventId)
+              ? prev
+              : [
+                  ...prev,
+                  {
+                    eventId: payload.eventId,
+                    type: payload.type,
+                    severity: payload.severity,
+                    heading: payload.heading,
+                    suggestion: payload.suggestion,
+                    acknowledgedAt: payload.acknowledgedAt,
+                  },
+                ],
+          );
+          break;
+        case COACHING_EVENT_TYPES.coachingSessionFinal:
+          setSession({
+            wpmAvg: payload.wpmAvg,
+            fillerCount: payload.fillerCount,
+            pauseCount: payload.pauseCount,
+            longPauseCount: payload.longPauseCount,
+            score: payload.score,
+            summary: payload.summary,
+          });
+          break;
+      }
+    };
+
+    eventSource.addEventListener("workspace_event", handleWorkspaceEvent);
+    eventSource.onerror = () => {
+      logger.debug("Coaching SSE interrupted; EventSource will retry");
+    };
+
+    return () => {
+      eventSource.removeEventListener("workspace_event", handleWorkspaceEvent);
+      eventSource.close();
+    };
+  }, [workspaceId, callSid, subscribe]);
+
+  const acknowledgeCue = useCallback(
+    async (eventId: string) => {
+      const stamp = (acknowledgedAt: string | undefined) =>
+        setCues((prev) =>
+          prev.map((cue) =>
+            cue.eventId === eventId ? { ...cue, acknowledgedAt } : cue,
+          ),
+        );
+
+      // Optimistic, then reverted if the server disagrees — a 403/404 must not
+      // leave a cue looking acknowledged when nothing was written.
+      stamp(new Date().toISOString());
+      try {
+        // `workspaceId` lets the server gate on tenant-scoped call ownership
+        // before it reads or writes the cue; it is validated against the
+        // caller's membership server-side, never trusted as-is.
+        const response = await fetch("/api/coaching-ack", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ coachingEventId: eventId, workspaceId }),
+        });
+        if (!response.ok) {
+          throw new Error(`Acknowledge failed with status ${response.status}`);
+        }
+      } catch (error) {
+        stamp(undefined);
+        logger.error("Failed to acknowledge coaching cue", error);
+        toast.error("Could not acknowledge that cue. Please try again.");
+      }
+    },
+    [workspaceId],
+  );
+
+  return { segments, metrics, cues, session, acknowledgeCue };
+}

--- a/app/hooks/call/useCallScreen.ts
+++ b/app/hooks/call/useCallScreen.ts
@@ -61,6 +61,8 @@ export function useCallScreen() {
     isActive,
     hasAccess,
     verifiedNumbers,
+    featureFlags,
+    initialCoaching,
   } = useLoaderData<LoaderData>();
   const revalidator = useRevalidator();
   useWorkspaceEventSubscription({
@@ -446,6 +448,9 @@ export function useCallScreen() {
       ...phoneVerification,
       setSelectedDevice: handleDeviceSelect,
     },
+    featureFlags,
+    callSid,
+    initialCoaching,
   };
 }
 

--- a/app/hooks/realtime/useWorkspaceEventSubscription.ts
+++ b/app/hooks/realtime/useWorkspaceEventSubscription.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { logger } from "@/lib/logger.client";
 import {
+  ACCESS_REVOKED_EVENT,
   matchesPostgresChangeFilter,
   parseWorkspaceEventData,
   type PostgresChangePayload,
@@ -74,13 +75,24 @@ export const useWorkspaceEventSubscription = ({
       }
     };
 
+    // The server sends this when the user's workspace access is revoked while
+    // the stream is open. Close explicitly: EventSource reconnects on its own
+    // after a server-side close, and every retry would be rejected by the
+    // middleware, so without this the tab retries forever.
+    const handleAccessRevoked = () => {
+      logger.warn("Workspace access revoked; closing SSE subscription");
+      eventSource.close();
+    };
+
     eventSource.addEventListener("workspace_event", handleWorkspaceEvent);
+    eventSource.addEventListener(ACCESS_REVOKED_EVENT, handleAccessRevoked);
     eventSource.onerror = () => {
       logger.debug("Workspace SSE connection interrupted; EventSource will retry");
     };
 
     return () => {
       eventSource.removeEventListener("workspace_event", handleWorkspaceEvent);
+      eventSource.removeEventListener(ACCESS_REVOKED_EVENT, handleAccessRevoked);
       eventSource.close();
     };
   }, [workspaceId, tablesForSubscription, filter]);

--- a/app/lib/billing-keys.ts
+++ b/app/lib/billing-keys.ts
@@ -7,6 +7,9 @@ export {
   stripeSessionKey,
   stripeEventKey,
   welcomeCreditsKey,
+  liveTranscriptionKey,
+  batchTranscriptionKey,
+  coachingCueKey,
   bucketFromIdempotencyKey,
   type BillingBucket,
 } from "../../shared/billing-keys";

--- a/app/lib/call-coaching-ack.server.ts
+++ b/app/lib/call-coaching-ack.server.ts
@@ -1,0 +1,83 @@
+/**
+ * Acknowledge a live-coaching cue.
+ *
+ * Tenancy: `coaching_event` carries no workspace column, so it is not in
+ * `workspace-scoped-tables.ts` and the scoped client cannot filter it. We
+ * therefore mirror `call-coaching-hydration.server.ts`: gate on `call` — which
+ * *is* scoped — via `createTenantDb`, and only touch the transcription table
+ * once the call is proven to belong to this workspace.
+ *
+ * Order matters. Membership in the *claimed* workspace is checked before any
+ * transcription row is read, and the tenant-scoped `call` gate is checked
+ * before any row is written. The one unavoidable admin read is the cue's
+ * `call_sid` pointer: an event id is the only handle the client has, and the
+ * sid is the only way to reach a scoped table. That read returns no cue content
+ * to the caller and a foreign / missing id is indistinguishable in the
+ * response — both yield the same 404, per the repo's uniform-404 posture
+ * (ADR-0004).
+ *
+ * Policy (deliberate): any member of the workspace, in any role, may ack any
+ * cue in that workspace. There is no role gate and no agent-ownership gate.
+ *
+ * Lives in `app/lib/**` rather than the route because routes are barred from
+ * `@/server/admin-db` by `no-restricted-imports` (ADR-0004).
+ */
+import { eq } from "drizzle-orm";
+import { call as callTable } from "@/db/schema";
+import { coaching_event } from "@/db/schema-transcription";
+import { requireWorkspaceAccess } from "@/lib/workspace-membership.server";
+import { createTenantDb } from "@/server/tenant-db";
+import { adminDb } from "@/server/admin-db";
+
+export type AcknowledgeCoachingCueResult =
+  | { ok: true }
+  | { ok: false; status: 400 | 404; error: string };
+
+export async function acknowledgeCoachingCue({
+  user,
+  workspaceId,
+  coachingEventId,
+}: {
+  user: { id: string };
+  workspaceId: string | undefined;
+  coachingEventId: string | undefined;
+}): Promise<AcknowledgeCoachingCueResult> {
+  if (!coachingEventId) {
+    return { ok: false, status: 400, error: "coachingEventId is required" };
+  }
+  if (!workspaceId) {
+    return { ok: false, status: 400, error: "workspaceId is required" };
+  }
+
+  // Membership gate first: a non-member never gets as far as a cue lookup.
+  // Throws AppError(404) for non-members (uniform 404), 403 for a bad role.
+  const tdb = createTenantDb(workspaceId);
+  await requireWorkspaceAccess({ user: { id: user.id }, workspaceId, tdb });
+
+  // Pointer read: `call_sid` only, nothing that could leak another tenant's cue.
+  const event = await adminDb.query.coaching_event.findFirst({
+    where: eq(coaching_event.id, coachingEventId),
+    columns: { call_sid: true },
+  });
+  if (!event) {
+    return { ok: false, status: 404, error: "Coaching event not found" };
+  }
+
+  // Tenancy gate: the scoped client filters `call` by workspace for us, so a
+  // cue whose call belongs to another workspace misses here and is never
+  // written.
+  const owned = await tdb.call.findFirst({
+    where: eq(callTable.sid, event.call_sid),
+    columns: { sid: true },
+  });
+  if (!owned) {
+    return { ok: false, status: 404, error: "Coaching event not found" };
+  }
+
+  await adminDb
+    .update(coaching_event)
+    .set({ acknowledged_at: new Date().toISOString() })
+    .where(eq(coaching_event.id, coachingEventId));
+
+  return { ok: true };
+}

--- a/app/lib/call-coaching-hydration.server.ts
+++ b/app/lib/call-coaching-hydration.server.ts
@@ -1,0 +1,126 @@
+/**
+ * Initial transcript / coaching state for a call that is already in flight.
+ *
+ * Without this, a reload or a late mount of the coaching panels starts from an
+ * empty UI even though `transcript_segment` / `coaching_event` /
+ * `coaching_session` rows already exist for the call. The SSE stream is a
+ * *delta* transport, not a hydration transport: a fresh EventSource has no
+ * `Last-Event-ID`, so relying on replay would stream the workspace's entire
+ * event history from id 0 just to reconstruct one call.
+ *
+ * Tenancy: `transcript_segment` / `coaching_event` / `coaching_session` carry no
+ * workspace column, so they are not in `workspace-scoped-tables.ts` and the
+ * scoped client cannot filter them. We therefore gate on `call` — which *is*
+ * scoped — via `createTenantDb`, and only touch the transcription tables once
+ * the call is proven to belong to this workspace. A call in another workspace
+ * yields `null`, matching the repo's uniform-404 posture (ADR-0004).
+ */
+import { desc, eq } from "drizzle-orm";
+import { call as callTable } from "@/db/schema";
+import {
+  coaching_event,
+  coaching_session,
+  transcript_segment,
+} from "@/db/schema-transcription";
+import { createTenantDb } from "@/server/tenant-db";
+import { adminDb } from "@/server/admin-db";
+
+/** Bounds. A long call can accumulate thousands of segments; hydrate a tail. */
+export const HYDRATION_SEGMENT_LIMIT = 200;
+export const HYDRATION_CUE_LIMIT = 50;
+
+export type CallCoachingHydration = {
+  callSid: string;
+  segments: Array<{
+    id: string;
+    speaker: number;
+    speakerLabel: string;
+    text: string;
+    startMs: number;
+    endMs: number;
+    fillerCount: number;
+  }>;
+  metrics: null;
+  cues: Array<{
+    eventId: string;
+    type: string;
+    severity: string;
+    heading: string;
+    suggestion: string;
+    acknowledgedAt?: string;
+  }>;
+  session: {
+    wpmAvg: number;
+    fillerCount: number;
+    pauseCount: number;
+    longPauseCount: number;
+    score: number;
+    summary: string;
+  } | null;
+};
+
+export async function getCallCoachingHydration(
+  workspaceId: string,
+  callSid: string | null | undefined,
+): Promise<CallCoachingHydration | null> {
+  if (!callSid) return null;
+
+  // Tenancy gate: the scoped client filters `call` by workspace for us.
+  const tdb = createTenantDb(workspaceId);
+  const owned = await tdb.call.findFirst({
+    where: eq(callTable.sid, callSid),
+    columns: { sid: true },
+  });
+  if (!owned) return null;
+
+  const [segmentRows, cueRows, sessionRow] = await Promise.all([
+    adminDb.query.transcript_segment.findMany({
+      where: eq(transcript_segment.call_sid, callSid),
+      orderBy: [desc(transcript_segment.start_ms)],
+      limit: HYDRATION_SEGMENT_LIMIT,
+    }),
+    adminDb.query.coaching_event.findMany({
+      where: eq(coaching_event.call_sid, callSid),
+      orderBy: [desc(coaching_event.created_at)],
+      limit: HYDRATION_CUE_LIMIT,
+    }),
+    adminDb.query.coaching_session.findFirst({
+      where: eq(coaching_session.call_sid, callSid),
+    }),
+  ]);
+
+  return {
+    callSid,
+    // Queried newest-first to bound the tail, rendered oldest-first.
+    segments: [...segmentRows].reverse().map((row) => ({
+      id: row.id,
+      speaker: row.speaker,
+      speakerLabel: row.speaker_label ?? "speaker",
+      text: row.text,
+      startMs: row.start_ms,
+      endMs: row.end_ms,
+      fillerCount: row.filler_count ?? 0,
+    })),
+    // `coaching_metrics` is a computed, cadence-published event with no table
+    // behind it, so there is nothing to hydrate; the next engine tick fills it.
+    metrics: null,
+    cues: [...cueRows].reverse().map((row) => ({
+      eventId: row.id,
+      type: row.type,
+      severity: row.severity ?? "info",
+      heading: String(row.payload?.heading ?? row.type),
+      suggestion: String(row.payload?.suggestion ?? ""),
+      acknowledgedAt: row.acknowledged_at ?? undefined,
+    })),
+    session: sessionRow
+      ? {
+          wpmAvg: sessionRow.wpm_avg ?? 0,
+          fillerCount: sessionRow.filler_count ?? 0,
+          pauseCount: sessionRow.pause_count ?? 0,
+          longPauseCount: sessionRow.long_pause_count ?? 0,
+          score: sessionRow.score ?? 0,
+          summary: sessionRow.summary ?? "",
+        }
+      : null,
+  };
+}

--- a/app/lib/call-recording-storage.server.ts
+++ b/app/lib/call-recording-storage.server.ts
@@ -1,0 +1,206 @@
+import { eq } from "drizzle-orm";
+import { workspace } from "@/db/schema";
+import { adminDb } from "@/server/admin-db";
+import { NORMALIZED_AUDIO_CONTENT_TYPE } from "@/lib/audio-upload";
+import { logger } from "@/lib/logger.server";
+import { uploadObject } from "@/lib/object-storage.server";
+import {
+  readTwilioWorkspaceCredentials,
+  type TwilioWorkspaceCredentials,
+} from "@/lib/twilio-workspace-credentials";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 200;
+
+function parseTwilioDataColumn(raw: unknown): unknown {
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return raw;
+    }
+  }
+  return raw;
+}
+
+/** Railway Buckets object path for a Twilio call recording copy. */
+export function callRecordingStoragePath(
+  workspaceId: string,
+  callSid: string,
+): string {
+  return `${workspaceId}/recording-${callSid}.mp3`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function jitterDelay(baseMs: number, attempt: number): number {
+  const exp = baseMs * 2 ** attempt;
+  return exp + Math.floor(Math.random() * baseMs);
+}
+
+function isRetryableHttpStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function twilioRecordingMp3Url(accountSid: string, recordingSid: string): string {
+  return `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Recordings/${recordingSid}.mp3`;
+}
+
+function basicAuthHeader(creds: TwilioWorkspaceCredentials): string {
+  return `Basic ${Buffer.from(`${creds.sid}:${creds.authToken}`).toString("base64")}`;
+}
+
+type FetchTwilioRecordingDeps = {
+  fetch?: typeof fetch;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+};
+
+export async function fetchTwilioRecordingMp3(
+  accountSid: string,
+  recordingSid: string,
+  creds: TwilioWorkspaceCredentials,
+  deps: FetchTwilioRecordingDeps = {},
+): Promise<Buffer> {
+  const fetchFn = deps.fetch ?? fetch;
+  const maxAttempts = deps.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const baseDelayMs = deps.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const url = twilioRecordingMp3Url(accountSid, recordingSid);
+  const headers = { Authorization: basicAuthHeader(creds) };
+
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      const response = await fetchFn(url, { headers });
+      if (!response.ok) {
+        const message = `Twilio recording fetch failed (${response.status} ${response.statusText})`;
+        if (isRetryableHttpStatus(response.status) && attempt < maxAttempts - 1) {
+          logger.warn("call_recording.fetch_retry", {
+            accountSid,
+            recordingSid,
+            attempt: attempt + 1,
+            maxAttempts,
+            status: response.status,
+          });
+          await sleep(jitterDelay(baseDelayMs, attempt));
+          continue;
+        }
+        throw new Error(message);
+      }
+
+      const bytes = Buffer.from(await response.arrayBuffer());
+      if (bytes.length === 0) {
+        throw new Error("Twilio recording fetch returned empty body");
+      }
+      return bytes;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      const retryable =
+        error instanceof TypeError || lastError.message.includes("fetch failed");
+
+      if (retryable && attempt < maxAttempts - 1) {
+        logger.warn("call_recording.fetch_retry", {
+          accountSid,
+          recordingSid,
+          attempt: attempt + 1,
+          maxAttempts,
+          error: lastError.message,
+        });
+        await sleep(jitterDelay(baseDelayMs, attempt));
+        continue;
+      }
+      throw lastError;
+    }
+  }
+
+  throw lastError ?? new Error("Twilio recording fetch failed");
+}
+
+export async function loadWorkspaceTwilioCredentials(
+  workspaceId: string,
+): Promise<TwilioWorkspaceCredentials | null> {
+  const row = await adminDb.query.workspace.findFirst({
+    where: eq(workspace.id, workspaceId),
+    columns: { twilio_data: true },
+  });
+  if (!row) return null;
+  return readTwilioWorkspaceCredentials(parseTwilioDataColumn(row.twilio_data));
+}
+
+type PersistCallRecordingArgs = {
+  workspaceId: string;
+  callSid: string;
+  accountSid: string;
+  recordingSid: string;
+  existingAudioUrl?: string | null;
+};
+
+type PersistCallRecordingDeps = FetchTwilioRecordingDeps & {
+  uploadObject?: typeof uploadObject;
+  loadCredentials?: typeof loadWorkspaceTwilioCredentials;
+};
+
+export type PersistCallRecordingResult =
+  | { ok: true; audioUrl: string; skipped: false }
+  | { ok: true; audioUrl: string; skipped: true; reason: "already_persisted" }
+  | {
+      ok: false;
+      reason: "missing_credentials" | "download_failed" | "upload_failed";
+      error: string;
+    };
+
+export async function persistCallRecordingToStorage(
+  args: PersistCallRecordingArgs,
+  deps: PersistCallRecordingDeps = {},
+): Promise<PersistCallRecordingResult> {
+  const objectPath = callRecordingStoragePath(args.workspaceId, args.callSid);
+
+  if (args.existingAudioUrl?.trim()) {
+    return {
+      ok: true,
+      audioUrl: args.existingAudioUrl.trim(),
+      skipped: true,
+      reason: "already_persisted",
+    };
+  }
+
+  const loadCredentials = deps.loadCredentials ?? loadWorkspaceTwilioCredentials;
+  const creds = await loadCredentials(args.workspaceId);
+  if (!creds) {
+    return {
+      ok: false,
+      reason: "missing_credentials",
+      error: "Workspace Twilio credentials not found",
+    };
+  }
+
+  let audioBuffer: Buffer;
+  try {
+    audioBuffer = await fetchTwilioRecordingMp3(
+      args.accountSid,
+      args.recordingSid,
+      creds,
+      deps,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: "download_failed", error: message };
+  }
+
+  const upload = deps.uploadObject ?? uploadObject;
+  try {
+    await upload("workspaceAudio", objectPath, audioBuffer, {
+      contentType: NORMALIZED_AUDIO_CONTENT_TYPE,
+      cacheControl: "60",
+      upsert: true,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: "upload_failed", error: message };
+  }
+
+  return { ok: true, audioUrl: objectPath, skipped: false };
+}

--- a/app/lib/campaign-queue-search.server.ts
+++ b/app/lib/campaign-queue-search.server.ts
@@ -337,6 +337,58 @@ export async function countDialableCompletedCampaignQueueRows(
   return countCampaignQueueRows(campaignId, buildCompletedCampaignQueueWhere(campaignId));
 }
 
+export type CampaignQueueProgressCounts = {
+  completedCount: number;
+  totalCount: number;
+};
+
+export async function fetchWorkspaceCampaignQueueProgressMap(
+  workspaceId: string,
+): Promise<Map<number, CampaignQueueProgressCounts>> {
+  const dialableContact = exists(
+    db
+      .select({ one: sql`1` })
+      .from(contactTable)
+      .where(
+        and(
+          eq(contactTable.id, campaignQueueTable.contact_id),
+          isNotNull(contactTable.phone),
+          ne(contactTable.phone, ""),
+        ),
+      ),
+  );
+
+  const rows = await db
+    .select({
+      campaignId: campaignQueueTable.campaign_id,
+      totalCount: count(),
+      completedCount: sql<number>`
+        count(*) filter (
+          where ${campaignQueueTable.queue_state} = ${QUEUE_STATUS_DEQUEUED}
+            or ${campaignQueueTable.dequeued_at} is not null
+        )::int
+      `.mapWith(Number),
+    })
+    .from(campaignQueueTable)
+    .where(
+      and(
+        eq(campaignQueueTable.workspace, workspaceId),
+        dialableContact,
+      ),
+    )
+    .groupBy(campaignQueueTable.campaign_id);
+
+  return new Map(
+    rows.map((row) => [
+      row.campaignId,
+      {
+        completedCount: row.completedCount ?? 0,
+        totalCount: row.totalCount ?? 0,
+      },
+    ]),
+  );
+}
+
 export async function fetchDialableCampaignQueueWithContacts(args: {
   campaignId: number;
   limit: number;

--- a/app/lib/coaching-events.shared.ts
+++ b/app/lib/coaching-events.shared.ts
@@ -1,0 +1,144 @@
+/**
+ * Single source of truth for the live transcript / coaching workspace events
+ * (ADR-0027/0028).
+ *
+ * Both ends of the wire import this module:
+ *  - `services/media-stream/db-writer.ts` parses payloads on the way OUT, so a
+ *    malformed producer is a loud failure at the publish site rather than a
+ *    silently-dropped event in every browser.
+ *  - `app/hooks/call/useCallCoaching.ts` safe-parses on the way IN, so a bad or
+ *    hostile row can never corrupt UI state.
+ *
+ * Client-safe: zod only, no server imports. `app/db/schema-transcription.ts`
+ * already establishes that `@/lib/*` schema modules are importable from
+ * `services/media-stream`, so this module is reachable from both trees.
+ */
+import { z } from "zod";
+
+/**
+ * The four event-type literals. Previously duplicated as bare strings between
+ * db-writer.ts and useCallCoaching.ts; import from here instead.
+ */
+export const COACHING_EVENT_TYPES = {
+  transcriptSegment: "transcript_segment",
+  coachingMetrics: "coaching_metrics",
+  coachingCue: "coaching_cue",
+  coachingSessionFinal: "coaching_session_final",
+} as const;
+
+/** `speaker_label` is nullable in `transcript_segment`; normalise it here once. */
+const speakerLabel = z
+  .string()
+  .nullish()
+  .transform((value) => value ?? "speaker");
+
+const nullableCount = z
+  .number()
+  .nullish()
+  .transform((value) => value ?? 0);
+
+export const TranscriptSegmentEventPayload = z.object({
+  callSid: z.string().min(1),
+  segmentId: z.string().min(1),
+  speaker: z.number(),
+  speakerLabel,
+  text: z.string(),
+  startMs: z.number(),
+  endMs: z.number(),
+  fillerCount: nullableCount,
+});
+export type TranscriptSegmentEventPayload = z.infer<typeof TranscriptSegmentEventPayload>;
+
+export const CoachingMetricsEventPayload = z.object({
+  callSid: z.string().min(1),
+  wpm: z.number(),
+  fillerCount: z.number(),
+  pauseCount: z.number(),
+  longPauseCount: z.number(),
+});
+export type CoachingMetricsEventPayload = z.infer<typeof CoachingMetricsEventPayload>;
+
+export const CoachingCueEventPayload = z.object({
+  callSid: z.string().min(1),
+  eventId: z.string().min(1),
+  type: z.string().min(1),
+  severity: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? "info"),
+  heading: z.string(),
+  suggestion: z.string(),
+  /** Present on hydrated cues; live cues are always unacknowledged. */
+  acknowledgedAt: z.string().nullish().transform((value) => value ?? undefined),
+});
+export type CoachingCueEventPayload = z.infer<typeof CoachingCueEventPayload>;
+
+export const CoachingSessionFinalEventPayload = z.object({
+  callSid: z.string().min(1),
+  sessionId: z.string().min(1),
+  wpmAvg: nullableCount,
+  fillerCount: nullableCount,
+  pauseCount: nullableCount,
+  longPauseCount: nullableCount,
+  score: nullableCount,
+  summary: z
+    .string()
+    .nullish()
+    .transform((value) => value ?? ""),
+});
+export type CoachingSessionFinalEventPayload = z.infer<typeof CoachingSessionFinalEventPayload>;
+
+export const COACHING_EVENT_PAYLOAD_SCHEMAS = {
+  [COACHING_EVENT_TYPES.transcriptSegment]: TranscriptSegmentEventPayload,
+  [COACHING_EVENT_TYPES.coachingMetrics]: CoachingMetricsEventPayload,
+  [COACHING_EVENT_TYPES.coachingCue]: CoachingCueEventPayload,
+  [COACHING_EVENT_TYPES.coachingSessionFinal]: CoachingSessionFinalEventPayload,
+} as const;
+
+export type CoachingEventType = keyof typeof COACHING_EVENT_PAYLOAD_SCHEMAS;
+
+export type CoachingEvent =
+  | { type: typeof COACHING_EVENT_TYPES.transcriptSegment; payload: TranscriptSegmentEventPayload }
+  | { type: typeof COACHING_EVENT_TYPES.coachingMetrics; payload: CoachingMetricsEventPayload }
+  | { type: typeof COACHING_EVENT_TYPES.coachingCue; payload: CoachingCueEventPayload }
+  | {
+      type: typeof COACHING_EVENT_TYPES.coachingSessionFinal;
+      payload: CoachingSessionFinalEventPayload;
+    };
+
+export function isCoachingEventType(eventType: string): eventType is CoachingEventType {
+  return Object.prototype.hasOwnProperty.call(COACHING_EVENT_PAYLOAD_SCHEMAS, eventType);
+}
+
+export type CoachingEventParseResult =
+  | { ok: true; event: CoachingEvent }
+  /** `unknownType` distinguishes "not ours, ignore quietly" from "ours but malformed". */
+  | { ok: false; unknownType: true }
+  | { ok: false; unknownType: false; error: string };
+
+/**
+ * Validate one workspace-event envelope. Never throws — the SSE handler must not
+ * be able to tear down the stream on a single bad row.
+ */
+export function safeParseCoachingEvent(
+  eventType: string,
+  payload: unknown,
+): CoachingEventParseResult {
+  if (!isCoachingEventType(eventType)) {
+    return { ok: false, unknownType: true };
+  }
+
+  const schema = COACHING_EVENT_PAYLOAD_SCHEMAS[eventType];
+  const result = schema.safeParse(payload);
+  if (!result.success) {
+    return {
+      ok: false,
+      unknownType: false,
+      error: result.error.issues
+        .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("; "),
+    };
+  }
+
+  return { ok: true, event: { type: eventType, payload: result.data } as CoachingEvent };
+}

--- a/app/lib/coaching-schemas.ts
+++ b/app/lib/coaching-schemas.ts
@@ -5,6 +5,16 @@ export const WorkspaceFeatureFlags = z
   .object({
     liveTranscription: z.boolean().default(false),
     liveCoaching: z.boolean().default(false),
+    /**
+     * Post-call batch transcription of the recording (ElevenLabs Scribe batch).
+     *
+     * Default-off and off everywhere: the product policy for batch — whether it
+     * ships at all, and whether it is billed per call or bundled — is UNDECIDED.
+     * Until it is decided, no call is enqueued for batch and no call is billed
+     * for batch. The handler is kept intact so flipping this flag on is the only
+     * change needed to re-enable the path.
+     */
+    batchTranscription: z.boolean().default(false),
   })
   .passthrough();
 
@@ -45,6 +55,7 @@ export const TranscriptMetadata = z
   .object({
     deepgramModel: z.string().optional(),
     cohereModel: z.string().optional(),
+    elevenlabsModel: z.string().optional(),
     utteranceCount: z.number().optional(),
     detectedLanguage: z.string().optional(),
   })

--- a/app/lib/database/campaign-stats.server.ts
+++ b/app/lib/database/campaign-stats.server.ts
@@ -332,14 +332,16 @@ export async function fetchQueueCounts({
   campaignId: string;
 }) {
   const campaignIdNum = Number(campaignId);
-  const [fullCount, queuedCount] = await Promise.all([
+  const [fullCount, queuedCount, completedCount] = await Promise.all([
     countDialableCampaignQueueRows(campaignIdNum),
     countDialableQueuedCampaignQueueRows(campaignIdNum),
+    countDialableCompletedCampaignQueueRows(campaignIdNum),
   ]);
 
   return {
     fullCount,
     queuedCount,
+    completedCount,
   };
 }
 

--- a/app/lib/env.server.ts
+++ b/app/lib/env.server.ts
@@ -150,7 +150,11 @@ export function warnIfStripeKeyModeMismatch(): boolean {
 
 // Validate environment variables on module load
 // This will throw an error immediately if required vars are missing
-if (typeof window === 'undefined') {
+// `!("window" in globalThis)` rather than `typeof window === "undefined"`:
+// this module is also pulled in by services/** (the Bun media-stream service),
+// which typechecks without the DOM lib, so the bare `window` global is not
+// declared there. The runtime semantics are identical.
+if (!("window" in globalThis)) {
   // Only validate on server-side
   try {
     validateEnv();
@@ -220,8 +224,23 @@ export const env = {
     }
     return 'dev-media-stream-secret-change-me';
   },
-  /** Public host of the media-stream Bun service. Defaults to localhost:3001 for dev. */
-  MEDIA_STREAM_HOST: () => getEnv('MEDIA_STREAM_HOST') ?? 'localhost:3001',
+  /**
+   * Public host of the media-stream Bun service.
+   *
+   * Defaults to localhost:3001 in non-production ONLY. In production an unset
+   * value must stay undefined so the fail-closed guard in
+   * media-stream-twiml.server.ts fires (logs `media-stream-host-missing` and
+   * skips `<Stream>`); defaulting there would instead hand Twilio a
+   * `wss://localhost:3001` URL it can never reach — a silently broken
+   * `<Stream>` on every call.
+   */
+  MEDIA_STREAM_HOST: () => {
+    const value = getEnv('MEDIA_STREAM_HOST');
+    if (value) {
+      return value;
+    }
+    return isProduction() ? undefined : 'localhost:3001';
+  },
 } as const;
 
 /**

--- a/app/lib/feature-flags.ts
+++ b/app/lib/feature-flags.ts
@@ -13,13 +13,3 @@ export function hasFeatureFlag(
   if (!parsed.success) return false;
   return Boolean(parsed.data[flag]);
 }
-
-/** True when live transcription or live coaching is enabled for the workspace. */
-export function coachingEnabled(
-  flags?: WorkspaceFeatureFlags | Record<string, unknown> | null,
-): boolean {
-  return (
-    hasFeatureFlag(flags, "liveTranscription") ||
-    hasFeatureFlag(flags, "liveCoaching")
-  );
-}

--- a/app/lib/live-media-capabilities.ts
+++ b/app/lib/live-media-capabilities.ts
@@ -1,0 +1,43 @@
+import type { WorkspaceFeatureFlags } from "@/lib/coaching-schemas";
+import { hasFeatureFlag } from "@/lib/feature-flags";
+
+/**
+ * Derives what a workspace's live-media pipeline should actually do from its
+ * persisted feature flags.
+ *
+ * The persisted flags (`liveTranscription`, `liveCoaching`) stay independent —
+ * enabling coaching does NOT write `liveTranscription: true`. All implication
+ * is derived here, at runtime:
+ *
+ * - Coaching consumes realtime transcription as its input, so enabling coaching
+ *   alone must still attach the Twilio Media Stream (`attachStream`). Gating the
+ *   stream on `liveTranscription` alone leaves coaching-only workspaces with no
+ *   audio and no cues.
+ * - The transcript UI is the transcription product, so `showTranscript` stays
+ *   gated on `liveTranscription` only. A coaching-only workspace runs STT
+ *   internally but never shows the raw transcript.
+ */
+export type LiveMediaCapabilities = {
+  /** Attach `<Start><Stream>` — coaching cannot work without STT input. */
+  attachStream: boolean;
+  /** Run the coaching engine over committed transcripts. */
+  runCoaching: boolean;
+  /** Render the live transcript UI. */
+  showTranscript: boolean;
+  /** Render the live coaching UI. */
+  showCoaching: boolean;
+};
+
+export function liveMediaCapabilities(
+  flags: WorkspaceFeatureFlags | Record<string, unknown> | null | undefined,
+): LiveMediaCapabilities {
+  const liveTranscription = hasFeatureFlag(flags, "liveTranscription");
+  const liveCoaching = hasFeatureFlag(flags, "liveCoaching");
+
+  return {
+    attachStream: liveTranscription || liveCoaching,
+    runCoaching: liveCoaching,
+    showTranscript: liveTranscription,
+    showCoaching: liveCoaching,
+  };
+}

--- a/app/lib/media-stream-twiml.server.ts
+++ b/app/lib/media-stream-twiml.server.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+import type Twilio from "twilio";
+import { env } from "@/lib/env.server";
+import type { WorkspaceFeatureFlags } from "@/lib/coaching-schemas";
+import { liveMediaCapabilities } from "@/lib/live-media-capabilities";
+import { createMediaStreamToken } from "@/lib/media-stream-token.server";
+import { logger } from "@/lib/logger.server";
+
+export type LiveTranscriptionDirection = "outbound" | "predictive" | "inbound";
+
+export type LiveTranscriptionStreamParams = {
+  workspaceId: string;
+  userId: string;
+  direction: LiveTranscriptionDirection;
+  callId?: string | number | null;
+  contactId?: string | number | null;
+  campaignId?: string | number | null;
+  callSid?: string | null;
+  streamName?: string;
+};
+
+export type AppendLiveTranscriptionStreamInput = {
+  twiml: Twilio.twiml.VoiceResponse;
+  featureFlags: WorkspaceFeatureFlags | Record<string, unknown> | null | undefined;
+  params: LiveTranscriptionStreamParams;
+};
+
+/**
+ * Builds the signed WSS URL Twilio connects to for Media Streams.
+ * Returns null when the host is unset — the caller skips `<Stream>` and logs.
+ */
+export function buildMediaStreamWsUrl(sessionId: string, token: string): string | null {
+  const host = env.MEDIA_STREAM_HOST()?.trim();
+  if (!host) {
+    return null;
+  }
+
+  const protocol = process.env.NODE_ENV === "production" ? "wss" : "ws";
+  return `${protocol}://${host}/${sessionId}?token=${encodeURIComponent(token)}`;
+}
+
+/**
+ * Appends `<Start><Stream track="both_tracks">` when the workspace's derived
+ * capabilities say the stream is needed (live transcription OR live coaching —
+ * coaching needs the same audio as its STT input).
+ *
+ * Never throws: returns false without mutating TwiML when gated off or
+ * misconfigured, so the call itself always proceeds. A missing
+ * `MEDIA_STREAM_HOST` while the stream was wanted fails closed (no `<Stream>`)
+ * and is logged as an error — it is a deploy misconfiguration, not a normal
+ * "feature off" path.
+ */
+export function appendLiveTranscriptionStreamTwiml({
+  twiml,
+  featureFlags,
+  params,
+}: AppendLiveTranscriptionStreamInput): boolean {
+  if (!liveMediaCapabilities(featureFlags).attachStream) {
+    return false;
+  }
+
+  const { workspaceId, userId, direction } = params;
+  if (!workspaceId || !userId) {
+    return false;
+  }
+
+  try {
+    const sessionId = randomUUID();
+    const token = createMediaStreamToken({
+      workspaceId,
+      campaignId:
+        params.campaignId != null ? String(params.campaignId) : "",
+      userId,
+      sessionId,
+    });
+
+    const url = buildMediaStreamWsUrl(sessionId, token);
+    if (!url) {
+      logger.error(
+        "MEDIA_STREAM_HOST is unset — skipping <Stream> for a workspace with live media enabled",
+        {
+          guard: "media-stream-host-missing",
+          workspaceId,
+          direction,
+          callSid: params.callSid ?? null,
+        },
+      );
+      return false;
+    }
+
+    const streamName =
+      params.streamName ??
+      (params.callId != null ? `call-${params.callId}` : `stream-${sessionId}`);
+
+    const start = twiml.start();
+    const stream = start.stream({
+      url,
+      track: "both_tracks",
+      name: streamName,
+    });
+
+    if (params.callId != null) {
+      stream.parameter({ name: "callId", value: String(params.callId) });
+    }
+    stream.parameter({ name: "workspaceId", value: workspaceId });
+    stream.parameter({ name: "userId", value: userId });
+    if (params.contactId != null) {
+      stream.parameter({ name: "contactId", value: String(params.contactId) });
+    }
+    if (params.campaignId != null) {
+      stream.parameter({ name: "campaignId", value: String(params.campaignId) });
+    }
+    stream.parameter({ name: "direction", value: direction });
+    if (params.callSid) {
+      stream.parameter({ name: "callSid", value: params.callSid });
+    }
+
+    return true;
+  } catch (error) {
+    logger.warn("Skipping live transcription stream TwiML", {
+      workspaceId,
+      direction,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/app/lib/outreach-typed-fields.server.ts
+++ b/app/lib/outreach-typed-fields.server.ts
@@ -1,0 +1,154 @@
+import { contact as contactTable } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import type { TenantDb } from "@/server/tenant-db";
+import type { Json } from "@/lib/db-types";
+
+export type TypedOutreachFields = {
+  support_level?: number | null;
+  volunteer_interest?: string | null;
+  lawn_sign?: boolean | null;
+  vote_by_mail?: boolean | null;
+  issue_tags?: string[] | null;
+  membership_sold?: boolean | null;
+  callback_audit?: boolean | null;
+};
+
+const TYPED_FIELD_ALIASES: Record<keyof TypedOutreachFields, string[]> = {
+  support_level: ["support_level", "supportlevel", "support level", "support"],
+  volunteer_interest: [
+    "volunteer_interest",
+    "volunteerinterest",
+    "volunteer interest",
+    "volunteer",
+  ],
+  lawn_sign: ["lawn_sign", "lawnsign", "lawn sign", "lawnsigns"],
+  vote_by_mail: ["vote_by_mail", "votebymail", "vote by mail", "absentee"],
+  issue_tags: ["issue_tags", "issuetags", "issue tags", "issues"],
+  membership_sold: [
+    "membership_sold",
+    "membershipsold",
+    "membership sold",
+    "membership",
+  ],
+  callback_audit: [
+    "callback_audit",
+    "callbackaudit",
+    "callback audit",
+    "callback",
+  ],
+};
+
+function asBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    if (["true", "yes", "y", "1"].includes(v)) return true;
+    if (["false", "no", "n", "0"].includes(v)) return false;
+  }
+  return null;
+}
+
+function asSupportLevel(value: unknown): number | null {
+  if (typeof value === "number") {
+    return value >= 1 && value <= 5 ? value : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const parsed = Number(trimmed);
+    if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 5) return parsed;
+    const lower = trimmed.toLowerCase();
+    const labelMap: Record<string, number> = {
+      "strong support": 1,
+      "lean support": 2,
+      undecided: 3,
+      "lean opposition": 4,
+      "strong opposition": 5,
+    };
+    if (labelMap[lower] !== undefined) return labelMap[lower];
+  }
+  return null;
+}
+
+function asStringArray(value: unknown): string[] | null {
+  if (Array.isArray(value)) {
+    const tags = value
+      .map((v) => (typeof v === "string" ? v.trim() : String(v).trim()))
+      .filter((v) => v.length > 0);
+    return tags.length > 0 ? tags : null;
+  }
+  if (typeof value === "string") {
+    const tags = value
+      .split(/[,;]\s*|\s*\|\s*/)
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+    return tags.length > 0 ? tags : null;
+  }
+  return null;
+}
+
+export function extractTypedOutreachFields(update: Json | undefined): TypedOutreachFields {
+  if (!update || typeof update !== "object" || Array.isArray(update)) {
+    return {};
+  }
+  const root = update as Record<string, unknown>;
+  const lookup = new Map<string, unknown>();
+  const flatten = (obj: Record<string, unknown>, prefix = "") => {
+    for (const [key, value] of Object.entries(obj)) {
+      const lowerKey = `${prefix}${key}`.toLowerCase();
+      lookup.set(lowerKey, value);
+      if (value === null || typeof value !== "object" || Array.isArray(value)) {
+        const leafKey = key.toLowerCase();
+        if (!lookup.has(leafKey)) {
+          lookup.set(leafKey, value);
+        }
+      }
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        flatten(value as Record<string, unknown>, `${prefix}${key}.`);
+      }
+    }
+  };
+  flatten(root);
+
+  const result: TypedOutreachFields = {};
+  for (const [field, aliases] of Object.entries(TYPED_FIELD_ALIASES) as Array<
+    [keyof TypedOutreachFields, string[]]
+  >) {
+    for (const alias of aliases) {
+      const value = lookup.get(alias.toLowerCase());
+      if (value === undefined || value === null || value === "") continue;
+      if (field === "support_level") {
+        const parsed = asSupportLevel(value);
+        if (parsed !== null) result.support_level = parsed;
+      } else if (field === "issue_tags") {
+        const parsed = asStringArray(value);
+        if (parsed !== null) result.issue_tags = parsed;
+      } else if (
+        field === "lawn_sign" ||
+        field === "vote_by_mail" ||
+        field === "membership_sold" ||
+        field === "callback_audit"
+      ) {
+        const parsed = asBoolean(value);
+        if (parsed !== null) result[field] = parsed;
+      } else if (field === "volunteer_interest") {
+        if (typeof value === "string" && value.trim().length > 0) {
+          result.volunteer_interest = value.trim();
+        }
+      }
+    }
+  }
+  return result;
+}
+
+export async function syncContactSupportLevelCache(
+  tdb: TenantDb,
+  contactId: number,
+  supportLevel: number | null | undefined,
+): Promise<void> {
+  if (supportLevel === undefined || supportLevel === null) return;
+  await tdb.contact.update({
+    set: { support_level: supportLevel },
+    where: eq(contactTable.id, contactId),
+  });
+}

--- a/app/lib/platform-data.server.ts
+++ b/app/lib/platform-data.server.ts
@@ -165,48 +165,71 @@ export async function resolveDataPlaneAuth(
   return { userId: auth.user.id };
 }
 
-async function getCampaignWorkspaceId(
-  campaignId: string,
-): Promise<string | null> {
-  const rows = await db
-    .select({ workspace: campaignTable.workspace })
-    .from(campaignTable)
-    .where(eq(campaignTable.id, Number(campaignId)))
-    .limit(1);
-  return rows[0]?.workspace ?? null;
-}
+export type PlatformResourceKind =
+  | "campaign"
+  | "contact"
+  | "script"
+  | "survey"
+  | "outreach_attempt";
 
-async function getContactWorkspaceId(
-  contactId: string,
-): Promise<string | null> {
-  const rows = await db
-    .select({ workspace: contactTable.workspace })
-    .from(contactTable)
-    .where(eq(contactTable.id, Number(contactId)))
-    .limit(1);
-  return rows[0]?.workspace ?? null;
-}
+const RESOURCE_NOT_FOUND: Record<PlatformResourceKind, string> = {
+  campaign: "Campaign not found",
+  contact: "Contact not found",
+  script: "Script not found",
+  survey: "Survey not found",
+  outreach_attempt: "Outreach attempt not found",
+};
 
-async function getScriptWorkspaceId(
-  scriptId: string,
+export async function resolveResourceWorkspaceId(
+  kind: PlatformResourceKind,
+  id: string | number,
 ): Promise<string | null> {
-  const rows = await db
-    .select({ workspace: scriptTable.workspace })
-    .from(scriptTable)
-    .where(eq(scriptTable.id, Number(scriptId)))
-    .limit(1);
-  return rows[0]?.workspace ?? null;
-}
-
-async function getSurveyWorkspaceId(
-  surveyId: string,
-): Promise<string | null> {
-  const rows = await db
-    .select({ workspace: surveyTable.workspace })
-    .from(surveyTable)
-    .where(eq(surveyTable.survey_id, surveyId))
-    .limit(1);
-  return rows[0]?.workspace ?? null;
+  switch (kind) {
+    case "campaign": {
+      const rows = await db
+        .select({ workspace: campaignTable.workspace })
+        .from(campaignTable)
+        .where(eq(campaignTable.id, Number(id)))
+        .limit(1);
+      return rows[0]?.workspace ?? null;
+    }
+    case "contact": {
+      const rows = await db
+        .select({ workspace: contactTable.workspace })
+        .from(contactTable)
+        .where(eq(contactTable.id, Number(id)))
+        .limit(1);
+      return rows[0]?.workspace ?? null;
+    }
+    case "script": {
+      const rows = await db
+        .select({ workspace: scriptTable.workspace })
+        .from(scriptTable)
+        .where(eq(scriptTable.id, Number(id)))
+        .limit(1);
+      return rows[0]?.workspace ?? null;
+    }
+    case "survey": {
+      const rows = await db
+        .select({ workspace: surveyTable.workspace })
+        .from(surveyTable)
+        .where(eq(surveyTable.survey_id, String(id)))
+        .limit(1);
+      return rows[0]?.workspace ?? null;
+    }
+    case "outreach_attempt": {
+      const rows = await db
+        .select({ workspace: outreachAttemptTable.workspace })
+        .from(outreachAttemptTable)
+        .where(eq(outreachAttemptTable.id, Number(id)))
+        .limit(1);
+      return rows[0]?.workspace ?? null;
+    }
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
 }
 
 /**
@@ -234,25 +257,48 @@ async function enforceWorkspaceRole(
   }
 }
 
-export async function authForCampaign(
+export async function authForResource(
   request: Request,
-  campaignId: string,
+  kind: PlatformResourceKind,
+  id: string | number,
   minRole?: string,
 ): Promise<(DataPlaneAuthContext & { workspaceId: string }) | Response> {
+  if (kind === "outreach_attempt") {
+    const auth = await requireJsonAuth(request);
+    if (auth instanceof Response) return auth;
+
+    const workspaceId = await resolveResourceWorkspaceId(kind, id);
+    if (!workspaceId) {
+      return jsonError(RESOURCE_NOT_FOUND[kind], 404);
+    }
+
+    try {
+      await requireWorkspaceAccess({
+        user: auth.user,
+        workspaceId,
+        minRole,
+      });
+    } catch {
+      return jsonError("Forbidden", 403);
+    }
+
+    return { userId: auth.user.id, workspaceId };
+  }
+
   const auth = await verifyApiKeyOrSession(request);
   if ("error" in auth) {
     return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getCampaignWorkspaceId(campaignId);
+  }
+
+  const workspaceId = await resolveResourceWorkspaceId(kind, id);
   if (!workspaceId) {
-    return jsonError("Campaign not found", 404);
+    return jsonError(RESOURCE_NOT_FOUND[kind], 404);
   }
 
   if (auth.authType === "api_key") {
     if (auth.workspaceId !== workspaceId) {
-      return jsonError("Campaign not found", 404);
+      return jsonError(RESOURCE_NOT_FOUND[kind], 404);
     }
-    // Workspace-scoped API keys retain full data-plane access; role gating
-    // applies to session (member) auth only. Capability gates are opt-in per route.
     return {
       userId: null,
       workspaceId,
@@ -263,126 +309,6 @@ export async function authForCampaign(
   const denied = await enforceWorkspaceRole(auth.user, workspaceId, minRole);
   if (denied) return denied;
   return { userId: auth.user.id, workspaceId };
-}
-
-export async function authForContact(
-  request: Request,
-  contactId: string,
-  minRole?: string,
-): Promise<(DataPlaneAuthContext & { workspaceId: string }) | Response> {
-  const auth = await verifyApiKeyOrSession(request);
-  if ("error" in auth) {
-    return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getContactWorkspaceId(contactId);
-  if (!workspaceId) {
-    return jsonError("Contact not found", 404);
-  }
-
-  if (auth.authType === "api_key") {
-    if (auth.workspaceId !== workspaceId) {
-      return jsonError("Contact not found", 404);
-    }
-    // Workspace-scoped API keys retain full data-plane access; role gating
-    // applies to session (member) auth only. Capability gates are opt-in per route.
-    return {
-      userId: null,
-      workspaceId,
-      apiKey: { keyId: auth.keyId, scopes: auth.scopes },
-    };
-  }
-
-  const denied = await enforceWorkspaceRole(auth.user, workspaceId, minRole);
-  if (denied) return denied;
-  return { userId: auth.user.id, workspaceId };
-}
-
-export async function authForScript(
-  request: Request,
-  scriptId: string,
-): Promise<(DataPlaneAuthContext & { workspaceId: string }) | Response> {
-  const auth = await verifyApiKeyOrSession(request);
-  if ("error" in auth) {
-    return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getScriptWorkspaceId(scriptId);
-  if (!workspaceId) {
-    return jsonError("Script not found", 404);
-  }
-
-  if (auth.authType === "api_key") {
-    if (auth.workspaceId !== workspaceId) {
-      return jsonError("Script not found", 404);
-    }
-    return {
-      userId: null,
-      workspaceId,
-      apiKey: { keyId: auth.keyId, scopes: auth.scopes },
-    };
-  }
-
-  await requireWorkspaceAccess({
-    user: auth.user,
-    workspaceId,
-  });
-  return { userId: auth.user.id, workspaceId };
-}
-
-export async function authForSurvey(
-  request: Request,
-  surveyId: string,
-): Promise<(DataPlaneAuthContext & { workspaceId: string }) | Response> {
-  const auth = await verifyApiKeyOrSession(request);
-  if ("error" in auth) {
-    return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getSurveyWorkspaceId(surveyId);
-  if (!workspaceId) {
-    return jsonError("Survey not found", 404);
-  }
-
-  if (auth.authType === "api_key") {
-    if (auth.workspaceId !== workspaceId) {
-      return jsonError("Survey not found", 404);
-    }
-    return {
-      userId: null,
-      workspaceId,
-      apiKey: { keyId: auth.keyId, scopes: auth.scopes },
-    };
-  }
-
-  await requireWorkspaceAccess({
-    user: auth.user,
-    workspaceId,
-  });
-  return { userId: auth.user.id, workspaceId };
-}
-
-/** Auth for outreach attempt: session-only, resolves workspace from the attempt row. */
-export async function authForOutreachAttempt(
-  request: Request,
-  outreachAttemptId: number,
-): Promise<{user: { id: string; email?: string }; workspaceId: string } | Response> {
-  const auth = await requireJsonAuth(request);
-  if (auth instanceof Response) return auth;  const rows = await db
-    .select({ workspace: outreachAttemptTable.workspace })
-    .from(outreachAttemptTable)
-    .where(eq(outreachAttemptTable.id, outreachAttemptId))
-    .limit(1);
-  const attempt = rows[0];
-
-  if (!attempt?.workspace) {
-    return jsonError("Outreach attempt not found", 404);
-  }
-
-  try {
-    await requireWorkspaceAccess({
-      user: (auth as any).user,
-      workspaceId: attempt.workspace,
-    });
-  } catch {
-    return jsonError("Forbidden", 403);
-  }
-
-  return { user: (auth as any).user, workspaceId: attempt.workspace };
 }
 
 export async function listWorkspaceCampaignsApi(

--- a/app/lib/transaction-history-display.ts
+++ b/app/lib/transaction-history-display.ts
@@ -7,6 +7,7 @@ export type BillingEventSource =
   | "voice"
   | "number_rental"
   | "purchase"
+  | "ai"
   | "adjustment"
   | "unknown";
 
@@ -24,6 +25,8 @@ function bucketToEventSource(
       return "number_rental";
     case "purchase":
       return "purchase";
+    case "ai":
+      return "ai";
     case "other":
       if (type === "CREDIT") return "purchase";
       if (type === "DEBIT" && !hasKey) return "adjustment";
@@ -50,6 +53,8 @@ export function getBillingEventSourceLabel(source: BillingEventSource): string {
       return "Number rental";
     case "purchase":
       return "Purchase";
+    case "ai":
+      return "Transcription & coaching";
     case "adjustment":
       return "Adjustment";
     default:

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -1,5 +1,6 @@
 import type { Database, Tables } from "@/lib/db-types";
 import type { AccountInstance } from "twilio/lib/rest/api/v2010/account";
+import type { CallCoachingHydration } from "@/hooks/call/useCallCoaching";
 
 export type ENV = {
   BASE_URL: string | undefined;
@@ -655,6 +656,10 @@ export type LoaderData = {
   isActive: boolean;
   hasAccess: boolean;
   verifiedNumbers: string[];
+  featureFlags: Record<string, unknown>;
+  /** Transcript/coaching state for a call already in flight; null when the
+   * workspace has no live-media flags or there is nothing to hydrate. */
+  initialCoaching: CallCoachingHydration | null;
 };
 
 export interface CallAreaProps {

--- a/app/lib/worker/handlers.server.ts
+++ b/app/lib/worker/handlers.server.ts
@@ -5,6 +5,7 @@ import {
   RECORDING_SIDE_EFFECTS_JOB_TYPE,
   SMS_STATUS_SIDE_EFFECTS_JOB_TYPE,
   WEBHOOK_DELIVERY_JOB_TYPE,
+  ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE,
 } from "@/lib/worker/job-types.server";
 import type { JobHandlers } from "@/lib/worker/poll-jobs.server";
 import {
@@ -29,6 +30,7 @@ import {
   WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
   workspaceTwilioComplianceHandler,
 } from "./handlers/campaign.server";
+import { elevenlabsBatchTranscribeHandler } from "./handlers/elevenlabs-batch-transcribe.server";
 
 export { enqueueWorkspaceComplianceJob };
 
@@ -46,4 +48,5 @@ export const jobHandlers: JobHandlers = {
   [CAMPAIGN_EXPORT_JOB_TYPE]: campaignExportHandler,
   [CAMPAIGN_DISPATCH_JOB_TYPE]: campaignDispatchHandler,
   [WEBHOOK_DELIVERY_JOB_TYPE]: webhookDeliveryHandler,
+  [ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE]: elevenlabsBatchTranscribeHandler,
 };

--- a/app/lib/worker/handlers/elevenlabs-batch-transcribe.server.ts
+++ b/app/lib/worker/handlers/elevenlabs-batch-transcribe.server.ts
@@ -1,0 +1,156 @@
+import { eq } from "drizzle-orm";
+import { call as callTable, workspace as workspaceTable } from "@/db/schema";
+import { call_transcript } from "@/db/schema-transcription";
+import { batchTranscriptionKey } from "@/lib/billing-keys";
+import { hasFeatureFlag } from "@/lib/feature-flags";
+import { downloadObject } from "@/lib/object-storage.server";
+import { debitAmountFromCredits } from "@/lib/pricing";
+import { insertTransactionHistoryIdempotent } from "@/lib/transaction-history.server";
+import { logger } from "@/lib/logger.server";
+import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
+import { adminDb } from "@/server/admin-db";
+import { TRANSCRIPTION_BATCH_CREDITS } from "../../../../shared/billing-rates";
+import { requireStringParam } from "./shared.server";
+
+const ELEVENLABS_SCRIBE_MODEL = "scribe_v2";
+
+/**
+ * Batch transcription is gated on the `batchTranscription` workspace flag,
+ * which is default-off everywhere. Product policy for batch (ship or not, bill
+ * per call or bundle it) is UNDECIDED — until it is, nothing is enqueued and
+ * nothing is billed. Both the enqueue site (`runRecordingSideEffects`) and the
+ * debit site below consult this so a stale queued job cannot bill either.
+ */
+export async function isBatchTranscriptionEnabled(
+  workspaceId: string,
+): Promise<boolean> {
+  const row = await adminDb.query.workspace.findFirst({
+    where: eq(workspaceTable.id, workspaceId),
+    columns: { feature_flags: true },
+  });
+  return hasFeatureFlag(
+    row?.feature_flags as Record<string, unknown> | undefined,
+    "batchTranscription",
+  );
+}
+
+type ElevenLabsBatchWord = {
+  text: string;
+  start?: number | null;
+  end?: number | null;
+  type?: string;
+  speaker_id?: string | null;
+  logprob?: number;
+};
+
+type ElevenLabsBatchResponse = {
+  text?: string;
+  language_code?: string;
+  words?: ElevenLabsBatchWord[];
+};
+
+async function transcribeWithElevenLabs(audio: Buffer): Promise<ElevenLabsBatchResponse> {
+  const apiKey = process.env.ELEVENLABS_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("ELEVENLABS_API_KEY is not configured");
+  }
+
+  const formData = new FormData();
+  formData.append("model_id", ELEVENLABS_SCRIBE_MODEL);
+  formData.append("diarize", "true");
+  formData.append("detect_speaker_roles", "true");
+  formData.append(
+    "file",
+    new Blob([Uint8Array.from(audio)], { type: "audio/mpeg" }),
+    "recording.mp3",
+  );
+
+  const response = await fetch("https://api.elevenlabs.io/v1/speech-to-text", {
+    method: "POST",
+    headers: { "xi-api-key": apiKey },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`ElevenLabs transcribe failed (${response.status}): ${detail}`);
+  }
+
+  const body = (await response.json()) as ElevenLabsBatchResponse;
+  if (!body.text?.trim()) {
+    throw new Error("ElevenLabs transcribe returned empty text");
+  }
+  return body;
+}
+
+export async function elevenlabsBatchTranscribeHandler(
+  job: ClaimedJobRow,
+): Promise<unknown> {
+  const params = (job.params ?? {}) as Record<string, unknown>;
+  const callSid = requireStringParam(params, "callSid");
+  if (!callSid) {
+    throw new Error("elevenlabs_batch_transcribe: missing callSid");
+  }
+
+  const callRow = await adminDb.query.call.findFirst({
+    where: eq(callTable.sid, callSid),
+  });
+  if (!callRow?.audio_url || !callRow.workspace) {
+    return { status: "skipped", reason: "no_audio_url" };
+  }
+  if (callRow.transcript_id) {
+    return { status: "skipped", reason: "already_transcribed" };
+  }
+
+  const audio = await downloadObject("workspaceAudio", callRow.audio_url);
+  const result = await transcribeWithElevenLabs(audio);
+  const text = result.text!.trim();
+
+  const [transcript] = await adminDb
+    .insert(call_transcript)
+    .values({
+      call_sid: callSid,
+      provider: "elevenlabs_scribe_v2",
+      language: result.language_code ?? "en",
+      full_text: text,
+      word_count: text.split(/\s+/).filter(Boolean).length,
+      duration_ms: callRow.recording_duration
+        ? Number.parseInt(callRow.recording_duration, 10) * 1000
+        : null,
+      metadata: {
+        elevenlabsModel: ELEVENLABS_SCRIBE_MODEL,
+        wordCount: result.words?.length ?? 0,
+      },
+    })
+    .returning();
+
+  if (!transcript) {
+    throw new Error("Failed to insert call_transcript");
+  }
+
+  await adminDb
+    .update(callTable)
+    .set({ transcript_id: transcript.id })
+    .where(eq(callTable.sid, callSid));
+
+  const billable = await isBatchTranscriptionEnabled(callRow.workspace);
+  if (billable) {
+    await insertTransactionHistoryIdempotent({
+      workspaceId: callRow.workspace,
+      type: "DEBIT",
+      amount: debitAmountFromCredits(TRANSCRIPTION_BATCH_CREDITS),
+      note: `Batch transcription ${callSid}`,
+      idempotencyKey: batchTranscriptionKey(callSid),
+      callSid,
+    });
+  }
+
+  logger.info("elevenlabs_batch_transcribe.completed", {
+    callSid,
+    workspaceId: callRow.workspace,
+    transcriptId: transcript.id,
+    billed: billable,
+  });
+
+  return { status: "completed", transcriptId: transcript.id };
+}

--- a/app/lib/worker/job-types.server.ts
+++ b/app/lib/worker/job-types.server.ts
@@ -15,3 +15,4 @@ export type WebhookSideEffectJobType =
 export const CAMPAIGN_EXPORT_JOB_TYPE = "campaign_export";
 export const CAMPAIGN_DISPATCH_JOB_TYPE = "campaign_dispatch";
 export const WEBHOOK_DELIVERY_JOB_TYPE = "webhook_delivery";
+export const ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE = "elevenlabs_batch_transcribe";

--- a/app/lib/worker/webhook-side-effects.server.ts
+++ b/app/lib/worker/webhook-side-effects.server.ts
@@ -32,6 +32,10 @@ import {
   resolveCallOutreachContext,
   twilioParamsToUnderCase,
 } from "@/lib/twilio-call-status.server";
+import { persistCallRecordingToStorage } from "@/lib/call-recording-storage.server";
+import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE } from "@/lib/worker/job-types.server";
+import { isBatchTranscriptionEnabled } from "@/lib/worker/handlers/elevenlabs-batch-transcribe.server";
 
 export async function runCallStatusSideEffects(args: {
   callSid: string;
@@ -205,6 +209,7 @@ export async function runRecordingSideEffects(args: {
 
   const recordingSid = args.twilioParams.RecordingSid?.trim();
   const recordingDuration = args.twilioParams.RecordingDuration?.trim();
+  const accountSid = args.twilioParams.AccountSid?.trim();
 
   const enrichment: Record<string, string> = {};
   if (recordingSid) {
@@ -214,6 +219,51 @@ export async function runRecordingSideEffects(args: {
     enrichment.recording_duration = recordingDuration;
   }
 
+  if (recordingSid && accountSid) {
+    const persistResult = await persistCallRecordingToStorage({
+      workspaceId: callRow.workspace,
+      callSid: args.callSid,
+      accountSid,
+      recordingSid,
+      existingAudioUrl: callRow.audio_url,
+    });
+
+    if (persistResult.ok && !persistResult.skipped) {
+      enrichment.audio_url = persistResult.audioUrl;
+      // Batch transcription is default-off pending an undecided product policy
+      // (see `batchTranscription` in @/lib/coaching-schemas). Suppress the
+      // enqueue entirely rather than queueing work nothing will bill for.
+      if (await isBatchTranscriptionEnabled(callRow.workspace)) {
+        try {
+          await enqueueJob({
+            type: ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE,
+            workspaceId: callRow.workspace,
+            params: { callSid: args.callSid },
+            dedupe: { kind: "idempotency", key: `elevenlabs_batch:${args.callSid}` },
+          });
+        } catch (error) {
+          logger.warn("elevenlabs_batch_transcribe.enqueue_failed", {
+            callSid: args.callSid,
+            workspaceId: callRow.workspace,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    } else if (!persistResult.ok) {
+      logger.warn("call_recording.persist_skipped", {
+        callSid: args.callSid,
+        workspaceId: callRow.workspace,
+        reason: persistResult.reason,
+        error: persistResult.error,
+      });
+    }
+  } else if (recordingSid && !accountSid) {
+    logger.warn("call_recording.missing_account_sid", {
+      callSid: args.callSid,
+      workspaceId: callRow.workspace,
+    });
+  }
+
   if (Object.keys(enrichment).length > 0) {
     await updateCallBySid(callRow.workspace, args.callSid, enrichment);
   }
@@ -221,6 +271,7 @@ export async function runRecordingSideEffects(args: {
   logger.debug("Recording side effects completed", {
     callSid: args.callSid,
     workspaceId: callRow.workspace,
+    audioUrlPersisted: Boolean(enrichment.audio_url),
   });
 
   return { ok: true };

--- a/app/lib/workspace-events.shared.ts
+++ b/app/lib/workspace-events.shared.ts
@@ -65,3 +65,15 @@ export function matchesPostgresChangeFilter(
   if (!row) return false;
   return String(row[column] ?? "") === expected;
 }
+
+/**
+ * SSE event name for a stream terminated because the subscriber's workspace
+ * access was revoked mid-stream.
+ *
+ * Lives here so the producing loader and the consuming hooks share one literal,
+ * and so client code can reference it without importing a `.server` module.
+ * Clients must `close()` on this: EventSource auto-reconnects after a
+ * server-side close, and each retry would be rejected by the data-plane
+ * middleware, leaving the tab in a retry loop.
+ */
+export const ACCESS_REVOKED_EVENT = "access_revoked";

--- a/app/lib/workspace-events.shared.ts
+++ b/app/lib/workspace-events.shared.ts
@@ -1,4 +1,5 @@
 /** Client-safe workspace event types for SSE consumers. */
+import { z } from "zod";
 
 export type PostgresChangePayload = {
   eventType: "INSERT" | "UPDATE" | "DELETE" | string;
@@ -8,13 +9,15 @@ export type PostgresChangePayload = {
   old: Record<string, unknown> | null;
 };
 
-export type WorkspaceEventRecord = {
-  id: number;
-  workspace_id: string;
-  event_type: string;
-  payload: Record<string, unknown>;
-  created_at: string;
-};
+export const WorkspaceEventRecord = z.object({
+  id: z.number(),
+  workspace_id: z.string(),
+  event_type: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+});
+
+export type WorkspaceEventRecord = z.infer<typeof WorkspaceEventRecord>;
 
 export type RealtimeChangePayload<T extends Record<string, unknown> = Record<string, unknown>> =
   PostgresChangePayload & {
@@ -22,8 +25,25 @@ export type RealtimeChangePayload<T extends Record<string, unknown> = Record<str
     old: T | null;
   };
 
+/**
+ * Parse an SSE `data:` frame. Throws on malformed JSON *or* a frame that is not
+ * a workspace-event envelope; existing callers already wrap this in try/catch.
+ * Prefer {@link safeParseWorkspaceEventData} in handlers that must never throw.
+ */
 export function parseWorkspaceEventData(raw: string): WorkspaceEventRecord {
-  return JSON.parse(raw) as WorkspaceEventRecord;
+  return WorkspaceEventRecord.parse(JSON.parse(raw));
+}
+
+/** Non-throwing variant: returns `null` for anything that is not a valid envelope. */
+export function safeParseWorkspaceEventData(raw: string): WorkspaceEventRecord | null {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const result = WorkspaceEventRecord.safeParse(decoded);
+  return result.success ? result.data : null;
 }
 
 export function matchesPostgresChangeFilter(

--- a/app/routes/api+/auto-dial/$roomId.action.server.ts
+++ b/app/routes/api+/auto-dial/$roomId.action.server.ts
@@ -16,7 +16,9 @@ import {
 } from "@/lib/telephony-db.server";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { hangupTwiml, pausePlayTwiml } from "@/lib/twilio-twiml.server";
+import { appendLiveTranscriptionStreamTwiml } from "@/lib/media-stream-twiml.server";
 import { createSignedObjectUrl } from "@/lib/object-storage.server";
+import { getWorkspaceById } from "@/lib/workspace-members-db.server";
 import { defineAction } from "@/lib/handler.server";
 import Twilio from "twilio";
 
@@ -186,6 +188,18 @@ const handleDeviceCheck = async (dbCall: NonNullable<Partial<Call>>) => {
 
 async function addToConference(conferenceId: string, campaignId: string, workspaceId: string, userId: string) {
     const twiml = new Twilio.twiml.VoiceResponse();
+    const workspace = await getWorkspaceById(workspaceId);
+    appendLiveTranscriptionStreamTwiml({
+        twiml,
+        featureFlags: workspace?.feature_flags as Record<string, unknown> | undefined,
+        params: {
+            workspaceId,
+            userId,
+            direction: "predictive",
+            campaignId,
+            streamName: `conf-${conferenceId}`,
+        },
+    });
     const dial = twiml.dial();
     dial.conference({
         beep: 'false',

--- a/app/routes/api+/call.action.server.ts
+++ b/app/routes/api+/call.action.server.ts
@@ -1,10 +1,12 @@
 import { env } from "@/lib/env.server";
 import { getHandsetNumberForWorkspace } from "@/lib/database/workspace.server";
 import { findActiveHandsetSession } from "@/lib/handset/handset-session.server";
+import { appendLiveTranscriptionStreamTwiml } from "@/lib/media-stream-twiml.server";
 import { isPhoneNumber, normalizePhoneNumber } from "@/lib/utils";
 import { logger } from "@/lib/logger.server";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { insertCallForWorkspace } from "@/lib/telephony-db.server";
+import { getWorkspaceById } from "@/lib/workspace-members-db.server";
 import { defineAction } from "@/lib/handler.server";
 import Twilio from "twilio";
 import type { ActionFunctionArgs } from "react-router";
@@ -81,6 +83,19 @@ export const action = defineAction({
         is_last: false,
       });
     }
+
+    const workspace = await getWorkspaceById(workspaceId);
+    appendLiveTranscriptionStreamTwiml({
+      twiml,
+      featureFlags: workspace?.feature_flags as Record<string, unknown> | undefined,
+      params: {
+        workspaceId,
+        userId: session.user_id,
+        direction: "outbound",
+        callSid: callSid || null,
+        streamName: callSid ? `call-${callSid}` : undefined,
+      },
+    });
 
     const dial = twiml.dial({
       callerId,

--- a/app/routes/api+/campaigns/$campaignId.action.server.ts
+++ b/app/routes/api+/campaigns/$campaignId.action.server.ts
@@ -2,7 +2,7 @@ import { parseJsonBodyOrResponse } from "@/lib/api-parse.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { defineAction, defineLoader } from "@/lib/handler.server";
 import {
-  authForCampaign,
+  authForResource,
   duplicateCampaignApi,
   getCampaignDetailApi,
   transitionCampaignStatusApi,
@@ -17,7 +17,7 @@ export const loader = defineLoader({
       return jsonError("campaignId is required", 400);
     }
 
-    const auth = await authForCampaign(request, campaignId);
+    const auth = await authForResource(request, "campaign", campaignId);
     if (auth instanceof Response) return auth;
 
     return { ...auth, campaignId };
@@ -45,7 +45,7 @@ export const action = defineAction({
 
     // Both branches below (duplicate, status transition) are destructive
     // mutations: require at least `member`, blocking the `caller` role.
-    const auth = await authForCampaign(request, campaignId, "member");
+    const auth = await authForResource(request, "campaign", campaignId, "member");
     if (auth instanceof Response) return auth;
 
     return { ...auth, campaignId };

--- a/app/routes/api+/campaigns/$campaignId/queue.action.server.ts
+++ b/app/routes/api+/campaigns/$campaignId/queue.action.server.ts
@@ -6,7 +6,7 @@ import {
   mapCampaignQueueItemForUi,
 } from "@/lib/campaign-queue-search.server";
 import {
-  authForCampaign,
+  authForResource,
   getCampaignQueueApi,
   patchCampaignQueueApi,
 } from "@/lib/platform-data.server";
@@ -20,7 +20,7 @@ export const loader = defineLoader({
       return jsonError("campaignId is required", 400);
     }
 
-    const auth = await authForCampaign(request, campaignId);
+    const auth = await authForResource(request, "campaign", campaignId);
     if (auth instanceof Response) return auth;
 
     return { ...auth, campaignId };
@@ -78,7 +78,7 @@ export const action = defineAction({
     }
 
     // Destructive mutation: require at least `member`, blocking the `caller` role.
-    const auth = await authForCampaign(request, campaignId, "member");
+    const auth = await authForResource(request, "campaign", campaignId, "member");
     if (auth instanceof Response) return auth;
 
     return { ...auth, campaignId };

--- a/app/routes/api+/coaching-ack.action.server.ts
+++ b/app/routes/api+/coaching-ack.action.server.ts
@@ -1,0 +1,31 @@
+import { data as routeData } from "react-router";
+import { acknowledgeCoachingCue } from "@/lib/call-coaching-ack.server";
+import { requireJsonAuth } from "@/lib/api-auth.server";
+import { defineAction } from "@/lib/handler.server";
+import { safeParseJson } from "@/lib/request-utils.server";
+
+type CoachingAckBody = {
+  coachingEventId?: string;
+  workspaceId?: string;
+};
+
+export const action = defineAction({
+  auth: ({ request }) => requireJsonAuth(request),
+  sideEffects: ["db-write"],
+  handler: async ({ request, auth }) => {
+    const body = await safeParseJson<CoachingAckBody>(request);
+
+    // Data access lives in the lib module: routes may not touch `adminDb`, and
+    // the transcription tables have no workspace column to scope on (ADR-0004).
+    const result = await acknowledgeCoachingCue({
+      user: { id: auth.user.id },
+      workspaceId: body.workspaceId?.trim(),
+      coachingEventId: body.coachingEventId?.trim(),
+    });
+
+    if (!result.ok) {
+      return routeData({ error: result.error }, { status: result.status });
+    }
+    return routeData({ ok: true });
+  },
+});

--- a/app/routes/api+/coaching-ack.tsx
+++ b/app/routes/api+/coaching-ack.tsx
@@ -1,0 +1,1 @@
+export { action } from "./coaching-ack.action.server";

--- a/app/routes/api+/contacts/$contactId.action.server.ts
+++ b/app/routes/api+/contacts/$contactId.action.server.ts
@@ -1,7 +1,7 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { defineAction, defineLoader } from "@/lib/handler.server";
 import {
-  authForContact,
+  authForResource,
   deleteContactApi,
   getContactDetailApi,
 } from "@/lib/platform-data.server";
@@ -14,7 +14,7 @@ export const loader = defineLoader({
       return jsonError("contactId is required", 400);
     }
 
-    const auth = await authForContact(request, contactId);
+    const auth = await authForResource(request, "contact", contactId);
     if (auth instanceof Response) return auth;
 
     return { ...auth, contactId };
@@ -45,7 +45,7 @@ export const action = defineAction({
     }
 
     // Destructive mutation: require at least `member`, blocking the `caller` role.
-    const auth = await authForContact(request, contactId, "member");
+    const auth = await authForResource(request, "contact", contactId, "member");
     if (auth instanceof Response) return auth;
 
     return { ...auth, contactId };

--- a/app/routes/api+/dial/$number.action.server.ts
+++ b/app/routes/api+/dial/$number.action.server.ts
@@ -1,6 +1,9 @@
 import { env } from "@/lib/env.server";
 import { logger } from "@/lib/logger.server";
+import { appendLiveTranscriptionStreamTwiml } from "@/lib/media-stream-twiml.server";
+import { findCallBySid } from "@/lib/telephony-db.server";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
+import { getWorkspaceById } from "@/lib/workspace-members-db.server";
 import { defineAction } from "@/lib/handler.server";
 import Twilio from 'twilio';
 
@@ -29,6 +32,28 @@ export const action = defineAction({
             const formData = await request.clone().formData();
             const twiml = new Twilio.twiml.VoiceResponse();
             const number = params.number;
+            const callSid = String(formData.get("CallSid") ?? "");
+
+            if (callSid) {
+                const call = await findCallBySid(callSid);
+                const workspaceId = call?.workspace;
+                if (call && workspaceId && call.user_id) {
+                    const workspace = await getWorkspaceById(workspaceId);
+                    appendLiveTranscriptionStreamTwiml({
+                        twiml,
+                        featureFlags: workspace?.feature_flags as Record<string, unknown> | undefined,
+                        params: {
+                            workspaceId,
+                            userId: call.user_id,
+                            direction: "outbound",
+                            contactId: call.contact_id,
+                            campaignId: call.campaign_id,
+                            callSid,
+                            streamName: `call-${callSid}`,
+                        },
+                    });
+                }
+            }
 
             const dial = twiml.dial({
                 callerId: formData.get('From') as string,

--- a/app/routes/api+/inbound.action.server.ts
+++ b/app/routes/api+/inbound.action.server.ts
@@ -18,8 +18,9 @@ import {
   upsertInboundCallRecord,
   workspaceWebhookHasInboundCallInsert,
 } from "@/lib/inbound-call-db.server";
-import { findActiveHandsetSessionClientIdentity } from "@/lib/handset/handset-session.server";
-import { getWorkspaceWebhookRow } from "@/lib/workspace-members-db.server";
+import { findActiveHandsetSession, findActiveHandsetSessionClientIdentity } from "@/lib/handset/handset-session.server";
+import { appendLiveTranscriptionStreamTwiml } from "@/lib/media-stream-twiml.server";
+import { getWorkspaceById, getWorkspaceWebhookRow } from "@/lib/workspace-members-db.server";
 import Twilio from "twilio";
 import { inboundRingCountToDialTimeoutSeconds } from "../../../shared/inbound-rings";
 import { defineAction } from "@/lib/handler.server";
@@ -256,6 +257,19 @@ async function handleInboundAction(
       });
       const baseUrl = env.BASE_URL();
       const handsetTwiml = new Twilio.twiml.VoiceResponse();
+      const session = await findActiveHandsetSession({ workspaceId, clientIdentity });
+      const workspace = await getWorkspaceById(workspaceId);
+      appendLiveTranscriptionStreamTwiml({
+        twiml: handsetTwiml,
+        featureFlags: workspace?.feature_flags as Record<string, unknown> | undefined,
+        params: {
+          workspaceId,
+          userId: session?.user_id ?? "",
+          direction: "inbound",
+          callSid: data.CallSid,
+          streamName: `inbound-${data.CallSid}`,
+        },
+      });
       const dial = handsetTwiml.dial({
         timeout: dialTimeout,
         action: `${baseUrl}/api/inbound-handset-dial-end`,

--- a/app/routes/api+/ivr/$campaignId/$pageId/$blockId/response.action.server.ts
+++ b/app/routes/api+/ivr/$campaignId/$pageId/$blockId/response.action.server.ts
@@ -9,7 +9,14 @@ import { logger } from "@/lib/logger.server";
 import { hangupTwiml } from "@/lib/twilio-twiml.server";
 import { requireTwilioSignatureForIvrResponse } from "@/lib/ivr-webhook-auth.server";
 import { defineAction } from "@/lib/handler.server";
+import {
+  extractTypedOutreachFields,
+  syncContactSupportLevelCache,
+} from "@/lib/outreach-typed-fields.server";
+import { createTenantDb } from "@/server/tenant-db";
 import Twilio from "twilio";
+
+import type { Json } from "@/lib/db-types";
 const getOutreach = async (workspaceId: string, outreachId: number) => {
   const row = await findOutreachAttemptById(workspaceId, outreachId);
   if (!row) throw new Error("Outreach attempt not found");
@@ -176,13 +183,20 @@ export const action = defineAction({
     if (!call.outreach_attempt_id) {
       throw new Error("Missing outreach attempt for IVR response");
     }
+    const typedFields = extractTypedOutreachFields(newResult as Json);
+    const tdb = createTenantDb(call.workspace);
     const outreachUpdate = await updateOutreachAttemptForWorkspace(
       call.workspace,
       call.outreach_attempt_id,
-      { result: newResult },
+      { result: newResult, ...typedFields },
+      { tdb },
     );
     if (outreachUpdate instanceof Response) {
       throw new Error(await outreachUpdate.text());
+    }
+
+    if (call.contact_id != null && typedFields.support_level != null) {
+      await syncContactSupportLevelCache(tdb, call.contact_id, typedFields.support_level);
     }
 
     const nextStep = findNextStep(currentBlock, userInput, script, pageId);

--- a/app/routes/api+/outreach_attempts/$id.action.server.ts
+++ b/app/routes/api+/outreach_attempts/$id.action.server.ts
@@ -1,4 +1,4 @@
-import { authForOutreachAttempt } from "@/lib/platform-data.server";
+import { authForResource } from "@/lib/platform-data.server";
 import { data as routeData } from "react-router";
 import { getSession } from "@/lib/auth.server";
 import { defineAction } from "@/lib/handler.server";
@@ -17,7 +17,7 @@ export const action = defineAction({
     if (!params.id) return badRequest("id is required");
     const outreachAttemptId = Number(params.id);
     if (!Number.isFinite(outreachAttemptId)) return badRequest("id must be a number");
-    return authForOutreachAttempt(request, outreachAttemptId);
+    return authForResource(request, "outreach_attempt", outreachAttemptId);
   },
   sideEffects: ["db-write"],
   handler: async ({ request, params, auth }) => {

--- a/app/routes/api+/questions.action.server.ts
+++ b/app/routes/api+/questions.action.server.ts
@@ -9,6 +9,10 @@ import { rpcCreateOutreachAttempt } from "@/lib/db-rpc.server";
 import { createTenantDb } from "@/server/tenant-db";
 import { outreach_attempt as outreachAttemptTable } from "@/db/schema";
 import { and, eq, gte, desc } from "drizzle-orm";
+import {
+  extractTypedOutreachFields,
+  syncContactSupportLevelCache,
+} from "@/lib/outreach-typed-fields.server";
 
 import type { Json } from "@/lib/db-types";
 import type { ActionFunctionArgs } from "react-router";
@@ -20,138 +24,6 @@ interface RequestData {
   workspace: string;
   disposition: string;
   queue_id: number;
-}
-
-type TypedOutreachFields = {
-  support_level?: number | null;
-  volunteer_interest?: string | null;
-  lawn_sign?: boolean | null;
-  vote_by_mail?: boolean | null;
-  issue_tags?: string[] | null;
-  membership_sold?: boolean | null;
-  callback_audit?: boolean | null;
-};
-
-const TYPED_FIELD_ALIASES: Record<keyof TypedOutreachFields, string[]> = {
-  support_level: ["support_level", "supportlevel", "support level", "support"],
-  volunteer_interest: [
-    "volunteer_interest",
-    "volunteerinterest",
-    "volunteer interest",
-    "volunteer",
-  ],
-  lawn_sign: ["lawn_sign", "lawnsign", "lawn sign", "lawnsigns"],
-  vote_by_mail: ["vote_by_mail", "votebymail", "vote by mail", "absentee"],
-  issue_tags: ["issue_tags", "issuetags", "issue tags", "issues"],
-  membership_sold: [
-    "membership_sold",
-    "membershipsold",
-    "membership sold",
-    "membership",
-  ],
-  callback_audit: [
-    "callback_audit",
-    "callbackaudit",
-    "callback audit",
-    "callback",
-  ],
-};
-
-function asBoolean(value: unknown): boolean | null {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "number") return value !== 0;
-  if (typeof value === "string") {
-    const v = value.trim().toLowerCase();
-    if (["true", "yes", "y", "1"].includes(v)) return true;
-    if (["false", "no", "n", "0"].includes(v)) return false;
-  }
-  return null;
-}
-
-function asSupportLevel(value: unknown): number | null {
-  if (typeof value === "number") {
-    return value >= 1 && value <= 5 ? value : null;
-  }
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    const parsed = Number(trimmed);
-    if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 5) return parsed;
-    const lower = trimmed.toLowerCase();
-    const labelMap: Record<string, number> = {
-      "strong support": 1,
-      "lean support": 2,
-      undecided: 3,
-      "lean opposition": 4,
-      "strong opposition": 5,
-    };
-    if (labelMap[lower] !== undefined) return labelMap[lower];
-  }
-  return null;
-}
-
-function asStringArray(value: unknown): string[] | null {
-  if (Array.isArray(value)) {
-    const tags = value
-      .map((v) => (typeof v === "string" ? v.trim() : String(v).trim()))
-      .filter((v) => v.length > 0);
-    return tags.length > 0 ? tags : null;
-  }
-  if (typeof value === "string") {
-    const tags = value
-      .split(/[,;]\s*|\s*\|\s*/)
-      .map((v) => v.trim())
-      .filter((v) => v.length > 0);
-    return tags.length > 0 ? tags : null;
-  }
-  return null;
-}
-
-export function extractTypedOutreachFields(update: Json | undefined): TypedOutreachFields {
-  if (!update || typeof update !== "object" || Array.isArray(update)) {
-    return {};
-  }
-  const root = update as Record<string, unknown>;
-  const lookup = new Map<string, unknown>();
-  const flatten = (obj: Record<string, unknown>, prefix = "") => {
-    for (const [key, value] of Object.entries(obj)) {
-      const lowerKey = `${prefix}${key}`.toLowerCase();
-      lookup.set(lowerKey, value);
-      if (value && typeof value === "object" && !Array.isArray(value)) {
-        flatten(value as Record<string, unknown>, `${prefix}${key}.`);
-      }
-    }
-  };
-  flatten(root);
-
-  const result: TypedOutreachFields = {};
-  for (const [field, aliases] of Object.entries(TYPED_FIELD_ALIASES) as Array<
-    [keyof TypedOutreachFields, string[]]
-  >) {
-    for (const alias of aliases) {
-      const value = lookup.get(alias.toLowerCase());
-      if (value === undefined || value === null || value === "") continue;
-      if (field === "support_level") {
-        const parsed = asSupportLevel(value);
-        if (parsed !== null) result.support_level = parsed;
-      } else if (field === "issue_tags") {
-        const parsed = asStringArray(value);
-        if (parsed !== null) result.issue_tags = parsed;
-      } else if (
-        field === "lawn_sign" ||
-        field === "vote_by_mail" ||
-        field === "membership_sold" ||
-        field === "callback_audit"
-      ) {
-        const parsed = asBoolean(value);
-        if (parsed !== null) result[field] = parsed;
-      } else if (field === "volunteer_interest") {
-        if (typeof value === "string" && value.trim().length > 0) {
-          result.volunteer_interest = value.trim();
-        }
-      }
-    }
-  }
-  return result;
 }
 
 export const action = defineAction({
@@ -214,6 +86,8 @@ export const action = defineAction({
       },
       where: eq(outreachAttemptTable.id, outreachAttemptId),
     });
+
+    await syncContactSupportLevelCache(tdb, contact_id, typedFields.support_level);
 
     return routeData(finalUpdated, { headers });
   },

--- a/app/routes/api+/scripts/$scriptId.loader.server.ts
+++ b/app/routes/api+/scripts/$scriptId.loader.server.ts
@@ -1,5 +1,5 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
-import { authForScript, getScriptDetailApi } from "@/lib/platform-data.server";
+import { authForResource, getScriptDetailApi } from "@/lib/platform-data.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
@@ -10,7 +10,7 @@ export const loader = defineLoader({
       return jsonError("scriptId is required", 400);
     }
 
-    const auth = await authForScript(request, scriptId);
+    const auth = await authForResource(request, "script", scriptId);
     if (auth instanceof Response) return auth;
 
     return { ...auth, scriptId };

--- a/app/routes/api+/surveys/$surveyId.loader.server.ts
+++ b/app/routes/api+/surveys/$surveyId.loader.server.ts
@@ -1,5 +1,5 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
-import { authForSurvey, getSurveyDetailApi } from "@/lib/platform-data.server";
+import { authForResource, getSurveyDetailApi } from "@/lib/platform-data.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
@@ -10,7 +10,7 @@ export const loader = defineLoader({
       return jsonError("surveyId is required", 400);
     }
 
-    const auth = await authForSurvey(request, surveyId);
+    const auth = await authForResource(request, "survey", surveyId);
     if (auth instanceof Response) return auth;
 
     return { ...auth, surveyId };

--- a/app/routes/api+/surveys/$surveyId/responses.loader.server.ts
+++ b/app/routes/api+/surveys/$surveyId/responses.loader.server.ts
@@ -1,6 +1,6 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
-  authForSurvey,
+  authForResource,
   exportSurveyResponsesCsv,
   getSurveyResponsesApi,
 } from "@/lib/platform-data.server";
@@ -14,7 +14,7 @@ export const loader = defineLoader({
       return jsonError("surveyId is required", 400);
     }
 
-    const auth = await authForSurvey(request, surveyId);
+    const auth = await authForResource(request, "survey", surveyId);
     if (auth instanceof Response) return auth;
 
     return { ...auth, surveyId };

--- a/app/routes/api+/workspaces+/$workspaceId/events.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/events.loader.server.ts
@@ -1,6 +1,9 @@
 import type { LoaderFunctionArgs } from "react-router";
 import { getSession } from "@/lib/auth.server";
 import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { logger } from "@/lib/logger.server";
+import { ACCESS_REVOKED_EVENT } from "@/lib/workspace-events.shared";
+import { getUserRole } from "@/lib/workspace-membership.server";
 import {
   WORKSPACE_EVENTS_NOTIFY_CHANNEL,
   fetchWorkspaceEventsAfter,
@@ -11,6 +14,9 @@ import { directPool } from "@/server/db";
 
 const POLL_INTERVAL_MS = 2_000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
+
+/** Terminal frame telling the client its workspace access is gone. */
+const ACCESS_REVOKED_FRAME = `event: ${ACCESS_REVOKED_EVENT}\ndata: {"reason":"workspace_access_revoked"}\n\n`;
 
 function parseCursor(request: Request): number {
   const header = request.headers.get("Last-Event-ID");
@@ -42,8 +48,32 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
     return new Response("workspaceId is required", { status: 400 });
   }
 
-  getDataPlaneRouteContext(context, workspaceId);
+  const auth = getDataPlaneRouteContext(context, workspaceId);
   const { headers } = await getSession(request);
+
+  // Membership is verified once, by `dataPlaneMiddleware`, before this loader
+  // runs. This stream then outlives that check by design — it is held open
+  // indefinitely — so without re-checking, a member removed from the workspace
+  // keeps receiving events (including verbatim call transcripts) on an
+  // already-open connection. Re-check rides the heartbeat, so revocation takes
+  // effect within one HEARTBEAT_INTERVAL_MS rather than instantly.
+  const stillHasWorkspaceAccess = async (): Promise<boolean> => {
+    // API-key connections are pinned to one workspace when the key is issued
+    // and carry no membership to revoke; key revocation is a separate concern.
+    if (!auth.userId) return true;
+    try {
+      return (await getUserRole({ user: { id: auth.userId }, workspaceId })) != null;
+    } catch (error) {
+      // A failed lookup is not evidence of revocation, and connect-time auth
+      // already passed. Dropping every open stream on a database blip would be
+      // a self-inflicted outage; the next tick re-checks.
+      logger.warn("Workspace SSE access re-check failed; keeping stream open", {
+        workspaceId,
+        error,
+      });
+      return true;
+    }
+  };
 
   const initialCursor = parseCursor(request);
 
@@ -92,9 +122,17 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
       }, POLL_INTERVAL_MS);
 
       const heartbeatTimer = setInterval(() => {
-        if (!closed) {
+        void (async () => {
+          if (closed) return;
+          if (!(await stillHasWorkspaceAccess())) {
+            if (closed) return;
+            controller.enqueue(encoder.encode(ACCESS_REVOKED_FRAME));
+            closeStream();
+            return;
+          }
+          if (closed) return;
           controller.enqueue(encoder.encode(": heartbeat\n\n"));
-        }
+        })();
       }, HEARTBEAT_INTERVAL_MS);
 
       request.signal.addEventListener("abort", closeStream);

--- a/app/routes/workspaces+/$id.loader.server.ts
+++ b/app/routes/workspaces+/$id.loader.server.ts
@@ -8,6 +8,7 @@ import {
   getWorkspaceInfoWithDetails,
   getWorkspacePhoneNumbers,
 } from "@/lib/database/workspace.server";
+import { fetchWorkspaceCampaignQueueProgressMap } from "@/lib/campaign-queue-search.server";
 import { getWorkspaceRecentOutboundMessageCount } from "@/lib/database/workspace-twilio-portal-snapshot.server";
 import { workspaceContext } from "@/lib/route-context.server";
 import { defineLoader } from "@/lib/handler.server";
@@ -17,6 +18,7 @@ type LoaderData = {
   userRole: string | null | undefined;
   workspaceData: WorkspaceInfoWithDetails;
   onboardingReadiness: WorkspaceMessagingReadiness;
+  campaignQueueProgress: Record<string, { completedCount: number; totalCount: number }>;
 };
 
 export const loader = defineLoader({
@@ -33,12 +35,13 @@ export const loader = defineLoader({
 
     try {
       const pathname = url.pathname;
-      const [onboarding, phoneNumbersResult, recentOutboundCount, workspaceData] =
+      const [onboarding, phoneNumbersResult, recentOutboundCount, workspaceData, campaignQueueProgressMap] =
         await Promise.all([
           getWorkspaceMessagingOnboardingState({ workspaceId }),
           getWorkspacePhoneNumbers({ workspaceId }),
           getWorkspaceRecentOutboundMessageCount({ workspaceId }),
           getWorkspaceInfoWithDetails({ workspaceId, userId }),
+          fetchWorkspaceCampaignQueueProgressMap(workspaceId),
         ]);
       const readiness = deriveWorkspaceMessagingReadiness({
         onboarding,
@@ -61,6 +64,12 @@ export const loader = defineLoader({
         userRole,
         workspaceData,
         onboardingReadiness: readiness,
+        campaignQueueProgress: Object.fromEntries(
+          [...campaignQueueProgressMap.entries()].map(([campaignId, counts]) => [
+            String(campaignId),
+            counts,
+          ]),
+        ),
       } satisfies LoaderData, { headers });
     } catch (error) {
       if (

--- a/app/routes/workspaces+/$id.tsx
+++ b/app/routes/workspaces+/$id.tsx
@@ -14,6 +14,7 @@ import { MemberRole } from "@/components/workspace/TeamMember";
 import { Button } from "@/components/ui/button";
 import { useWorkspaceEventSubscription } from "@/hooks/realtime/useWorkspaceEventSubscription";
 import CampaignEmptyState from "@/components/campaign/CampaignEmptyState";
+import type { CampaignQueueProgressCounts } from "@/components/campaign/CampaignQueueProgress";
 import {
   Campaign,
   ContextType,
@@ -26,6 +27,7 @@ type LoaderData = {
   userRole: string | null | undefined;
   workspaceData: WorkspaceInfoWithDetails;
   onboardingReadiness: WorkspaceMessagingReadiness;
+  campaignQueueProgress: Record<string, CampaignQueueProgressCounts>;
 };
 
 function WorkspaceResolvedView({
@@ -34,12 +36,14 @@ function WorkspaceResolvedView({
   outlet,
   context,
   onboardingReadiness,
+  campaignQueueProgress,
 }: {
   resolvedData: WorkspaceInfoWithDetails;
   userRole: string | null | undefined;
   outlet: ReturnType<typeof useOutlet>;
   context: ContextType;
   onboardingReadiness: WorkspaceMessagingReadiness;
+  campaignQueueProgress: Record<string, CampaignQueueProgressCounts>;
 }) {
   const normalizedWorkspace = resolvedData.workspace as unknown as {
     id: string;
@@ -70,7 +74,7 @@ function WorkspaceResolvedView({
 
   useWorkspaceEventSubscription({
     workspaceId: workspace.id,
-    table: "campaign",
+    table: ["campaign", "campaign_queue"],
     onChange: () => revalidator.revalidate(),
   });
 
@@ -82,6 +86,7 @@ function WorkspaceResolvedView({
       <WorkspaceNav
         workspace={workspace}
         campaigns={campaigns as Campaign[]}
+        campaignQueueProgress={campaignQueueProgress}
         userRole={
           (userRole as MemberRole | null | undefined) ?? MemberRole.Member
         }
@@ -160,7 +165,7 @@ function WorkspaceResolvedView({
 }
 
 export default function Workspace() {
-  const { workspaceData, userRole, onboardingReadiness } =
+  const { workspaceData, userRole, onboardingReadiness, campaignQueueProgress } =
     useLoaderData<LoaderData>();
   const outlet = useOutlet();
   const context = useOutletContext<ContextType>();
@@ -173,6 +178,7 @@ export default function Workspace() {
         outlet={outlet}
         context={context}
         onboardingReadiness={onboardingReadiness}
+        campaignQueueProgress={campaignQueueProgress}
       />
     </main>
   );

--- a/app/routes/workspaces+/$id/campaigns/$campaign_id/call.loader.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$campaign_id/call.loader.server.ts
@@ -14,6 +14,8 @@ import {
 import { redirect } from "react-router";
 import { MemberRole } from "@/lib/member-role";
 import { defineLoader } from "@/lib/handler.server";
+import { getCallCoachingHydration } from "@/lib/call-coaching-hydration.server";
+import { liveMediaCapabilities } from "@/lib/live-media-capabilities";
 
 export const loader = defineLoader({
   auth: workspaceRouteAuth,
@@ -58,6 +60,22 @@ export const loader = defineLoader({
     const initialRecentAttempt = getInitialRecentAttempt(attempts || [], nextRecipient);
     const hasAccess = [MemberRole.Owner, MemberRole.Admin].includes(userRole as MemberRole);
     const isActive = campaign ? checkSchedule(campaign) : false;
+    // `useCallScreen` derives its live callSid as
+    // `getCallSid(activeCall) ?? recentCall?.sid`, and on a reload there is no
+    // activeCall yet — so the recent call is exactly the sid whose transcript
+    // the panels are about to ask for. Hydrating any other call would be waste.
+    //
+    // Gated on the same capabilities as the panels: when neither the transcript
+    // nor the coaching UI renders, the hook opens no EventSource and nothing
+    // consumes a seed, so the four hydration queries would be pure waste on
+    // every call-screen load for every workspace without the flags.
+    const { showTranscript, showCoaching } = liveMediaCapabilities(
+      workspaceData.feature_flags as Record<string, unknown> | undefined,
+    );
+    const initialCoaching =
+      showTranscript || showCoaching
+        ? await getCallCoachingHydration(workspaceId, initialRecentCall?.sid)
+        : null;
 
     return {
       campaign,
@@ -79,6 +97,8 @@ export const loader = defineLoader({
       isActive,
       hasAccess,
       verifiedNumbers,
+      featureFlags: workspaceData.feature_flags,
+      initialCoaching,
     };
   },
 });

--- a/app/routes/workspaces+/$id/campaigns/$selected_id.route.tsx
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id.route.tsx
@@ -69,7 +69,15 @@ export default function CampaignScreen() {
   const safeQueueCounts = {
     fullCount: queueCounts.fullCount ?? 0,
     queuedCount: queueCounts.queuedCount ?? 0,
+    completedCount: queueCounts.completedCount ?? 0,
   };
+  const campaignQueueProgress =
+    safeQueueCounts.fullCount > 0
+      ? {
+          completedCount: safeQueueCounts.completedCount,
+          totalCount: safeQueueCounts.fullCount,
+        }
+      : null;
   const campaignDetails = initialCampaignDetails;
 
   useWorkspaceEventSubscription({
@@ -90,12 +98,14 @@ export default function CampaignScreen() {
         title={campaignData?.title || ""}
         status={(campaignData?.status as CampaignStatus) || "pending"}
         isDesktop={false}
+        queueProgress={campaignQueueProgress}
       />
       <div className="flex flex-col items-start justify-between gap-3 border-b border-border/70 pb-4 sm:flex-row sm:items-center">
         <CampaignHeader
           title={campaignData?.title || ""}
           isDesktop
           status={(campaignData?.status as CampaignStatus) || "pending"}
+          queueProgress={campaignQueueProgress}
         />
         <NavigationLinks
           hasAccess={hasAccess}

--- a/app/routes/workspaces+/$id/scripts.action.server.ts
+++ b/app/routes/workspaces+/$id/scripts.action.server.ts
@@ -1,6 +1,7 @@
 import { data as routeData } from "react-router";
 import { logger } from "@/lib/logger.server";
 import { getScriptExportFields } from "@/lib/script-api-db.server";
+import { parseActionRequest } from "@/lib/request-utils.server";
 import { workspaceLoaderAuth } from "@/lib/workspace-route.server";
 import { defineAction } from "@/lib/handler.server";
 
@@ -13,8 +14,7 @@ export const action = defineAction({
     }
     const { headers, workspaceId } = access.ctx;
 
-    const formData = await request.formData();
-    const data = Object.fromEntries(formData.entries());
+    const data = await parseActionRequest(request);
 
     const idValue = data["id"];
     if (!idValue) {

--- a/app/routes/workspaces+/$id/settings/numbers.action.server.ts
+++ b/app/routes/workspaces+/$id/settings/numbers.action.server.ts
@@ -8,6 +8,7 @@ import {
   requireWorkspaceAccess,
 } from "@/lib/database/workspace.server";
 import { MemberRole } from "@/lib/member-role";
+import { parseActionRequest } from "@/lib/request-utils.server";
 import { normalizeInboundRingCount } from "../../../../../shared/inbound-rings";
 import { defineAction } from "@/lib/handler.server";
 
@@ -17,10 +18,7 @@ export const action = defineAction({
   handler: async ({ request, params, auth }) => {
     const { user, userRole } = auth;
 
-    const data = Object.fromEntries(await request.formData()) as Record<
-      string,
-      FormDataEntryValue
-    >;
+    const data = await parseActionRequest(request);
     const formName = data.formName;
     const workspace_id = params.id;
     if (!workspace_id) return { error: "Workspace ID is required" };

--- a/docs/effects-inventory.md
+++ b/docs/effects-inventory.md
@@ -5,7 +5,7 @@
 > the state it depends on, and the side effects it performs. See
 > [effects-strictness.md](./effects-strictness.md).
 
-**98** documented / **98** total effects (0 grandfathered, ratcheting to 0).
+**100** documented / **102** total effects (2 grandfathered, ratcheting to 0).
 
 | File | Purpose | Depends on | Side effects | Why not a loader/fetcher |
 | --- | --- | --- | --- | --- |
@@ -28,6 +28,8 @@
 | `app/hooks/call/useCallAudioControls.ts` | Enumerate audio devices on mount and subscribe to OS | refreshDevices (stable callback) | subscription (mediaDevices "devicechange" listener) | Browser hardware enumeration is a client-only API. |
 | `app/hooks/call/useCallAudioControls.ts` | Apply the selected microphone and speaker device IDs to the | device, microphone, output | dom (Twilio Device audio input/output routing) | Live Twilio audio routing follows user device picks. |
 | `app/hooks/call/useCallAudioControls.ts` | Auto-request microphone access whenever there's no live stream | stream, permissionError, requestMicrophoneAccess (re-runs | dom (navigator.mediaDevices.getUserMedia browser | Browser media-permission/hardware access is a |
+| `app/hooks/call/useCallCoaching.ts` | Track the active call sid in a ref for the SSE listener, and reset transcript/coaching state when the screen switches to a different call (re-seeding from hydration if the new call has any). | callSid (the active call; a change means the previous call's transcript, cues, metrics and session must not leak into the new one) | none — updates callSidRef/seededSidRef and resets local state only | Reacts to an in-page call switch rather than a navigation; the initial values come from the loader via `hydration`, and this only handles subsequent changes. |
+| `app/hooks/call/useCallCoaching.ts` | Open an SSE connection to the workspace events endpoint and apply this call's transcript segments, coaching metrics, cues and final session to local state. | workspaceId (which workspace's event stream to open); callSid (which call's events to keep — others are discarded); subscribe (capability gate; false means no connection is opened at all) | subscription — opens an EventSource (SSE) connection on mount/dep-change; removes listeners and closes the connection on cleanup, or on a terminal access_revoked frame | Live server-pushed transcript/coaching events cannot be modeled as request/response; the connection stays open for the call's duration. Initial state is loader-provided via `hydration`. |
 | `app/hooks/call/useCallDuration.ts` | Tick the call-duration counter once per second while connected. | callState (starts the timer on 'connected', resets otherwise) | timer (setInterval) + functional setState; cleared on unmount/state change | Wall-clock elapsed time is live client state, not server request data. |
 | `app/hooks/call/useCallHandling.ts` | Mirror `heldCalls` state into a ref so callbacks/other effects | heldCalls (re-syncs the ref whenever the held-calls list changes) | none (plain ref assignment) | Not data fetching; "latest ref" pattern for use in |
 | `app/hooks/call/useCallHandling.ts` | Mirror `activeCall` state into a ref for the same reason as | activeCall (re-syncs the ref whenever the active call changes) | none (plain ref assignment) | Not data fetching; "latest ref" pattern. |

--- a/docs/remediation/e2e-nitpick-remediation-plan-2026-07-15.md
+++ b/docs/remediation/e2e-nitpick-remediation-plan-2026-07-15.md
@@ -1,0 +1,467 @@
+# CallCaster E2E Nitpick Audit — Remediation Plan
+
+**Date:** 2026-07-15  
+**Prepared from:** Playwright-driven in-workspace audit on Railway review env (`visual-asset-review`)  
+**Environment:** `https://callcaster-review-visual-asset-review.up.railway.app/`  
+**Test workspace:** `25dcc770-e805-4162-8940-ab7f95fd57c1` (owner, incomplete onboarding, 0 credits)  
+**Test campaigns:** `Audit Live Campaign` (id 1, live call), `Audit SMS Campaign` (id 2, message)  
+**Companion artifact:** Cursor canvas `callcaster-e2e-nitpick-audit.canvas.tsx` (passes 1–4; local IDE artifact, not in repo)  
+**Status:** Open — implementation not started on this branch snapshot
+
+---
+
+## 1. Commander's intent
+
+Turn the review-environment nitpick audit into a sequenced, testable remediation program that:
+
+1. **Closes exploitable data exposure first** — workspace Twilio credentials and internal tokens must never appear in serialized route `.data` payloads.
+2. **Restores core campaign-manager and agent journeys** — campaign hub, join-call, and contact creation must work without crashes or infinite loading.
+3. **Eliminates dead-end navigation** — broken relative links and missing nested-route outlets are fixed before polish.
+4. **Raises product quality to ship bar** — dark-mode contrast, heading hierarchy, and icon accessibility are addressed in a second wave after blockers.
+5. **Hardens review/staging deploys** — schema drift that caused live 500s during the audit is gated in CI/deploy, not patched ad hoc on Railway.
+
+This plan is scoped to findings from passes 1–4 of the nitpick audit. It does not replace the broader [Critical Review Orchestration Plan](./critical-review-orchestration-plan-2026-07-12.md) or the [User Journey Audit](../user-journey-audit.md); it operationalizes the **browser-verified** gaps discovered on the review env after the earlier public/empty-state fix pass landed on `origin/dev`.
+
+---
+
+## 2. Key results (definition of done)
+
+The orchestrator should not declare this plan complete until all five results are met:
+
+| # | Result | Verification |
+|---|--------|--------------|
+| KR-1 | **No workspace secrets in client JSON** | Grep/test sweep: no `authToken`, workspace `token`, or `stripe_id` in any workspace route `.data` response |
+| KR-2 | **Campaign hub renders** | `/workspaces/:id/campaigns/:campaignId` shows results or empty state within 3s; no React #419 / perpetual "Loading results…" |
+| KR-3 | **Join campaign is safe** | `/campaigns/:id/call` does not 500 when `disposition_options` is null; join CTA hidden/disabled when `joinDisabled` is set |
+| KR-4 | **Contact create works** | `/contacts/new` renders `ContactScreen` form; save round-trips |
+| KR-5 | **No known dead-end CTAs** | Voicemail setup "Add a phone number" resolves; global 404 page does not throw in browser |
+
+Secondary (wave 2) results: onboarding step 1 cannot advance empty; SMS settings label says send window not calling hours; dark-mode active nav meets contrast; icon-only controls have accessible names; structural test prevents loader secret regression.
+
+---
+
+## 3. Audit methodology and limitations
+
+### What was exercised
+
+- **Auth:** Owner session on review env; 2FA enforcement disabled via `DISABLE_2FA_ENFORCEMENT=1` on CallCaster service (dev-only unblock).
+- **Surfaces:** Workspace home, campaigns list/create, campaign hub/settings/queue/script, join call, contacts list/new, audiences, scripts, audios, voicemails, settings (members, invite, webhooks), onboarding, archive, marketing chrome bleed-through, dark mode spot-check, mobile 390px on campaign settings.
+- **Technique:** Playwright MCP navigation + inspection of route `.data` JSON, DOM accessibility tree, console errors, and network failures.
+
+### What was not exercised (defer to follow-up nitpick)
+
+- Live call screen after join fix (Twilio device, coaching panels, disposition save loop)
+- Survey editor and public survey respondent flow
+- Billing purchase / Stripe checkout on review env (0 credits)
+- Admin surfaces
+- Full keyboard-only traversal of every workspace route
+- SSE reconnect behavior under forced disconnect
+
+### Live infra mitigations (not in app code)
+
+During the audit, review Postgres was behind app Drizzle schema. Missing columns caused 500s until migrations were applied manually:
+
+- `campaign.sms_send_window` (`20260710010000_campaign_send_window.sql`)
+- `workspace_number.twilio_phone_number_sid` (`20260710000000_workspace_number_twilio_sid.sql`)
+- `outreach_attempt.callback_audit` and related typed columns
+- Additional additive migrations applied in batch
+
+**Debt:** `supabase_migrations.schema_migrations` ledger on review still lags repo. Wave 0 addresses deploy gating; do not assume review DB matches HEAD without verification.
+
+---
+
+## 4. Already resolved (prior pass on `origin/dev`)
+
+These items were implemented, committed, and pushed before passes 2–4; treat as **closed** unless regression is observed:
+
+| Area | Fix |
+|------|-----|
+| Workspace creation | Errors surfaced in create dialog |
+| Root / workspaces index | Stripped sensitive fields from navbar/workspace list loaders |
+| Mobile marketing nav | Sheet drawer + `aria-label`s |
+| Home / pricing / docs | Copy and polish |
+| Role cast | Migration for workspace role enum drift |
+| Review DB users | nanoid→UUID repair for test accounts |
+| Dev 2FA block | `DISABLE_2FA_ENFORCEMENT=1` on review CallCaster service |
+
+---
+
+## 5. Findings inventory
+
+### P0 — Blockers / security
+
+#### SEC-NITPICK-01: Workspace row leaked in route `.data` (OPEN)
+
+**Severity:** Critical  
+**Routes confirmed leaking full `workspace` row** (includes `authToken`, `token`, `stripe_id`, `twilio_data`):
+
+| Route | Loader |
+|-------|--------|
+| `/workspaces/:id/contacts` | `contacts.loader.server.ts` |
+| `/workspaces/:id/contacts/new` | `contacts.loader.server.ts` (parent) + `$contactId.loader.server.ts` |
+| `/workspaces/:id/audiences` | `audiences.loader.server.ts` |
+| `/workspaces/:id/audiences/new` | audiences new loader |
+| `/workspaces/:id/scripts` | `scripts.loader.server.ts` |
+| `/workspaces/:id/scripts/new` | `scripts/new.loader.server.ts` |
+| `/workspaces/:id/scripts/:id` | `scripts/$scriptId.loader.server.ts` |
+| `/workspaces/:id/audios` | `audios.loader.server.ts` |
+| `/workspaces/:id/audios/new` | `audios/new.loader.server.ts` |
+
+**Root cause:** `getWorkspaceById()` in `app/lib/workspace-members-db.server.ts` does `adminDb.select()` with no column projection, returning the full Drizzle workspace row. Loaders assign `workspace: workspaceData` wholesale into `routeData()`.
+
+**Related (different field, still sensitive):** `/campaigns/:id/call.data` exposes a Twilio **capability JWT** in a `token` field — expected for client SDK init but should be documented and never confused with workspace `authToken`.
+
+**Fix strategy:**
+
+1. Introduce `getWorkspacePublicSummary(workspaceId)` (or `pickWorkspaceForClient(row)`) returning only UI-safe fields: `id`, `name`, `credits`, `onboarding_complete`, branding flags, etc. — explicitly omit `authToken`, `token`, `stripe_id`, `twilio_data`, internal billing keys.
+2. Replace `getWorkspaceById` in **all route loaders** with the public projection. Keep `getWorkspaceById` for server-only paths (Twilio webhooks, admin, API actions) — grep before/after.
+3. Add structural test `test/workspace-loader-secrets.test.ts` that asserts serialized loader fixtures never contain forbidden keys (pattern after root loader fix).
+4. Optional ESLint/guard script: flag `getWorkspaceById` imports in `app/routes/workspaces+/**` loaders.
+
+---
+
+### P1 — High severity (broken journeys)
+
+#### JOURNEY-NITPICK-01: Campaign hub hangs on "Loading results…" (OPEN)
+
+**Route:** `/workspaces/:id/campaigns/:campaignId`  
+**Symptom:** Perpetual loading + React error #419 (Suspense/Await boundary).  
+**Note:** `get_campaign_stats(1)` returns quickly in DB; failure is client deferred/streaming wiring.
+
+**Root cause hypothesis:**
+
+- `$selected_id.loader.server.ts` returns `results: resultsPromise` as a deferred promise via `routeData()`.
+- `$selected_id.route.tsx` wraps `<Await resolve={results}>` in nested `<Suspense>`; empty array or rejected promise may not resolve the outer boundary correctly.
+- `fetchBasicResults` in `campaign-stats.server.ts` calls `rpcGetCampaignStats` — verify RPC shape matches `ResultsDisplay` expectations for live campaigns with zero attempts.
+
+**Fix strategy:**
+
+1. Reproduce with unit test: loader returns deferred `results`; route test renders `CampaignScreen` with resolved empty array → shows `NoResultsYet`, not infinite spinner.
+2. If deferral is unnecessary for empty campaigns, await `fetchBasicResults` in loader (simplest fix) or use `defer()` explicitly per RR8 docs.
+3. Add error logging in `CampaignResultDisplay` when `Await` rejects.
+4. Confirm `resultsPromise || []` in loader does not mask a never-settling promise.
+
+**Files:** `campaigns/$selected_id.loader.server.ts`, `campaigns/$selected_id.route.tsx`, `CampaignResultDisplay.tsx`, `campaign-stats.server.ts`
+
+---
+
+#### JOURNEY-NITPICK-02: Join Campaign 500 — `disposition_options.map` on null (OPEN)
+
+**Route:** `/workspaces/:id/campaigns/:id/call`  
+**Symptom:** Server/client crash when `campaignDetails.disposition_options` is null.  
+**Secondary:** Join link still shown in campaign header despite `joinDisabled` reason.
+
+**Root cause:** `CallScreen.Layout.tsx` line ~228:
+
+```ts
+dispositionOptions={((campaignDetails.disposition_options as unknown) as string[]).map(...)}
+```
+
+No null guard; new campaigns have `disposition_options: null` in DB.
+
+**Fix strategy:**
+
+1. Default to `[]` at read boundary: `campaign.server.ts` / call loader, and defensively in `CallScreen.Layout.tsx`.
+2. Align `joinDisabled` with header join CTA — disable/hide when readiness says not joinable.
+3. Add test: call route loader + layout render with `disposition_options: null`.
+
+**Files:** `CallScreen.Layout.tsx`, call loader, `campaign-readiness.ts`, `CampaignHeader.tsx`
+
+---
+
+#### JOURNEY-NITPICK-03: Add Contact broken — no `<Outlet />` (OPEN)
+
+**Route:** `/workspaces/:id/contacts/new`  
+**Symptom:** Child route data loads; `ContactScreen` never mounts. List UI remains visible.
+
+**Root cause:** `contacts.route.tsx` re-exports `ContactsPage` as default with no outlet. `ContactsPage.tsx` renders list only — no `<Outlet />` for `$contactId` child.
+
+**Fix strategy (pick one, prefer A):**
+
+- **A (recommended):** Add `<Outlet />` to `ContactsPage` (or split layout route `contacts.layout.route.tsx` with outlet + index child).
+- **B:** Flatten `/contacts/new` to sibling route without nesting (more route-tree churn).
+
+**Files:** `contacts.route.tsx`, `ContactsPage.tsx`, optionally new layout module
+
+---
+
+#### JOURNEY-NITPICK-04: Onboarding step 1 advances with empty fields (OPEN)
+
+**Route:** `/workspaces/:id/onboarding`  
+**Symptom:** "Save & continue" on business basics step advances without required field validation.
+
+**Fix strategy:**
+
+1. Add Zod (or existing form validation pattern) to `OnboardingBusinessBasicsStep` / wizard action.
+2. Server-side validation in onboarding action — reject empty legal name, address, etc.
+3. E2E: submit empty step 1 → stays on step 1 with field errors.
+
+**Files:** `OnboardingWizard.tsx`, `OnboardingBusinessBasicsStep.tsx`, onboarding action server
+
+---
+
+#### JOURNEY-NITPICK-05: Voicemail setup CTA 404 (OPEN)
+
+**Route:** `/workspaces/:id/voicemails/setup` (no numbers)  
+**Symptom:** "Add a phone number" link resolves incorrectly; 404 page throws `ReferenceError: Buffer is not defined`.
+
+**Root cause (link):** `setup.route.tsx` uses `<Link to="../settings/numbers" relative="path">`. From `/voicemails/setup`, this resolves to `/voicemails/settings/numbers` (404). Correct target: `/workspaces/:id/settings/numbers`.
+
+**Fix:** Use absolute workspace-relative path: `to={`/workspaces/${workspaceId}/settings/numbers`}` from loader data, or `relative="route"` with correct segment count.
+
+**Root cause (404 Buffer):** Global error/404 route imports Node `Buffer` without polyfill — breaks client bundle.
+
+**Fix:** Find 404/root error boundary usage of `Buffer`; replace with browser-safe base64 (`atob`/`btoa`) or move decode server-side only.
+
+**Files:** `voicemails/setup.route.tsx`, root or catch-all error route, `e2e/specs/voicemail-setup.spec.ts`
+
+---
+
+### P2 — Medium (quality / a11y / UX)
+
+| ID | Finding | Fix direction |
+|----|---------|---------------|
+| UX-NITPICK-01 | SMS campaign settings show "Calling Hours" label | Use send-window copy when `campaign.type === "message"` |
+| UX-NITPICK-02 | Campaign settings horizontal overflow at 390px | Audit tabs/form grid in campaign settings; `min-w-0`, responsive stack |
+| UX-NITPICK-03 | Missing page `h1` / heading hierarchy | Pass with `PageShell title` or explicit `<Heading level={1}>` per route |
+| UX-NITPICK-04 | Script editor: no title/back/save until dirty | Persistent header + `SaveBar` integration on script edit route |
+| UX-NITPICK-05 | `SaveBar` hardcoded `bg-white`, red destructive | Design tokens + dark mode (`bg-background`, semantic destructive) |
+| UX-NITPICK-06 | Campaign queue: Next enabled at 0 results | Disable when `totalCount === 0` |
+| UX-NITPICK-07 | Workspace SSE console errors on healthy pages | Investigate EventSource URL/auth; downgrade or fix reconnect |
+| UX-NITPICK-08 | Settings invite: error without `aria-invalid` | Wire `FormField` error to input `aria-describedby` |
+| UX-NITPICK-09 | Marketing chrome on all workspace pages | Confirm layout intent; hide marketing header inside `/workspaces/*` if unintended |
+| UX-NITPICK-10 | Onboarding progress bar missing `aria-valuenow` | Add progressbar role + values |
+| UX-NITPICK-11 | Empty Members list, empty billing usage table | Empty-state components with CTA |
+| A11Y-NITPICK-01 | Dark mode: pale `brand-secondary` on active sidebar + marketing header | Token audit in `WorkspaceNav`, `Navbar` for `dark:` contrast |
+| A11Y-NITPICK-02 | Unlabeled icon buttons | Add `aria-label`: user menu, Settings gear, Scripts Download/Edit, queue sort, SMS composer |
+
+---
+
+### P3 — Low
+
+| ID | Finding | Fix direction |
+|----|---------|---------------|
+| LOW-NITPICK-01 | Duplicate unlabeled combobox nodes (Select primitive) | Audit Radix Select trigger `aria-label` or visible label association |
+| LOW-NITPICK-02 | Archive empty state says "Create Your First Campaign" when drafts exist | Conditional copy based on draft count |
+
+---
+
+## 6. Implementation waves
+
+### Wave 0 — Review env hygiene (infra, parallel to code)
+
+**Goal:** Prevent repeat of audit-time 500s from schema drift.
+
+| Task | Owner | Notes |
+|------|-------|-------|
+| W0-1 | Compare review `schema_migrations` to `client/migrations/` | Script or CI job |
+| W0-2 | Add deploy gate: `client db push` or migration apply before app redeploy | Railway review pipeline |
+| W0-3 | Document review DB refresh procedure | `docs/railway-review-env.md` |
+| W0-4 | Keep `DISABLE_2FA_ENFORCEMENT=1` documented as review-only | Do not set in production |
+
+**Exit criteria:** Fresh review deploy boots without manual SQL; campaign create + settings load without column-missing 500s.
+
+---
+
+### Wave 1 — Security and crash fixes (P0 + P1)
+
+**Goal:** KR-1 through KR-5. Single PR or stacked PRs; land SEC-01 before any other loader touches.
+
+```
+W1-A  SEC-NITPICK-01   Public workspace projection + loader sweep + regression test
+W1-B  JOURNEY-NITPICK-02  disposition_options null guard + join CTA gating
+W1-C  JOURNEY-NITPICK-01  Campaign hub Await/defer fix + test
+W1-D  JOURNEY-NITPICK-03  Contacts Outlet layout
+W1-E  JOURNEY-NITPICK-05  Voicemail link + 404 Buffer fix
+W1-F  JOURNEY-NITPICK-04  Onboarding step 1 validation
+```
+
+**Suggested order:** A → B → C → D → E → F (security first; call crash before hub polish).
+
+**Per-task acceptance:**
+
+- **W1-A:** `curl` or route test JSON for `/contacts.data` contains `workspace.id`, `workspace.name`; does **not** contain `authToken`, `token`, `stripe_id`.
+- **W1-B:** `/campaigns/1/call` returns 200 HTML; no stack trace; join hidden when `joinDisabled`.
+- **W1-C:** Campaign hub shows `NoResultsYet` or chart within one paint after hydration.
+- **W1-D:** `/contacts/new` shows "New Contact" heading and form fields.
+- **W1-E:** Voicemail setup link hits `/workspaces/:id/settings/numbers`; 404 page renders without console error.
+- **W1-F:** Empty onboarding step 1 shows validation errors; step index unchanged.
+
+---
+
+### Wave 2 — UX, a11y, dark mode (P2)
+
+**Goal:** Secondary key results; safe to parallelize after Wave 1 merges.
+
+| Batch | Items |
+|-------|-------|
+| 2a — Campaign UX | UX-01, UX-02, UX-06, script editor header (UX-04, UX-05) |
+| 2b — Global a11y | A11Y-01, A11Y-02, UX-08, UX-10 |
+| 2c — Chrome & empty states | UX-09, UX-11, LOW-02 |
+| 2d — Realtime | UX-07 (SSE) — may need separate spike |
+
+---
+
+### Wave 3 — Extended nitpick (out of scope for Wave 1–2)
+
+Resume Playwright pass 5+ after Wave 1 lands:
+
+- Call screen full flow (dial, disposition, coaching panels)
+- Survey editor + public survey
+- Billing with credits
+- Admin workspace Twilio tools
+- Keyboard-only audit checklist
+
+---
+
+## 7. File touchpoint matrix
+
+| Finding | Primary files | Tests to add/update |
+|---------|---------------|---------------------|
+| SEC-01 | `workspace-members-db.server.ts`, new `workspace-public.server.ts`, all loaders using `getWorkspaceById` in `workspaces+/` | `workspace-loader-secrets.test.ts` |
+| JOURNEY-01 | `$selected_id.loader.server.ts`, `$selected_id.route.tsx`, `CampaignResultDisplay.tsx` | UI test for empty results |
+| JOURNEY-02 | `CallScreen.Layout.tsx`, `CampaignHeader.tsx`, call loader | `db-campaign.server.test.ts` null disposition |
+| JOURNEY-03 | `ContactsPage.tsx`, `contacts.route.tsx` | `workspace-contacts.route.test.ts` |
+| JOURNEY-04 | `OnboardingWizard.tsx`, onboarding action | E2E onboarding spec |
+| JOURNEY-05 | `voicemails/setup.route.tsx`, error/404 route | `voicemail-setup.spec.ts`, `test/ui/voicemail-setup.test.tsx` |
+| UX-05 | `SaveBar.tsx` | Visual/dark mode spot test |
+| A11Y-01 | `WorkspaceNav.tsx`, `Navbar.tsx` | Manual dark mode checklist |
+
+### Loaders requiring workspace projection audit (non-exhaustive — re-grep at implementation)
+
+```
+app/routes/workspaces+/$id/contacts.loader.server.ts
+app/routes/workspaces+/$id/contacts/$contactId.loader.server.ts
+app/routes/workspaces+/$id/audiences.loader.server.ts
+app/routes/workspaces+/$id/scripts.loader.server.ts
+app/routes/workspaces+/$id/scripts/new.loader.server.ts
+app/routes/workspaces+/$id/scripts/$scriptId.loader.server.ts
+app/routes/workspaces+/$id/audios.loader.server.ts
+app/routes/workspaces+/$id/audios/new.loader.server.ts
+app/routes/workspaces+/$id/audios/record.loader.server.ts
+app/routes/workspaces+/$id/analytics.loader.server.ts
+```
+
+Server-only `getWorkspaceById` call sites (Twilio, admin, API) — **do not** switch to public projection without reviewing credential needs.
+
+---
+
+## 8. Test plan
+
+### Automated
+
+| Check | Command / location |
+|-------|-------------------|
+| Typecheck + lint | `npm run ci:local` (or constituent scripts) |
+| Loader secret regression | New `workspace-loader-secrets.test.ts` |
+| Campaign stats empty | Extend `db-campaign.server.test.ts` |
+| Contacts nested route | Extend `workspace-contacts.route.test.ts` |
+| Voicemail setup link | `test/ui/voicemail-setup.test.tsx`, `e2e/specs/voicemail-setup.spec.ts` |
+| Route tree | `npm run tools:routes:verify` |
+
+### Manual (review env)
+
+After deploy to `visual-asset-review`:
+
+1. **Secret sweep:** DevTools → Network → `*.data` on contacts, audiences, scripts, audios → confirm no `authToken`.
+2. **Campaign hub:** Open live campaign id 1 → results or empty state, no #419.
+3. **Join call:** Navigate to call route → no 500; disposition dropdown empty-safe.
+4. **New contact:** `/contacts/new` → form visible → save creates row.
+5. **Voicemail:** Setup with 0 numbers → link opens settings/numbers.
+6. **Onboarding:** Fresh workspace → step 1 empty submit blocked.
+7. **Dark mode:** Toggle theme → sidebar active item readable.
+
+### Regression risks
+
+| Change | Risk | Mitigation |
+|--------|------|------------|
+| Workspace projection | Server code expecting full row from shared helper | Separate `getWorkspaceById` (server) vs `getWorkspaceForClient` (routes) |
+| Await removal | Slower campaign hub TTFB | Benchmark; re-defer only stats RPC if needed |
+| Contacts layout | List/detail layout break on mobile | Visual check list + detail routes |
+
+---
+
+## 9. Repository invariants (agents must follow)
+
+From `AGENTS.md` — all implementation work must:
+
+- Use `createTenantDb(workspaceId)` for tenant table access in routes.
+- Never expose provider credentials in HTTP responses.
+- Use top-level imports; exhaustive TypeScript switches.
+- Not modify `.env`.
+- Prefer `app/components/ui/` primitives and design-system patterns.
+- Run `npm run ci:local` before PR.
+
+---
+
+## 10. Suggested PR structure
+
+| PR | Title | Waves |
+|----|-------|-------|
+| 1 | `fix(security): strip workspace secrets from workspace route loaders` | W1-A |
+| 2 | `fix(campaign): hub results loading and call screen null dispositions` | W1-B, W1-C |
+| 3 | `fix(contacts): render nested contact form via Outlet` | W1-D |
+| 4 | `fix(navigation): voicemail setup link and client-safe 404` | W1-E |
+| 5 | `fix(onboarding): validate business basics before advance` | W1-F |
+| 6 | `polish(ui): dark mode, a11y labels, campaign copy` | Wave 2 |
+
+PR 1 should merge first; PR 2–5 can stack or parallelize after PR 1 base.
+
+---
+
+## 11. Coverage matrix (audit passes 1–4)
+
+| Surface | Pass | Status |
+|---------|------|--------|
+| Sign-in / workspace pick | 1 | OK |
+| Workspace create dialog | 1 | Fixed (prior pass) |
+| Root / workspaces data leak | 1 | Fixed (prior pass) |
+| Mobile marketing nav | 1 | Fixed (prior pass) |
+| Onboarding wizard | 2 | **Open** — validation |
+| Campaign create (live/SMS) | 2 | OK |
+| Campaign hub / results | 2–3 | **Open** — hang |
+| Campaign settings / queue / script | 3 | OK with notes (SMS label, mobile overflow) |
+| Join campaign / call | 3 | **Open** — 500 |
+| Contacts list | 3 | OK |
+| Contacts new | 3 | **Open** — no Outlet |
+| Audiences / scripts / audios | 3–4 | **Open** — secret leak |
+| Voicemails setup | 4 | **Open** — bad link |
+| Settings members / invite / webhooks | 4 | Minor a11y |
+| Archive | 4 | LOW copy |
+| Dark mode / mobile 390px | 4 | **Open** — contrast, overflow |
+| Marketing chrome in workspace | 4 | **Open** — investigate |
+
+---
+
+## 12. Out of scope (this plan)
+
+- Live coaching / media-stream feature work (separate branch per git status)
+- CHS auth package adoption (critical review plan)
+- Production cutover / billing reconciliation
+- Full user-journey audit re-write (51 journeys) — only nitpick findings herein
+- Penetration test of API keys / webhook signature bypass (covered elsewhere)
+
+---
+
+## 13. Open questions
+
+| # | Question | Default if unanswered |
+|---|----------|----------------------|
+| Q1 | Should workspace layout stop rendering marketing `Navbar` inside `/workspaces/*`? | Yes — use workspace-only chrome |
+| Q2 | Await vs await-in-loader for campaign stats? | Await in loader unless perf regression |
+| Q3 | Contacts: master-detail on desktop vs full-page new? | Outlet with conditional list hide on child |
+| Q4 | Wave 0 migration gate in CI vs Railway deploy hook? | Both: CI fails on drift; deploy applies pending |
+
+---
+
+## 14. References
+
+- [Critical Review Orchestration Plan](./critical-review-orchestration-plan-2026-07-12.md)
+- [User Journey Audit](../user-journey-audit.md)
+- [Railway review env](../railway-review-env.md)
+- [Design system](../design-system.md)
+- Agent transcript: [E2E nitpick session](cursor://agent-transcripts/e6927693-6401-46f6-a867-5c04ec9782de)
+
+---
+
+*Last updated: 2026-07-15 — synthesizes audit passes 1–4 and prior `origin/dev` fix pass.*

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "bun run ./server/bun.ts",
     "worker": "bun run ./worker/index.ts",
-    "typecheck": "react-router typegen && tsc",
+    "typecheck": "react-router typegen && tsc && tsc -p services/tsconfig.json",
     "typecheck:deno": "node scripts/check-deno-functions.mjs",
     "test": "npm run test:node && npm run test:ui",
     "test:node": "vitest run -c vitest.node.config.ts && bun test test/server-runtime.test.ts test/twilio-webhook-prehandler.test.ts vendor/scriptkit/scriptkit-call-script-core/src/",

--- a/scripts/baselines/route-tree.txt
+++ b/scripts/baselines/route-tree.txt
@@ -59,6 +59,7 @@ api/campaign_audience
 api/campaign_queue
 api/campaigns
 api/chat_sms
+api/coaching-ack
 api/connect-campaign-conference/:workspaceId/:campaignId
 api/connect-phone-device
 api/contact-audience

--- a/scripts/check-credit-write-paths.mjs
+++ b/scripts/check-credit-write-paths.mjs
@@ -12,6 +12,10 @@ const SCAN_DIRS = [
   path.join(ROOT, "app"),
   path.join(ROOT, "worker"),
   path.join(ROOT, "client/functions"),
+  // The media-stream Bun service debits credits too (live transcription,
+  // coaching cues). It was outside this scan until 2026-07, which is how those
+  // debits shipped bypassing shared/billing-keys.ts unnoticed.
+  path.join(ROOT, "services"),
 ];
 
 const APPROVED_FILES = new Set([

--- a/services/media-stream/coaching-billing.ts
+++ b/services/media-stream/coaching-billing.ts
@@ -1,0 +1,85 @@
+/**
+ * Billing debits raised by the live media pipeline.
+ *
+ * ## Boundary note (v1): intentional in-process coupling with the app
+ *
+ * The media-stream service is a separate Railway process (ADR-0030) but ships in
+ * the same image and runs from the same source tree, so it imports the app's
+ * billing primitives directly via the `@/` alias — TOP-LEVEL, not through
+ * `await import()`. The dynamic imports this module replaces guarded nothing:
+ * there is no cycle (`@/lib/pricing` only re-exports `shared/pricing`) and no
+ * bundling constraint (the service is not part of the app build; Bun resolves
+ * `@/` from tsconfig paths, and `db-writer.ts` has always imported
+ * `@/server/admin-db` at top level). Deferring them only hid the debits from
+ * static analysis — which is exactly how `scripts/check-credit-write-paths.mjs`
+ * came to miss this file. That script now scans `services/` too.
+ *
+ * Accepted for v1: the service reaches into `@/lib/*` service-role modules. If
+ * this ever needs to run out-of-process from the app, the seam to cut is here
+ * and in `db-writer.ts` — the rest of the engine is already effect-free.
+ */
+import { debitAmountFromCredits } from "@/lib/pricing";
+import { insertTransactionHistoryIdempotent } from "@/lib/transaction-history.server";
+import {
+  coachingCueKey,
+  liveTranscriptionKey,
+} from "../../shared/billing-keys";
+import {
+  COACHING_CUE_CREDITS,
+  TRANSCRIPTION_RATE_CREDITS,
+} from "../../shared/billing-rates";
+
+/** Charge for one LLM-generated coaching cue, keyed by its persisted row id. */
+export async function billCoachingCue(args: {
+  workspaceId: string;
+  callSid: string;
+  eventId: string;
+}): Promise<void> {
+  await insertTransactionHistoryIdempotent({
+    workspaceId: args.workspaceId,
+    type: "DEBIT",
+    amount: debitAmountFromCredits(COACHING_CUE_CREDITS),
+    note: `Coaching cue ${args.callSid}`,
+    idempotencyKey: coachingCueKey(args.callSid, args.eventId),
+    callSid: args.callSid,
+  });
+}
+
+/** Credits owed for a realtime STT session of `durationMs`. Exported for tests. */
+export function liveTranscriptionCredits(durationMs: number): number {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return 0;
+  return Math.ceil((durationMs / 60_000) * TRANSCRIPTION_RATE_CREDITS);
+}
+
+/**
+ * Charge for a realtime STT session, billed from the STT clock.
+ *
+ * Follows the STT lifecycle, NOT the coaching lifecycle: a transcription-only
+ * workspace opens a stream and must be billed for it even though no coaching
+ * session exists. Previously this lived inside `finalizeCoachingSession` and
+ * measured the coaching state's clock, so those workspaces ran STT for free.
+ *
+ * A session that opened but accrued no billable time writes nothing — never a
+ * zero or negative debit.
+ */
+export async function billLiveTranscription(args: {
+  workspaceId: string;
+  callSid: string;
+  durationMs: number;
+}): Promise<{ billed: boolean; credits: number }> {
+  const credits = liveTranscriptionCredits(args.durationMs);
+  if (credits <= 0) {
+    return { billed: false, credits: 0 };
+  }
+
+  await insertTransactionHistoryIdempotent({
+    workspaceId: args.workspaceId,
+    type: "DEBIT",
+    amount: debitAmountFromCredits(credits),
+    note: `Live transcription ${args.callSid}`,
+    idempotencyKey: liveTranscriptionKey(args.callSid),
+    callSid: args.callSid,
+  });
+
+  return { billed: true, credits };
+}

--- a/services/media-stream/coaching-engine.ts
+++ b/services/media-stream/coaching-engine.ts
@@ -1,0 +1,86 @@
+/**
+ * Coaching engine facade — orchestration only.
+ *
+ * The engine is split so each concern is independently testable:
+ * - `coaching-rules.ts`    pure rules: utterance + state -> cue intents + metrics
+ * - `coaching-llm.ts`      Cohere generate + parse + validate (all failures non-fatal)
+ * - `coaching-billing.ts`  cue + live-transcription debits
+ * - `coaching-finalize.ts` summary, final metrics, persistence, publish
+ *
+ * This module is the only place the four meet: it takes the intents the rules
+ * produce and performs their effects. It should stay thin.
+ */
+import { billCoachingCue } from "./coaching-billing";
+import { generateLlmCue } from "./coaching-llm";
+import { evaluateUtterance, type CueIntent } from "./coaching-rules";
+import type { CoachingState } from "./coaching-state";
+import type { TranscriptSegmentRow } from "./db-writer";
+import {
+  publishCoachingCueEvent,
+  publishCoachingMetricsEvent,
+  writeCoachingEvent,
+} from "./db-writer";
+
+export { createCoachingState, type CoachingState } from "./coaching-state";
+export { finalizeCoachingSession } from "./coaching-finalize";
+export { computeScore, type CueIntent } from "./coaching-rules";
+
+/**
+ * Persist a cue, publish it to the workspace, and bill it if it is LLM-generated.
+ * Rule-based cues cost nothing to produce and are not billed.
+ */
+async function emitCue(state: CoachingState, cue: CueIntent): Promise<void> {
+  const row = await writeCoachingEvent({
+    call_sid: state.callSid,
+    type: cue.type,
+    severity: cue.severity,
+    payload: cue.payload,
+  });
+
+  await publishCoachingCueEvent(state.workspaceId, state.callSid, {
+    eventId: row.id,
+    type: cue.type,
+    severity: cue.severity,
+    heading: cue.heading,
+    suggestion: cue.suggestion,
+  });
+
+  if (cue.type === "suggestion") {
+    await billCoachingCue({
+      workspaceId: state.workspaceId,
+      callSid: state.callSid,
+      eventId: row.id,
+    });
+  }
+}
+
+/**
+ * Fold one committed utterance into the session.
+ *
+ * Mutates `state` in place because the caller holds it on the socket; the rules
+ * themselves are pure and return the next state, which is copied back here.
+ */
+export async function processUtterance(
+  state: CoachingState,
+  segment: TranscriptSegmentRow,
+): Promise<void> {
+  const { next, cues, metrics, llmCueDue } = evaluateUtterance(
+    state,
+    segment,
+    Date.now(),
+  );
+  Object.assign(state, next);
+
+  for (const cue of cues) {
+    await emitCue(state, cue);
+  }
+
+  await publishCoachingMetricsEvent(state.workspaceId, state.callSid, metrics);
+
+  if (llmCueDue) {
+    const llmCue = await generateLlmCue(state);
+    if (llmCue) {
+      await emitCue(state, llmCue);
+    }
+  }
+}

--- a/services/media-stream/coaching-finalize.ts
+++ b/services/media-stream/coaching-finalize.ts
@@ -1,0 +1,44 @@
+/**
+ * End-of-session coaching work: summary, final metrics, persistence, publish.
+ *
+ * Note what is NOT here: the live-transcription debit. That charge follows the
+ * STT lifecycle and is raised by the twilio-handler on stream stop, so that
+ * transcription-only workspaces (which never build a coaching state) are still
+ * billed. See `coaching-billing.ts`.
+ */
+import { computeWpm } from "./coaching-state";
+import type { CoachingState } from "./coaching-state";
+import { generateCallSummary } from "./coaching-llm";
+import { computeScore } from "./coaching-rules";
+import {
+  publishCoachingSessionFinalEvent,
+  writeCoachingSessionFinal,
+} from "./db-writer";
+
+export async function finalizeCoachingSession(
+  state: CoachingState,
+): Promise<void> {
+  const wpmAvg = computeWpm(state.wpmWindow);
+  const summary = await generateCallSummary(state);
+  const score = computeScore(state);
+
+  const session = await writeCoachingSessionFinal({
+    call_sid: state.callSid,
+    wpm_avg: wpmAvg,
+    filler_count: state.fillerTotal,
+    pause_count: state.pauseTotal,
+    long_pause_count: state.longPauseTotal,
+    score,
+    summary: summary || null,
+  });
+
+  await publishCoachingSessionFinalEvent(state.workspaceId, state.callSid, {
+    sessionId: session.id,
+    wpmAvg,
+    fillerCount: state.fillerTotal,
+    pauseCount: state.pauseTotal,
+    longPauseCount: state.longPauseTotal,
+    score,
+    summary,
+  });
+}

--- a/services/media-stream/coaching-llm.ts
+++ b/services/media-stream/coaching-llm.ts
@@ -1,0 +1,129 @@
+/**
+ * Cohere calls for the coaching engine: generate, parse, and VALIDATE.
+ *
+ * Every failure mode here is non-fatal by contract — no API key, HTTP error,
+ * malformed JSON, or a well-formed response that is not a cue all resolve to
+ * `null`/`""`. An LLM is a best-effort embellishment on the rule-based cues; it
+ * must never be able to take down a live call's coaching session.
+ */
+import { z } from "zod";
+import type { CoachingState } from "./coaching-state";
+import type { CueIntent } from "./coaching-rules";
+
+const COHERE_GENERATE_URL = "https://api.cohere.com/v1/generate";
+const COHERE_MODEL = "command-a-03-2025";
+const CUE_CONTEXT_SEGMENTS = 10;
+
+/** Shape Cohere is asked to emit. Anything else is discarded, not thrown on. */
+const LlmCue = z.object({
+  heading: z.string().trim().min(1),
+  suggestion: z.string().trim().min(1),
+});
+
+const CohereGenerateResponse = z.object({
+  generations: z
+    .array(z.object({ text: z.string().optional() }).passthrough())
+    .optional(),
+});
+
+function transcriptOf(state: CoachingState, limit?: number): string {
+  const segments = limit ? state.segments.slice(-limit) : state.segments;
+  return segments
+    .map((segment) => `${segment.speaker_label ?? "speaker"}: ${segment.text}`)
+    .join("\n");
+}
+
+async function cohereGenerate(
+  apiKey: string,
+  prompt: string,
+  options: { maxTokens: number; temperature: number },
+): Promise<string | null> {
+  const response = await fetch(COHERE_GENERATE_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: COHERE_MODEL,
+      prompt,
+      max_tokens: options.maxTokens,
+      temperature: options.temperature,
+    }),
+  });
+
+  if (!response.ok) return null;
+
+  const parsed = CohereGenerateResponse.safeParse(await response.json());
+  if (!parsed.success) return null;
+
+  return parsed.data.generations?.[0]?.text?.trim() ?? null;
+}
+
+/** Parse + validate a raw LLM completion into a cue. Never throws. */
+export function parseLlmCue(raw: string | null | undefined): CueIntent | null {
+  if (!raw?.trim()) return null;
+
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const cue = LlmCue.safeParse(candidate);
+  if (!cue.success) return null;
+
+  return {
+    type: "suggestion",
+    severity: "info",
+    payload: { heading: cue.data.heading, suggestion: cue.data.suggestion },
+    heading: cue.data.heading,
+    suggestion: cue.data.suggestion,
+  };
+}
+
+/** Ask Cohere for one coaching cue. Returns null on any failure. */
+export async function generateLlmCue(
+  state: CoachingState,
+): Promise<CueIntent | null> {
+  const apiKey = process.env.COHERE_API_KEY?.trim();
+  if (!apiKey) return null;
+  if (state.segments.length === 0) return null;
+
+  const prompt = `You are an ${state.config.llmPersona}. Based on the last utterances of a live phone call, give ONE concise coaching cue for the agent. Respond as JSON only: {"heading":"two words","suggestion":"one sentence"}.
+
+Transcript:
+${transcriptOf(state, CUE_CONTEXT_SEGMENTS)}`;
+
+  try {
+    const raw = await cohereGenerate(apiKey, prompt, {
+      maxTokens: 100,
+      temperature: 0.7,
+    });
+    return parseLlmCue(raw);
+  } catch {
+    // Non-fatal — rule-based cues still work without the LLM.
+    return null;
+  }
+}
+
+/** Ask Cohere for a call summary. Returns "" on any failure. */
+export async function generateCallSummary(state: CoachingState): Promise<string> {
+  const apiKey = process.env.COHERE_API_KEY?.trim();
+  if (!apiKey) return "";
+  if (state.segments.length === 0) return "";
+
+  const prompt = `Summarize this call in 2-3 sentences for the agent, noting one strength and one improvement:\n\n${transcriptOf(state)}`;
+
+  try {
+    const raw = await cohereGenerate(apiKey, prompt, {
+      maxTokens: 150,
+      temperature: 0.5,
+    });
+    return raw ?? "";
+  } catch {
+    // Non-fatal — the session still finalizes without a summary.
+    return "";
+  }
+}

--- a/services/media-stream/coaching-rules.ts
+++ b/services/media-stream/coaching-rules.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure coaching rules. Utterance + state in, cue intents + metric snapshot out.
+ *
+ * This module MUST stay free of DB, network, billing and clock access — it is
+ * the only part of the coaching engine that is testable without mocks, and that
+ * property is the point of the split. Effects belong to the caller
+ * (`coaching-engine.ts`), which turns the returned intents into writes.
+ */
+import { computeWpm, type CoachingState } from "./coaching-state";
+import type { TranscriptSegmentRow } from "./db-writer";
+
+/** A cue the rules decided to raise. Persisting/publishing it is the caller's job. */
+export type CueIntent = {
+  type: "filler_burst" | "pace" | "pause" | "suggestion";
+  severity: "info" | "warn";
+  payload: Record<string, unknown>;
+  heading: string;
+  suggestion: string;
+};
+
+export type MetricsSnapshot = {
+  wpm: number;
+  fillerCount: number;
+  pauseCount: number;
+  longPauseCount: number;
+};
+
+export type UtteranceEvaluation = {
+  /** Next state. The input state is not mutated. */
+  next: CoachingState;
+  cues: CueIntent[];
+  metrics: MetricsSnapshot;
+  /** True when the LLM cadence has elapsed and the caller should ask for an LLM cue. */
+  llmCueDue: boolean;
+};
+
+const WPM_WINDOW_MS = 30_000;
+const WPM_WINDOW_DECAY = 0.75;
+const FILLER_BURST_THRESHOLD = 3;
+const OUT_OF_RANGE_STREAK_THRESHOLD = 3;
+
+export function extractFillers(text: string, fillerWords: string[]): string[] {
+  const lower = text.toLowerCase();
+  return fillerWords
+    .map((word) => word.toLowerCase())
+    .filter((filler) => lower.includes(filler));
+}
+
+function advanceWpmWindow(
+  window: { words: number; ms: number },
+  segment: TranscriptSegmentRow,
+): { words: number; ms: number } {
+  let ms = window.ms + (segment.end_ms - segment.start_ms);
+  let words = window.words + segment.text.split(/\s+/).filter(Boolean).length;
+
+  while (ms > WPM_WINDOW_MS) {
+    ms = Math.floor(ms * WPM_WINDOW_DECAY);
+    words = Math.floor(words * WPM_WINDOW_DECAY);
+  }
+
+  return { words, ms };
+}
+
+/**
+ * Evaluate one committed utterance against the rule set.
+ *
+ * @param now - injected clock reading, so the cadence decision stays pure.
+ */
+export function evaluateUtterance(
+  state: CoachingState,
+  segment: TranscriptSegmentRow,
+  now: number,
+): UtteranceEvaluation {
+  const config = state.config;
+  const cues: CueIntent[] = [];
+
+  const wpmWindow = advanceWpmWindow(state.wpmWindow, segment);
+  const wpm = computeWpm(wpmWindow);
+
+  const fillerCount = segment.filler_count ?? 0;
+  if (fillerCount >= FILLER_BURST_THRESHOLD) {
+    cues.push({
+      type: "filler_burst",
+      severity: "warn",
+      payload: {
+        count: fillerCount,
+        words: extractFillers(segment.text, config.fillerWords),
+      },
+      heading: "Filler burst",
+      suggestion: "Pause briefly instead of filling silence with filler words.",
+    });
+  }
+
+  let outOfRangeStreak = state.outOfRangeStreak;
+  if (wpm > 0 && (wpm < config.wpmMin || wpm > config.wpmMax)) {
+    outOfRangeStreak += 1;
+    if (outOfRangeStreak >= OUT_OF_RANGE_STREAK_THRESHOLD) {
+      const slow = wpm < config.wpmMin;
+      cues.push({
+        type: "pace",
+        severity: "info",
+        payload: { wpm, range: slow ? "slow" : "fast" },
+        heading: slow ? "Pace up" : "Slow down",
+        suggestion: slow
+          ? "Try speaking a little faster to keep momentum."
+          : "Take a breath and slow your pace for clarity.",
+      });
+      outOfRangeStreak = 0;
+    }
+  } else {
+    outOfRangeStreak = 0;
+  }
+
+  let pauseTotal = state.pauseTotal;
+  let longPauseTotal = state.longPauseTotal;
+  if (state.lastUtteranceEndMs > 0) {
+    const gapMs = segment.start_ms - state.lastUtteranceEndMs;
+    if (gapMs > config.pauseThresholdMs) {
+      const isLong = gapMs > config.pauseThresholdMs * 2;
+      pauseTotal += 1;
+      longPauseTotal += isLong ? 1 : 0;
+      cues.push({
+        type: "pause",
+        severity: isLong ? "warn" : "info",
+        payload: { durationMs: gapMs, position: "between_utterances" },
+        heading: isLong ? "Long pause" : "Pause",
+        suggestion: isLong
+          ? "Long silence detected — acknowledge it or ask an open question."
+          : "Brief pause — good moment to listen.",
+      });
+    }
+  }
+
+  const metrics: MetricsSnapshot = {
+    wpm,
+    fillerCount: state.fillerTotal + fillerCount,
+    pauseCount: pauseTotal,
+    longPauseCount: longPauseTotal,
+  };
+
+  const llmCueDue = now - state.lastCueAt >= config.llmCadenceMs;
+
+  const next: CoachingState = {
+    ...state,
+    segments: [...state.segments, segment],
+    wpmWindow,
+    fillerTotal: state.fillerTotal + fillerCount,
+    pauseTotal,
+    longPauseTotal,
+    lastUtteranceEndMs: segment.end_ms,
+    lastCueAt: llmCueDue ? now : state.lastCueAt,
+    outOfRangeStreak,
+  };
+
+  return { next, cues, metrics, llmCueDue };
+}
+
+/**
+ * Session score, 0–100, over the three signals the engine actually measures.
+ *
+ * The previous formula added a hardcoded `75 * 0.2` term standing in for a
+ * signal that was never implemented. That constant was not a rule, it was a
+ * bias: it floored every score at 15 and capped a flawless call at 85. Rather
+ * than invent a fourth signal to justify it, the term is removed and the three
+ * real weights (pace .25 / filler .30 / pause .25) are renormalized over their
+ * own sum, so the score spans the full range and reflects only measured input.
+ */
+export function computeScore(state: CoachingState): number {
+  const wpm = computeWpm(state.wpmWindow);
+  const paceScore =
+    wpm >= state.config.wpmMin && wpm <= state.config.wpmMax ? 100 : 60;
+  const fillerScore = Math.max(0, 100 - state.fillerTotal * 5);
+  const pauseScore = Math.max(0, 100 - state.longPauseTotal * 10);
+
+  const PACE_WEIGHT = 0.25;
+  const FILLER_WEIGHT = 0.3;
+  const PAUSE_WEIGHT = 0.25;
+  const totalWeight = PACE_WEIGHT + FILLER_WEIGHT + PAUSE_WEIGHT;
+
+  return Math.round(
+    (paceScore * PACE_WEIGHT + fillerScore * FILLER_WEIGHT + pauseScore * PAUSE_WEIGHT) /
+      totalWeight,
+  );
+}

--- a/services/media-stream/coaching-state.ts
+++ b/services/media-stream/coaching-state.ts
@@ -1,0 +1,46 @@
+import type { CoachingConfig } from "@/lib/coaching-schemas";
+import type { TranscriptSegmentRow } from "./db-writer";
+
+export type CoachingState = {
+  callSid: string;
+  workspaceId: string;
+  direction: string;
+  startTime: number;
+  config: CoachingConfig;
+  segments: TranscriptSegmentRow[];
+  wpmWindow: { words: number; ms: number };
+  fillerTotal: number;
+  pauseTotal: number;
+  longPauseTotal: number;
+  lastUtteranceEndMs: number;
+  lastCueAt: number;
+  outOfRangeStreak: number;
+};
+
+export function createCoachingState(args: {
+  callSid: string;
+  workspaceId: string;
+  direction: string;
+  config: CoachingConfig;
+}): CoachingState {
+  return {
+    callSid: args.callSid,
+    workspaceId: args.workspaceId,
+    direction: args.direction,
+    startTime: Date.now(),
+    config: args.config,
+    segments: [],
+    wpmWindow: { words: 0, ms: 0 },
+    fillerTotal: 0,
+    pauseTotal: 0,
+    longPauseTotal: 0,
+    lastUtteranceEndMs: 0,
+    lastCueAt: 0,
+    outOfRangeStreak: 0,
+  };
+}
+
+export function computeWpm(window: { words: number; ms: number }): number {
+  if (window.ms <= 0) return 0;
+  return Math.round((window.words / window.ms) * 60_000);
+}

--- a/services/media-stream/db-writer.ts
+++ b/services/media-stream/db-writer.ts
@@ -1,0 +1,118 @@
+import { transcript_segment, coaching_event, coaching_session } from "@/db/schema-transcription";
+import {
+  COACHING_EVENT_TYPES,
+  CoachingCueEventPayload,
+  CoachingMetricsEventPayload,
+  CoachingSessionFinalEventPayload,
+  TranscriptSegmentEventPayload,
+} from "@/lib/coaching-events.shared";
+import { insertWorkspaceEvent } from "@/lib/workspace-events.server";
+import { adminDb } from "@/server/admin-db";
+
+export type TranscriptSegmentInsert = typeof transcript_segment.$inferInsert;
+export type TranscriptSegmentRow = typeof transcript_segment.$inferSelect;
+export type CoachingEventInsert = typeof coaching_event.$inferInsert;
+export type CoachingEventRow = typeof coaching_event.$inferSelect;
+export type CoachingSessionInsert = typeof coaching_session.$inferInsert;
+export type CoachingSessionRow = typeof coaching_session.$inferSelect;
+
+export async function writeTranscriptSegment(
+  segment: TranscriptSegmentInsert,
+): Promise<TranscriptSegmentRow> {
+  const [row] = await adminDb.insert(transcript_segment).values(segment).returning();
+  if (!row) {
+    throw new Error("Failed to insert transcript segment");
+  }
+  return row;
+}
+
+export async function writeCoachingEvent(
+  event: CoachingEventInsert,
+): Promise<CoachingEventRow> {
+  const [row] = await adminDb.insert(coaching_event).values(event).returning();
+  if (!row) {
+    throw new Error("Failed to insert coaching event");
+  }
+  return row;
+}
+
+export async function writeCoachingSessionFinal(
+  session: CoachingSessionInsert,
+): Promise<CoachingSessionRow> {
+  const [row] = await adminDb
+    .insert(coaching_session)
+    .values(session)
+    .onConflictDoUpdate({
+      target: coaching_session.call_sid,
+      set: session,
+    })
+    .returning();
+  if (!row) {
+    throw new Error("Failed to upsert coaching session");
+  }
+  return row;
+}
+
+export async function publishTranscriptSegmentEvent(
+  workspaceId: string,
+  callSid: string,
+  segment: TranscriptSegmentRow,
+): Promise<void> {
+  const payload = TranscriptSegmentEventPayload.parse({
+    callSid,
+    segmentId: segment.id,
+    speaker: segment.speaker,
+    speakerLabel: segment.speaker_label,
+    text: segment.text,
+    startMs: segment.start_ms,
+    endMs: segment.end_ms,
+    fillerCount: segment.filler_count,
+  });
+  await insertWorkspaceEvent(workspaceId, COACHING_EVENT_TYPES.transcriptSegment, payload);
+}
+
+export async function publishCoachingMetricsEvent(
+  workspaceId: string,
+  callSid: string,
+  metrics: {
+    wpm: number;
+    fillerCount: number;
+    pauseCount: number;
+    longPauseCount: number;
+  },
+): Promise<void> {
+  const payload = CoachingMetricsEventPayload.parse({ callSid, ...metrics });
+  await insertWorkspaceEvent(workspaceId, COACHING_EVENT_TYPES.coachingMetrics, payload);
+}
+
+export async function publishCoachingCueEvent(
+  workspaceId: string,
+  callSid: string,
+  cue: {
+    eventId: string;
+    type: string;
+    severity: string;
+    heading: string;
+    suggestion: string;
+  },
+): Promise<void> {
+  const payload = CoachingCueEventPayload.parse({ callSid, ...cue });
+  await insertWorkspaceEvent(workspaceId, COACHING_EVENT_TYPES.coachingCue, payload);
+}
+
+export async function publishCoachingSessionFinalEvent(
+  workspaceId: string,
+  callSid: string,
+  session: {
+    sessionId: string;
+    wpmAvg: number;
+    fillerCount: number;
+    pauseCount: number;
+    longPauseCount: number;
+    score: number;
+    summary: string;
+  },
+): Promise<void> {
+  const payload = CoachingSessionFinalEventPayload.parse({ callSid, ...session });
+  await insertWorkspaceEvent(workspaceId, COACHING_EVENT_TYPES.coachingSessionFinal, payload);
+}

--- a/services/media-stream/elevenlabs-realtime-client.ts
+++ b/services/media-stream/elevenlabs-realtime-client.ts
@@ -1,0 +1,121 @@
+import type { ElevenLabsCommittedTranscriptMessage, ElevenLabsRealtimeEvent } from "./types";
+
+const ELEVENLABS_REALTIME_URL = "wss://api.elevenlabs.io/v1/speech-to-text/realtime";
+
+export type ElevenLabsCommittedCallback = (
+  event: ElevenLabsCommittedTranscriptMessage,
+) => void | Promise<void>;
+
+export interface ElevenLabsRealtimeStream {
+  send: (audio: Buffer) => void;
+  close: () => void;
+}
+
+export type ElevenLabsRealtimeClientDeps = {
+  apiKey?: string;
+  realtimeUrl?: string;
+  WebSocketImpl?: typeof WebSocket;
+};
+
+function buildElevenLabsRealtimeUrl(baseUrl: string): string {
+  const params = new URLSearchParams({
+    model_id: "scribe_v2_realtime",
+    audio_format: "ulaw_8000",
+    commit_strategy: "vad",
+    include_timestamps: "true",
+  });
+  return `${baseUrl}?${params.toString()}`;
+}
+
+/**
+ * Parses an ElevenLabs realtime WebSocket message payload.
+ * @throws Error when JSON is invalid.
+ */
+export function parseElevenLabsRealtimeMessage(raw: string): ElevenLabsRealtimeEvent {
+  return JSON.parse(raw) as ElevenLabsRealtimeEvent;
+}
+
+export function isCommittedTranscriptEvent(
+  event: ElevenLabsRealtimeEvent,
+): event is ElevenLabsCommittedTranscriptMessage {
+  return (
+    event.message_type === "committed_transcript_with_timestamps" &&
+    typeof event.text === "string" &&
+    event.text.trim().length > 0
+  );
+}
+
+/**
+ * Opens an ElevenLabs Scribe v2 realtime WebSocket (ulaw 8kHz, VAD commits).
+ * Returns null when ELEVENLABS_API_KEY is unset (local demos without transcription).
+ */
+export async function openElevenLabsRealtimeStream(
+  workspaceId: string,
+  onCommitted: ElevenLabsCommittedCallback,
+  deps: ElevenLabsRealtimeClientDeps = {},
+): Promise<ElevenLabsRealtimeStream | null> {
+  const apiKey = deps.apiKey ?? process.env.ELEVENLABS_API_KEY;
+  if (!apiKey) {
+    console.log(
+      JSON.stringify({
+        level: "warn",
+        message: "ELEVENLABS_API_KEY not set; skipping ElevenLabs STT stream",
+        workspaceId,
+      }),
+    );
+    return null;
+  }
+
+  const WebSocketImpl = deps.WebSocketImpl ?? WebSocket;
+  const url = buildElevenLabsRealtimeUrl(deps.realtimeUrl ?? ELEVENLABS_REALTIME_URL);
+  const ws = new WebSocketImpl(url, {
+    headers: { "xi-api-key": apiKey },
+  });
+
+  const stream: ElevenLabsRealtimeStream = {
+    send(audio: Buffer) {
+      if (ws.readyState === WebSocketImpl.OPEN) {
+        ws.send(
+          JSON.stringify({
+            message_type: "input_audio_chunk",
+            audio_base_64: audio.toString("base64"),
+            commit: false,
+            sample_rate: 8000,
+          }),
+        );
+      }
+    },
+    close() {
+      ws.close();
+    },
+  };
+
+  ws.addEventListener("message", (event) => {
+    void (async () => {
+      try {
+        const raw = typeof event.data === "string" ? event.data : String(event.data);
+        const data = parseElevenLabsRealtimeMessage(raw);
+        if (!isCommittedTranscriptEvent(data)) return;
+        await onCommitted(data);
+      } catch (err) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            message: "elevenlabs realtime parse error",
+            workspaceId,
+            err: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    ws.addEventListener("open", () => resolve());
+    ws.addEventListener("error", (event) => {
+      reject(event instanceof ErrorEvent ? event.error : new Error("ElevenLabs WebSocket error"));
+    });
+  });
+
+  return stream;
+}

--- a/services/media-stream/index.ts
+++ b/services/media-stream/index.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "node:crypto";
 import type { ServerWebSocket } from "bun";
-import { verifyMediaStreamToken, type MediaStreamTokenPayload } from "@/lib/media-stream-token.server";
+import {
+  verifyMediaStreamToken,
+  type MediaStreamTokenPayload,
+} from "@/lib/media-stream-token.server";
 import {
   captureException,
   initializeSentry,
 } from "@/lib/sentry.server";
+import { handleTwilioStreamMessage } from "./twilio-handler";
+import { isTwilioStreamMessage, type MediaStreamSocketData } from "./types";
 import {
   parseMediaStreamMaxPerWorkspace,
   WorkspaceStreamCapTracker,
@@ -16,7 +21,6 @@ const maxPerWorkspace = parseMediaStreamMaxPerWorkspace();
 const workspaceCaps = new WorkspaceStreamCapTracker(maxPerWorkspace);
 
 // Map of sessionId -> connected clients in that session.
-type MediaStreamSocketData = MediaStreamTokenPayload & { requestId: string };
 const sessions = new Map<string, Set<ServerWebSocket<MediaStreamSocketData>>>();
 
 function log(level: "info" | "error", message: string, meta?: Record<string, unknown>) {
@@ -145,8 +149,28 @@ const server = Bun.serve<MediaStreamSocketData>({
       const clients = sessions.get(sessionId);
       if (!clients) return;
 
-      // Passthrough/echo: forward every packet to the other clients in the session.
-      // TODO: Deepgram Nova-3 streaming integration for live transcription.
+      // Bun hands binary frames over as a Buffer (an ArrayBufferView), which
+      // TextDecoder accepts directly as a BufferSource — no cast needed.
+      const text = typeof message === "string" ? message : new TextDecoder().decode(message);
+
+      try {
+        const parsed: unknown = JSON.parse(text);
+        if (isTwilioStreamMessage(parsed)) {
+          void handleTwilioStreamMessage(ws, parsed).catch((error) => {
+            log("error", "Twilio stream handler failed", {
+              sessionId,
+              requestId: ws.data.requestId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            captureException(error, { sessionId, requestId: ws.data.requestId });
+          });
+          return;
+        }
+      } catch {
+        // Not JSON — fall through to agent passthrough.
+      }
+
+      // Passthrough: forward non-Twilio packets to other clients in the session.
       for (const client of clients) {
         if (client !== ws) {
           client.send(message);
@@ -155,6 +179,22 @@ const server = Bun.serve<MediaStreamSocketData>({
     },
     close(ws, code, reason) {
       const { sessionId, userId, workspaceId, requestId } = ws.data;
+
+      if (ws.data.twilio?.phase === "streaming") {
+        void handleTwilioStreamMessage(ws, {
+          event: "stop",
+          code,
+          reason: reason ? Buffer.from(reason).toString("utf-8") : undefined,
+        }).catch((error) => {
+          log("error", "Twilio stream stop handler failed", {
+            sessionId,
+            requestId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          captureException(error, { sessionId, requestId });
+        });
+      }
+
       workspaceCaps.release(workspaceId);
       log("info", "Client disconnected", {
         sessionId,

--- a/services/media-stream/twilio-handler.ts
+++ b/services/media-stream/twilio-handler.ts
@@ -1,0 +1,219 @@
+import {
+  isCommittedTranscriptEvent,
+  openElevenLabsRealtimeStream,
+} from "./elevenlabs-realtime-client";
+import { billLiveTranscription } from "./coaching-billing";
+import {
+  createCoachingState,
+  finalizeCoachingSession,
+  processUtterance,
+} from "./coaching-engine";
+import {
+  publishTranscriptSegmentEvent,
+  writeTranscriptSegment,
+  type TranscriptSegmentInsert,
+} from "./db-writer";
+import { loadWorkspaceMediaStreamConfig } from "./workspace-config";
+import type {
+  ElevenLabsCommittedTranscriptMessage,
+  ElevenLabsWord,
+  MediaStreamWebSocket,
+  TwilioStreamMessage,
+  TwilioStreamState,
+} from "./types";
+
+const DEFAULT_FILLER_WORDS = new Set(["uh", "um", "like", "you know", "basically", "actually"]);
+
+function log(level: "info" | "warn" | "error", message: string, meta?: Record<string, unknown>) {
+  console.log(JSON.stringify({ level, message, ...meta }));
+}
+
+function getOrInitTwilioState(ws: MediaStreamWebSocket): TwilioStreamState {
+  if (!ws.data.twilio) {
+    ws.data.twilio = { phase: "init" };
+  }
+  return ws.data.twilio;
+}
+
+export function countFillerWords(words: ElevenLabsWord[] | undefined): number {
+  if (!words?.length) return 0;
+  let count = 0;
+  for (const word of words) {
+    if (word.type !== "word") continue;
+    const normalized = word.text.toLowerCase().replace(/[.,!?]/g, "");
+    if (DEFAULT_FILLER_WORDS.has(normalized)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function speakerIndexFromId(speakerId: string | null | undefined): number {
+  if (!speakerId) return 0;
+  const match = /(\d+)/.exec(speakerId);
+  return match ? Number.parseInt(match[1]!, 10) : 0;
+}
+
+function speakerLabelFor(speaker: number): "agent" | "contact" {
+  return speaker === 0 ? "agent" : "contact";
+}
+
+function averageWordConfidence(words: ElevenLabsWord[] | undefined): number | null {
+  const wordRows = words?.filter((word) => word.type === "word" && typeof word.logprob === "number");
+  if (!wordRows?.length) return null;
+  const avgLogprob =
+    wordRows.reduce((sum, word) => sum + (word.logprob ?? 0), 0) / wordRows.length;
+  return Math.min(1, Math.max(0, Math.exp(avgLogprob)));
+}
+
+function buildTranscriptSegment(
+  callSid: string,
+  event: ElevenLabsCommittedTranscriptMessage,
+): TranscriptSegmentInsert {
+  const words = event.words?.filter((word) => word.type === "word") ?? [];
+  const speaker = speakerIndexFromId(words[0]?.speaker_id);
+  const startSec = words[0]?.start ?? 0;
+  const endSec = words[words.length - 1]?.end ?? startSec;
+
+  return {
+    call_sid: callSid,
+    speaker,
+    speaker_label: speakerLabelFor(speaker),
+    text: event.text,
+    start_ms: Math.round(startSec * 1000),
+    end_ms: Math.round(endSec * 1000),
+    confidence: averageWordConfidence(event.words),
+    filler_count: countFillerWords(event.words),
+    is_final: true,
+  };
+}
+
+async function handleCommittedTranscript(
+  ws: MediaStreamWebSocket,
+  state: TwilioStreamState,
+  event: ElevenLabsCommittedTranscriptMessage,
+): Promise<void> {
+  if (!state.callSid || !isCommittedTranscriptEvent(event)) return;
+
+  const segmentInput = buildTranscriptSegment(state.callSid, event);
+  const segment = await writeTranscriptSegment(segmentInput);
+  await publishTranscriptSegmentEvent(ws.data.workspaceId, state.callSid, segment);
+
+  if (state.coaching) {
+    await processUtterance(state.coaching, segment);
+  }
+
+  log("info", "transcript segment persisted", {
+    callSid: state.callSid,
+    workspaceId: ws.data.workspaceId,
+    segmentId: segment.id,
+    speaker: segment.speaker_label,
+  });
+}
+
+export async function handleTwilioStreamMessage(
+  ws: MediaStreamWebSocket,
+  msg: TwilioStreamMessage,
+): Promise<void> {
+  const state = getOrInitTwilioState(ws);
+
+  switch (msg.event) {
+    case "connected":
+      return;
+
+    case "start": {
+      const params = msg.start.customParameters ?? {};
+      const direction = params.direction ?? "outbound";
+
+      state.phase = "streaming";
+      state.streamSid = msg.start.streamSid ?? msg.streamSid;
+      state.callSid = msg.start.callSid;
+      state.direction = direction;
+      state.startTime = Date.now();
+
+      const workspaceConfig = await loadWorkspaceMediaStreamConfig(ws.data.workspaceId);
+      if (workspaceConfig.capabilities.runCoaching && state.callSid) {
+        state.coaching = createCoachingState({
+          callSid: state.callSid,
+          workspaceId: ws.data.workspaceId,
+          direction,
+          config: workspaceConfig.coachingConfig,
+        });
+      }
+
+      const stt = await openElevenLabsRealtimeStream(ws.data.workspaceId, async (event) => {
+        await handleCommittedTranscript(ws, state, event);
+      });
+
+      state.stt = stt;
+      // The STT clock — not the coaching clock — is what live transcription is
+      // billed on. Only set once the stream is actually open.
+      state.sttOpenedAt = stt ? Date.now() : null;
+
+      log("info", "twilio stream started", {
+        workspaceId: ws.data.workspaceId,
+        callSid: state.callSid,
+        streamSid: state.streamSid,
+        direction,
+        sttEnabled: stt !== null,
+        coachingEnabled: state.coaching != null,
+      });
+      return;
+    }
+
+    case "media": {
+      if (state.phase !== "streaming" || !state.stt) return;
+      const payload = msg.media.payload;
+      if (!payload) return;
+      const audio = Buffer.from(payload, "base64");
+      state.stt.send(audio);
+      return;
+    }
+
+    case "mark":
+      return;
+
+    case "stop": {
+      if (state.stt) {
+        state.stt.close();
+        state.stt = null;
+      }
+      if (state.coaching) {
+        await finalizeCoachingSession(state.coaching);
+        state.coaching = null;
+      }
+
+      // Live transcription follows the STT lifecycle, not coaching: bill
+      // whenever realtime STT actually opened, whether or not this workspace
+      // runs coaching. Clearing sttOpenedAt first makes a repeated stop a
+      // no-op on top of the key-level idempotency in the ledger.
+      const sttOpenedAt = state.sttOpenedAt ?? null;
+      state.sttOpenedAt = null;
+      let transcriptionCredits = 0;
+      if (sttOpenedAt !== null && state.callSid) {
+        const result = await billLiveTranscription({
+          workspaceId: ws.data.workspaceId,
+          callSid: state.callSid,
+          durationMs: Date.now() - sttOpenedAt,
+        });
+        transcriptionCredits = result.credits;
+      }
+
+      state.phase = "stopped";
+      log("info", "twilio stream stopped", {
+        workspaceId: ws.data.workspaceId,
+        callSid: state.callSid,
+        streamSid: state.streamSid,
+        code: msg.code,
+        reason: msg.reason,
+        transcriptionCredits,
+      });
+      return;
+    }
+
+    default: {
+      const _exhaustive: never = msg;
+      return _exhaustive;
+    }
+  }
+}

--- a/services/media-stream/types.ts
+++ b/services/media-stream/types.ts
@@ -1,0 +1,152 @@
+import type { ServerWebSocket } from "bun";
+import type { MediaStreamTokenPayload } from "@/lib/media-stream-token.server";
+import type { ElevenLabsRealtimeStream } from "./elevenlabs-realtime-client";
+
+/** Twilio Media Streams protocol events. */
+export type TwilioStreamEvent = "connected" | "start" | "media" | "stop" | "mark";
+
+export interface TwilioMediaFormat {
+  encoding: string;
+  sampleRate: number;
+  channels: number;
+}
+
+export interface TwilioStartPayload {
+  streamSid: string;
+  accountSid: string;
+  callSid: string;
+  tracks: string[];
+  mediaFormat: TwilioMediaFormat;
+  customParameters?: Record<string, string>;
+}
+
+export interface TwilioMediaPayload {
+  track: string;
+  chunk: string;
+  timestamp: string;
+  payload: string;
+}
+
+export interface TwilioStopPayload {
+  accountSid: string;
+  callSid: string;
+}
+
+export interface TwilioConnectedMessage {
+  event: "connected";
+  protocol?: string;
+  version?: string;
+}
+
+export interface TwilioStartMessage {
+  event: "start";
+  sequenceNumber?: string;
+  streamSid?: string;
+  start: TwilioStartPayload;
+}
+
+export interface TwilioMediaMessage {
+  event: "media";
+  sequenceNumber?: string;
+  streamSid?: string;
+  media: TwilioMediaPayload;
+}
+
+export interface TwilioStopMessage {
+  event: "stop";
+  sequenceNumber?: string;
+  streamSid?: string;
+  stop?: TwilioStopPayload;
+  code?: number;
+  reason?: string;
+}
+
+export interface TwilioMarkMessage {
+  event: "mark";
+  sequenceNumber?: string;
+  streamSid?: string;
+  mark?: { name: string };
+}
+
+export type TwilioStreamMessage =
+  | TwilioConnectedMessage
+  | TwilioStartMessage
+  | TwilioMediaMessage
+  | TwilioStopMessage
+  | TwilioMarkMessage;
+
+export type TwilioStreamPhase = "init" | "streaming" | "stopped";
+
+export interface TwilioStreamState {
+  phase: TwilioStreamPhase;
+  streamSid?: string;
+  callSid?: string;
+  direction?: string;
+  stt?: ElevenLabsRealtimeStream | null;
+  startTime?: number;
+  /**
+   * Epoch ms the realtime STT stream actually opened, and the clock the
+   * live-transcription debit is measured from. Cleared once billed so a
+   * repeated stop cannot re-enter the debit path.
+   */
+  sttOpenedAt?: number | null;
+  coaching?: import("./coaching-state").CoachingState | null;
+}
+
+export type MediaStreamSocketData = MediaStreamTokenPayload & {
+  requestId: string;
+  twilio?: TwilioStreamState;
+};
+
+export type MediaStreamWebSocket = ServerWebSocket<MediaStreamSocketData>;
+
+/** ElevenLabs Scribe v2 realtime WebSocket event shapes. */
+export interface ElevenLabsWord {
+  text: string;
+  start: number | null;
+  end: number | null;
+  type: "word" | "spacing" | "audio_event";
+  speaker_id?: string | null;
+  logprob?: number;
+}
+
+export interface ElevenLabsCommittedTranscriptMessage {
+  message_type: "committed_transcript" | "committed_transcript_with_timestamps";
+  text: string;
+  language_code?: string;
+  words?: ElevenLabsWord[];
+}
+
+export interface ElevenLabsPartialTranscriptMessage {
+  message_type: "partial_transcript";
+  text: string;
+}
+
+export interface ElevenLabsSessionStartedMessage {
+  message_type: "session_started";
+  session_id: string;
+}
+
+export interface ElevenLabsErrorMessage {
+  message_type: "error";
+  error: string;
+}
+
+export type ElevenLabsRealtimeEvent =
+  | ElevenLabsCommittedTranscriptMessage
+  | ElevenLabsPartialTranscriptMessage
+  | ElevenLabsSessionStartedMessage
+  | ElevenLabsErrorMessage
+  | { message_type: string; [key: string]: unknown };
+
+export function isTwilioStreamMessage(value: unknown): value is TwilioStreamMessage {
+  if (!value || typeof value !== "object") return false;
+  const event = (value as { event?: unknown }).event;
+  return (
+    event === "connected" ||
+    event === "start" ||
+    event === "media" ||
+    event === "stop" ||
+    event === "mark"
+  );
+}

--- a/services/media-stream/workspace-config.ts
+++ b/services/media-stream/workspace-config.ts
@@ -1,0 +1,41 @@
+import { eq } from "drizzle-orm";
+import { workspace } from "@/db/schema";
+import {
+  CoachingConfig,
+  DEFAULT_COACHING_CONFIG,
+  type CoachingConfig as CoachingConfigType,
+  type WorkspaceFeatureFlags,
+} from "@/lib/coaching-schemas";
+import {
+  liveMediaCapabilities,
+  type LiveMediaCapabilities,
+} from "@/lib/live-media-capabilities";
+import { adminDb } from "@/server/admin-db";
+
+export type WorkspaceMediaStreamConfig = {
+  featureFlags: WorkspaceFeatureFlags | Record<string, unknown>;
+  coachingConfig: CoachingConfigType;
+  /** Derived capabilities — consumers gate on these, never on the raw flags. */
+  capabilities: LiveMediaCapabilities;
+};
+
+export async function loadWorkspaceMediaStreamConfig(
+  workspaceId: string,
+): Promise<WorkspaceMediaStreamConfig> {
+  const row = await adminDb.query.workspace.findFirst({
+    where: eq(workspace.id, workspaceId),
+    columns: { feature_flags: true, coaching_config: true },
+  });
+
+  const featureFlags = (row?.feature_flags ?? {}) as WorkspaceFeatureFlags;
+  const coachingParsed = CoachingConfig.safeParse(row?.coaching_config ?? {});
+  const coachingConfig = coachingParsed.success
+    ? coachingParsed.data
+    : DEFAULT_COACHING_CONFIG;
+
+  return {
+    featureFlags,
+    coachingConfig,
+    capabilities: liveMediaCapabilities(featureFlags),
+  };
+}

--- a/services/tsconfig.json
+++ b/services/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["**/*.ts"],
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["bun"],
+    "jsx": "react-jsx"
+  }
+}

--- a/shared/billing-keys.ts
+++ b/shared/billing-keys.ts
@@ -7,7 +7,13 @@
  * (`categorizeLedgerRow`) classify rows through a single `bucketFromIdempotencyKey`.
  */
 
-export type BillingBucket = "sms" | "voice" | "numbers" | "purchase" | "other";
+export type BillingBucket =
+  | "sms"
+  | "voice"
+  | "numbers"
+  | "purchase"
+  | "ai"
+  | "other";
 
 const SMS_PREFIX = "sms:";
 const CALL_PREFIX = "call:";
@@ -16,6 +22,9 @@ const NUMBER_RENT_PURCHASE_PREFIX = "number_rent_purchase:";
 const STRIPE_EVT_PREFIX = "stripe_evt:";
 const STRIPE_SESSION_PREFIX = "stripe_session:";
 const WELCOME_CREDITS_PREFIX = "welcome-credits:";
+const TRANSCRIPTION_PREFIX = "transcription:";
+const TRANSCRIPTION_BATCH_PREFIX = "transcription_batch:";
+const COACHING_PREFIX = "coaching:";
 
 export function smsKey(sid: string): string {
   return `${SMS_PREFIX}${sid}`;
@@ -64,6 +73,31 @@ export function welcomeCreditsKey(workspaceId: string): string {
 }
 
 /**
+ * Realtime (live) speech-to-text for one call. Keyed on CallSid alone: one
+ * media stream per call, billed once from the STT clock on stream stop.
+ */
+export function liveTranscriptionKey(callSid: string): string {
+  return `${TRANSCRIPTION_PREFIX}${callSid}`;
+}
+
+/**
+ * Post-call batch transcription of the recording. Distinct namespace from
+ * {@link liveTranscriptionKey} — a call may be both live- and batch-transcribed,
+ * and the two are separate vendor charges.
+ */
+export function batchTranscriptionKey(callSid: string): string {
+  return `${TRANSCRIPTION_BATCH_PREFIX}${callSid}`;
+}
+
+/**
+ * One LLM-generated coaching cue. Keyed by the persisted `coaching_event` row id
+ * so each cue is charged exactly once; rule-based cues are not billed.
+ */
+export function coachingCueKey(callSid: string, eventId: string): string {
+  return `${COACHING_PREFIX}${callSid}:${eventId}`;
+}
+
+/**
  * Classify a ledger row into a billing bucket from its idempotency key prefix.
  * Consumed by both `getBillingEventSource` (app display) and
  * `categorizeLedgerRow` (shared reconciliation) so the two mappers no longer
@@ -80,6 +114,16 @@ export function bucketFromIdempotencyKey(
   }
   if (key.startsWith(STRIPE_EVT_PREFIX) || key.startsWith(STRIPE_SESSION_PREFIX)) {
     return "purchase";
+  }
+  // AI vendor pass-through (ElevenLabs STT, Cohere cues). Deliberately NOT
+  // "voice": the voice bucket is reconciled unit-for-unit against Twilio
+  // call minutes, and these charges have no Twilio usage record behind them.
+  if (
+    key.startsWith(TRANSCRIPTION_PREFIX) ||
+    key.startsWith(TRANSCRIPTION_BATCH_PREFIX) ||
+    key.startsWith(COACHING_PREFIX)
+  ) {
+    return "ai";
   }
   return "other";
 }

--- a/shared/billing-rates.ts
+++ b/shared/billing-rates.ts
@@ -1,0 +1,8 @@
+/** ElevenLabs Scribe v2 realtime: ~$0.0043/min → 0.43 credits/min at 1 credit = $0.01. */
+export const TRANSCRIPTION_RATE_CREDITS = 0.43;
+
+/** Cohere Command A coaching cue: ~$0.0001/cue → 0.1 credits. */
+export const COACHING_CUE_CREDITS = 0.1;
+
+/** ElevenLabs Scribe v2 batch: ~$0.005/call → 1 credit. */
+export const TRANSCRIPTION_BATCH_CREDITS = 1;

--- a/shared/billing-reconciliation.ts
+++ b/shared/billing-reconciliation.ts
@@ -1,13 +1,22 @@
 // Inline bucket classifier to avoid cross-file import incompatibility between Node (extensionless) and Deno (.ts extension).
 // Keep in sync with `shared/billing-keys.ts` `bucketFromIdempotencyKey`.
+type LedgerBucket = "sms" | "voice" | "numbers" | "purchase" | "ai" | "other";
+
 function bucketFromIdempotencyKey(
   idempotencyKey: string | null | undefined,
-): "sms" | "voice" | "numbers" | "purchase" | "other" {
+): LedgerBucket {
   const key = idempotencyKey?.trim() ?? "";
   if (key.startsWith("sms:")) return "sms";
   if (key.startsWith("call:")) return "voice";
   if (key.startsWith("number_rent:") || key.startsWith("number_rent_purchase:")) return "numbers";
   if (key.startsWith("stripe_evt:") || key.startsWith("stripe_session:")) return "purchase";
+  if (
+    key.startsWith("transcription:") ||
+    key.startsWith("transcription_batch:") ||
+    key.startsWith("coaching:")
+  ) {
+    return "ai";
+  }
   return "other";
 }
 
@@ -100,7 +109,7 @@ function sumTwilioCostUsd(
 }
 
 export function categorizeLedgerRow(row: LedgerTransactionRow): {
-  bucket: "sms" | "voice" | "numbers" | "purchase" | "other";
+  bucket: LedgerBucket;
   credits: number;
 } {
   const key = row.idempotency_key?.trim() ?? "";
@@ -131,6 +140,7 @@ export function summarizeLedger(rows: LedgerTransactionRow[]) {
     voice: { events: 0, credits: 0 },
     numbers: { events: 0, credits: 0 },
     purchase: { events: 0, credits: 0 },
+    ai: { events: 0, credits: 0 },
     other: { events: 0, credits: 0 },
   };
 
@@ -213,6 +223,7 @@ export function buildBillingReconciliationReport(args: {
       ledgerSummary.sms.credits +
       ledgerSummary.voice.credits +
       ledgerSummary.numbers.credits +
+      ledgerSummary.ai.credits +
       ledgerSummary.other.credits,
     ledgerCreditPurchases: ledgerSummary.purchase.credits,
     unrecognizedDebitEvents: ledgerSummary.other.events,

--- a/test/batch-transcription-gating.test.ts
+++ b/test/batch-transcription-gating.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { WorkspaceFeatureFlags } from "@/lib/coaching-schemas";
+import { batchTranscriptionKey } from "../shared/billing-keys";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const mocks = vi.hoisted(() => ({
+  workspaceFindFirst: vi.fn(),
+  callFindFirst: vi.fn(),
+  insertTransactionHistoryIdempotent: vi.fn(),
+  downloadObject: vi.fn(),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/server/admin-db", () => ({
+  adminDb: {
+    query: {
+      workspace: { findFirst: (...a: unknown[]) => mocks.workspaceFindFirst(...a) },
+      call: { findFirst: (...a: unknown[]) => mocks.callFindFirst(...a) },
+    },
+    insert: () => ({
+      values: () => ({
+        returning: async () => [{ id: "transcript-1" }],
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  },
+}));
+
+vi.mock("@/lib/transaction-history.server", () => ({
+  insertTransactionHistoryIdempotent: (...a: unknown[]) =>
+    mocks.insertTransactionHistoryIdempotent(...a),
+}));
+
+vi.mock("@/lib/object-storage.server", () => ({
+  downloadObject: (...a: unknown[]) => mocks.downloadObject(...a),
+}));
+
+vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
+
+describe("batchTranscription feature flag", () => {
+  test("defaults to false when absent — batch is off until product policy lands", () => {
+    expect(WorkspaceFeatureFlags.parse({}).batchTranscription).toBe(false);
+  });
+
+  test("is independent of the live transcription and coaching flags", () => {
+    const flags = WorkspaceFeatureFlags.parse({
+      liveTranscription: true,
+      liveCoaching: true,
+    });
+    expect(flags.batchTranscription).toBe(false);
+  });
+
+  test("can be turned on explicitly", () => {
+    expect(WorkspaceFeatureFlags.parse({ batchTranscription: true }).batchTranscription).toBe(true);
+  });
+});
+
+describe("elevenlabsBatchTranscribeHandler billing gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env.ELEVENLABS_API_KEY = "test-key";
+
+    mocks.callFindFirst.mockResolvedValue({
+      sid: "CA1",
+      workspace: "w1",
+      audio_url: "audio/CA1.mp3",
+      transcript_id: null,
+      recording_duration: "60",
+    });
+    mocks.downloadObject.mockResolvedValue(Buffer.from("audio"));
+    mocks.insertTransactionHistoryIdempotent.mockResolvedValue({ inserted: true });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ text: "hello world", language_code: "en", words: [] }),
+      }),
+    );
+  });
+
+  test("does not bill when batchTranscription is off (the default)", async () => {
+    mocks.workspaceFindFirst.mockResolvedValue({ feature_flags: {} });
+
+    const { elevenlabsBatchTranscribeHandler } = await import(
+      "@/lib/worker/handlers/elevenlabs-batch-transcribe.server"
+    );
+    const result = await elevenlabsBatchTranscribeHandler({
+      params: { callSid: "CA1" },
+    } as never);
+
+    expect(result).toMatchObject({ status: "completed" });
+    expect(mocks.insertTransactionHistoryIdempotent).not.toHaveBeenCalled();
+  });
+
+  test("bills with the canonical key once the flag is on", async () => {
+    mocks.workspaceFindFirst.mockResolvedValue({
+      feature_flags: { batchTranscription: true },
+    });
+
+    const { elevenlabsBatchTranscribeHandler } = await import(
+      "@/lib/worker/handlers/elevenlabs-batch-transcribe.server"
+    );
+    await elevenlabsBatchTranscribeHandler({ params: { callSid: "CA1" } } as never);
+
+    expect(mocks.insertTransactionHistoryIdempotent).toHaveBeenCalledTimes(1);
+    const args = mocks.insertTransactionHistoryIdempotent.mock.calls[0]?.[0] as {
+      idempotencyKey: string;
+      amount: number;
+    };
+    expect(args.idempotencyKey).toBe(batchTranscriptionKey("CA1"));
+    expect(args.amount).toBeLessThan(0);
+  });
+
+  test("isBatchTranscriptionEnabled is false for an unknown workspace", async () => {
+    mocks.workspaceFindFirst.mockResolvedValue(undefined);
+
+    const { isBatchTranscriptionEnabled } = await import(
+      "@/lib/worker/handlers/elevenlabs-batch-transcribe.server"
+    );
+    await expect(isBatchTranscriptionEnabled("missing")).resolves.toBe(false);
+  });
+});

--- a/test/billing-rates-coaching-engine.test.ts
+++ b/test/billing-rates-coaching-engine.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import {
+  COACHING_CUE_CREDITS,
+  TRANSCRIPTION_BATCH_CREDITS,
+  TRANSCRIPTION_RATE_CREDITS,
+} from "../shared/billing-rates";
+import { computeWpm, createCoachingState } from "../services/media-stream/coaching-state";
+
+describe("billing-rates", () => {
+  test("exports stable credit constants", () => {
+    expect(TRANSCRIPTION_RATE_CREDITS).toBe(0.43);
+    expect(COACHING_CUE_CREDITS).toBe(0.1);
+    expect(TRANSCRIPTION_BATCH_CREDITS).toBe(1);
+  });
+});
+
+describe("coaching-engine", () => {
+  test("createCoachingState initializes counters", () => {
+    const state = createCoachingState({
+      callSid: "CA123",
+      workspaceId: "ws-1",
+      direction: "outbound",
+      config: {
+        fillerWords: ["uh"],
+        wpmMin: 120,
+        wpmMax: 160,
+        pauseThresholdMs: 1500,
+        llmCadenceMs: 30_000,
+        llmPersona: "coach",
+        disclosureEnabled: false,
+      },
+    });
+    expect(state.fillerTotal).toBe(0);
+    expect(state.pauseTotal).toBe(0);
+  });
+
+  test("computeWpm derives words per minute from rolling window", () => {
+    expect(computeWpm({ words: 150, ms: 60_000 })).toBe(150);
+    expect(computeWpm({ words: 0, ms: 0 })).toBe(0);
+  });
+});

--- a/test/call-coaching-ack.server.test.ts
+++ b/test/call-coaching-ack.server.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? "postgres://test:test@localhost:5432/test";
+});
+
+const mocks = vi.hoisted(() => ({
+  createTenantDb: vi.fn(),
+  callFindFirst: vi.fn(),
+  cueFindFirst: vi.fn(),
+  requireWorkspaceAccess: vi.fn(),
+  update: vi.fn(),
+  set: vi.fn(),
+  where: vi.fn(),
+}));
+
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: mocks.createTenantDb,
+}));
+
+vi.mock("@/lib/workspace-membership.server", () => ({
+  requireWorkspaceAccess: mocks.requireWorkspaceAccess,
+}));
+
+vi.mock("@/server/admin-db", () => ({
+  adminDb: {
+    query: { coaching_event: { findFirst: mocks.cueFindFirst } },
+    update: mocks.update,
+  },
+}));
+
+const { acknowledgeCoachingCue } = await import("@/lib/call-coaching-ack.server");
+
+const user = { id: "user-1" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createTenantDb.mockReturnValue({ call: { findFirst: mocks.callFindFirst } });
+  mocks.callFindFirst.mockResolvedValue({ sid: "CA123" });
+  mocks.cueFindFirst.mockResolvedValue({ call_sid: "CA123" });
+  mocks.requireWorkspaceAccess.mockResolvedValue(undefined);
+  mocks.where.mockResolvedValue(undefined);
+  mocks.set.mockReturnValue({ where: mocks.where });
+  mocks.update.mockReturnValue({ set: mocks.set });
+});
+
+describe("acknowledgeCoachingCue", () => {
+  test("acks a cue for a workspace member and stamps acknowledged_at", async () => {
+    await expect(
+      acknowledgeCoachingCue({ user, workspaceId: "ws-1", coachingEventId: "evt-1" }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(mocks.update).toHaveBeenCalledTimes(1);
+    expect(mocks.set).toHaveBeenCalledWith(
+      expect.objectContaining({ acknowledged_at: expect.any(String) }),
+    );
+  });
+
+  test("any member role may ack — no role gate is imposed", async () => {
+    await acknowledgeCoachingCue({
+      user,
+      workspaceId: "ws-1",
+      coachingEventId: "evt-1",
+    });
+
+    // A `minRole` here would break the product decision that any member in any
+    // role can acknowledge any cue in their workspace.
+    expect(mocks.requireWorkspaceAccess).toHaveBeenCalledWith(
+      expect.not.objectContaining({ minRole: expect.anything() }),
+    );
+  });
+
+  test("gates on the tenant-scoped call, not an unscoped admin read", async () => {
+    await acknowledgeCoachingCue({
+      user,
+      workspaceId: "ws-1",
+      coachingEventId: "evt-1",
+    });
+
+    expect(mocks.createTenantDb).toHaveBeenCalledWith("ws-1");
+    expect(mocks.callFindFirst).toHaveBeenCalledTimes(1);
+  });
+
+  test("a cue whose call belongs to another workspace is 404 and writes nothing", async () => {
+    // The scoped `call` client filters by workspace, so a foreign call misses.
+    mocks.callFindFirst.mockResolvedValue(undefined);
+
+    await expect(
+      acknowledgeCoachingCue({
+        user,
+        workspaceId: "ws-1",
+        coachingEventId: "evt-foreign",
+      }),
+    ).resolves.toEqual({ ok: false, status: 404, error: "Coaching event not found" });
+
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("a non-member never reaches the cue row and writes nothing", async () => {
+    mocks.requireWorkspaceAccess.mockRejectedValue(
+      Object.assign(new Error("Workspace not found"), { status: 404 }),
+    );
+
+    await expect(
+      acknowledgeCoachingCue({ user, workspaceId: "ws-2", coachingEventId: "evt-1" }),
+    ).rejects.toThrow("Workspace not found");
+
+    // Authz precedes every transcription-table touch.
+    expect(mocks.cueFindFirst).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("an unknown cue id is 404 and writes nothing", async () => {
+    mocks.cueFindFirst.mockResolvedValue(undefined);
+
+    await expect(
+      acknowledgeCoachingCue({ user, workspaceId: "ws-1", coachingEventId: "nope" }),
+    ).resolves.toEqual({ ok: false, status: 404, error: "Coaching event not found" });
+
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("a missing coachingEventId is 400 and touches nothing", async () => {
+    await expect(
+      acknowledgeCoachingCue({ user, workspaceId: "ws-1", coachingEventId: undefined }),
+    ).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: "coachingEventId is required",
+    });
+
+    expect(mocks.requireWorkspaceAccess).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("a missing workspaceId is 400 and touches nothing", async () => {
+    await expect(
+      acknowledgeCoachingCue({ user, workspaceId: undefined, coachingEventId: "evt-1" }),
+    ).resolves.toEqual({ ok: false, status: 400, error: "workspaceId is required" });
+
+    expect(mocks.createTenantDb).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("reads only the call_sid pointer from the cue, never its payload", async () => {
+    await acknowledgeCoachingCue({
+      user,
+      workspaceId: "ws-1",
+      coachingEventId: "evt-1",
+    });
+
+    expect(mocks.cueFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ columns: { call_sid: true } }),
+    );
+  });
+});

--- a/test/call-coaching-hydration.server.test.ts
+++ b/test/call-coaching-hydration.server.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? "postgres://test:test@localhost:5432/test";
+});
+
+const mocks = vi.hoisted(() => ({
+  createTenantDb: vi.fn(),
+  callFindFirst: vi.fn(),
+  segmentFindMany: vi.fn(),
+  cueFindMany: vi.fn(),
+  sessionFindFirst: vi.fn(),
+}));
+
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: mocks.createTenantDb,
+}));
+
+vi.mock("@/server/admin-db", () => ({
+  adminDb: {
+    query: {
+      transcript_segment: { findMany: mocks.segmentFindMany },
+      coaching_event: { findMany: mocks.cueFindMany },
+      coaching_session: { findFirst: mocks.sessionFindFirst },
+    },
+  },
+}));
+
+const { getCallCoachingHydration, HYDRATION_SEGMENT_LIMIT, HYDRATION_CUE_LIMIT } =
+  await import("@/lib/call-coaching-hydration.server");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createTenantDb.mockReturnValue({ call: { findFirst: mocks.callFindFirst } });
+  mocks.callFindFirst.mockResolvedValue({ sid: "CA123" });
+  mocks.segmentFindMany.mockResolvedValue([]);
+  mocks.cueFindMany.mockResolvedValue([]);
+  mocks.sessionFindFirst.mockResolvedValue(undefined);
+});
+
+describe("getCallCoachingHydration", () => {
+  test("returns null without a callSid and touches no table", async () => {
+    await expect(getCallCoachingHydration("ws-1", null)).resolves.toBeNull();
+    await expect(getCallCoachingHydration("ws-1", undefined)).resolves.toBeNull();
+    expect(mocks.createTenantDb).not.toHaveBeenCalled();
+    expect(mocks.segmentFindMany).not.toHaveBeenCalled();
+  });
+
+  test("scopes the tenancy gate through createTenantDb for this workspace", async () => {
+    await getCallCoachingHydration("ws-1", "CA123");
+    expect(mocks.createTenantDb).toHaveBeenCalledWith("ws-1");
+  });
+
+  test("returns null and reads no transcript rows when the call is not in the workspace", async () => {
+    // The scoped `call` client filters by workspace, so a foreign sid misses.
+    mocks.callFindFirst.mockResolvedValue(undefined);
+
+    await expect(getCallCoachingHydration("ws-1", "CA-other")).resolves.toBeNull();
+    expect(mocks.segmentFindMany).not.toHaveBeenCalled();
+    expect(mocks.cueFindMany).not.toHaveBeenCalled();
+    expect(mocks.sessionFindFirst).not.toHaveBeenCalled();
+  });
+
+  test("bounds both list queries rather than fetching unbounded history", async () => {
+    await getCallCoachingHydration("ws-1", "CA123");
+
+    expect(mocks.segmentFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: HYDRATION_SEGMENT_LIMIT }),
+    );
+    expect(mocks.cueFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: HYDRATION_CUE_LIMIT }),
+    );
+    expect(HYDRATION_SEGMENT_LIMIT).toBeLessThanOrEqual(200);
+  });
+
+  test("maps rows to view shape and restores chronological order", async () => {
+    // Queried newest-first to bound the tail; the UI needs oldest-first.
+    mocks.segmentFindMany.mockResolvedValue([
+      {
+        id: "seg-2",
+        speaker: 1,
+        speaker_label: "contact",
+        text: "second",
+        start_ms: 500,
+        end_ms: 900,
+        filler_count: 2,
+      },
+      {
+        id: "seg-1",
+        speaker: 0,
+        speaker_label: null,
+        text: "first",
+        start_ms: 0,
+        end_ms: 400,
+        filler_count: null,
+      },
+    ]);
+
+    const result = await getCallCoachingHydration("ws-1", "CA123");
+
+    expect(result?.callSid).toBe("CA123");
+    expect(result?.segments).toEqual([
+      {
+        id: "seg-1",
+        speaker: 0,
+        speakerLabel: "speaker",
+        text: "first",
+        startMs: 0,
+        endMs: 400,
+        fillerCount: 0,
+      },
+      {
+        id: "seg-2",
+        speaker: 1,
+        speakerLabel: "contact",
+        text: "second",
+        startMs: 500,
+        endMs: 900,
+        fillerCount: 2,
+      },
+    ]);
+  });
+
+  test("derives cue heading/suggestion from the jsonb payload", async () => {
+    mocks.cueFindMany.mockResolvedValue([
+      {
+        id: "evt-1",
+        type: "pace",
+        severity: "warn",
+        payload: { heading: "Slow down", suggestion: "Breathe." },
+        acknowledged_at: "2026-07-15T00:00:00Z",
+      },
+    ]);
+
+    const result = await getCallCoachingHydration("ws-1", "CA123");
+
+    expect(result?.cues).toEqual([
+      {
+        eventId: "evt-1",
+        type: "pace",
+        severity: "warn",
+        heading: "Slow down",
+        suggestion: "Breathe.",
+        acknowledgedAt: "2026-07-15T00:00:00Z",
+      },
+    ]);
+  });
+
+  test("falls back to the cue type when the payload has no heading", async () => {
+    mocks.cueFindMany.mockResolvedValue([
+      { id: "evt-1", type: "filler", severity: null, payload: null, acknowledged_at: null },
+    ]);
+
+    const result = await getCallCoachingHydration("ws-1", "CA123");
+
+    expect(result?.cues[0]).toEqual({
+      eventId: "evt-1",
+      type: "filler",
+      severity: "info",
+      heading: "filler",
+      suggestion: "",
+      acknowledgedAt: undefined,
+    });
+  });
+
+  test("maps a finalised coaching session", async () => {
+    mocks.sessionFindFirst.mockResolvedValue({
+      wpm_avg: 140,
+      filler_count: 3,
+      pause_count: 4,
+      long_pause_count: 1,
+      score: 82,
+      summary: "Solid.",
+    });
+
+    const result = await getCallCoachingHydration("ws-1", "CA123");
+
+    expect(result?.session).toEqual({
+      wpmAvg: 140,
+      fillerCount: 3,
+      pauseCount: 4,
+      longPauseCount: 1,
+      score: 82,
+      summary: "Solid.",
+    });
+  });
+
+  test("coerces a session row of all-null metric columns to zeroes", async () => {
+    mocks.sessionFindFirst.mockResolvedValue({
+      wpm_avg: null,
+      filler_count: null,
+      pause_count: null,
+      long_pause_count: null,
+      score: null,
+      summary: null,
+    });
+
+    const result = await getCallCoachingHydration("ws-1", "CA123");
+    expect(result?.session).toEqual({
+      wpmAvg: 0,
+      fillerCount: 0,
+      pauseCount: 0,
+      longPauseCount: 0,
+      score: 0,
+      summary: "",
+    });
+  });
+
+  test("returns an empty-but-present hydration for a call with no transcript yet", async () => {
+    const result = await getCallCoachingHydration("ws-1", "CA123");
+    expect(result).toEqual({
+      callSid: "CA123",
+      segments: [],
+      metrics: null,
+      cues: [],
+      session: null,
+    });
+  });
+});

--- a/test/call-recording-storage.server.test.ts
+++ b/test/call-recording-storage.server.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const mocks = vi.hoisted(() => ({
+  uploadObject: vi.fn(async () => undefined),
+  loadWorkspaceTwilioCredentials: vi.fn(async () => ({
+    sid: "ACsub",
+    authToken: "secret",
+  })),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  fetch: vi.fn(),
+}));
+
+vi.mock("@/lib/object-storage.server", () => ({
+  uploadObject: (...args: unknown[]) => mocks.uploadObject(...args),
+}));
+
+vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
+
+vi.mock("@/server/admin-db", () => ({
+  adminDb: {
+    query: {
+      workspace: {
+        findFirst: vi.fn(),
+      },
+    },
+  },
+}));
+
+describe("call-recording-storage.server", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mocks.fetch);
+    mocks.fetch.mockResolvedValue(
+      new Response(Buffer.from("audio-bytes"), {
+        status: 200,
+        headers: { "Content-Type": "audio/mpeg" },
+      }),
+    );
+    mocks.uploadObject.mockResolvedValue(undefined);
+    mocks.loadWorkspaceTwilioCredentials.mockResolvedValue({
+      sid: "ACsub",
+      authToken: "secret",
+    });
+  });
+
+  test("callRecordingStoragePath uses workspace and call sid", async () => {
+    const { callRecordingStoragePath } = await import(
+      "@/lib/call-recording-storage.server"
+    );
+    expect(callRecordingStoragePath("w1", "CA123")).toBe(
+      "w1/recording-CA123.mp3",
+    );
+  });
+
+  test("fetchTwilioRecordingMp3 downloads with workspace basic auth", async () => {
+    const { fetchTwilioRecordingMp3 } = await import(
+      "@/lib/call-recording-storage.server"
+    );
+
+    const buffer = await fetchTwilioRecordingMp3(
+      "ACmain",
+      "RE1",
+      { sid: "ACsub", authToken: "secret" },
+      { fetch: mocks.fetch, maxAttempts: 1, baseDelayMs: 0 },
+    );
+
+    expect(buffer.toString()).toBe("audio-bytes");
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      "https://api.twilio.com/2010-04-01/Accounts/ACmain/Recordings/RE1.mp3",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: expect.stringMatching(/^Basic /),
+        }),
+      }),
+    );
+  });
+
+  test("fetchTwilioRecordingMp3 retries transient HTTP failures", async () => {
+    const { fetchTwilioRecordingMp3 } = await import(
+      "@/lib/call-recording-storage.server"
+    );
+
+    mocks.fetch
+      .mockResolvedValueOnce(new Response(null, { status: 503, statusText: "Unavailable" }))
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("ok"), {
+          status: 200,
+          headers: { "Content-Type": "audio/mpeg" },
+        }),
+      );
+
+    const buffer = await fetchTwilioRecordingMp3(
+      "ACmain",
+      "RE1",
+      { sid: "ACsub", authToken: "secret" },
+      { fetch: mocks.fetch, maxAttempts: 2, baseDelayMs: 0 },
+    );
+
+    expect(buffer.toString()).toBe("ok");
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+    expect(mocks.logger.warn).toHaveBeenCalled();
+  });
+
+  test("persistCallRecordingToStorage uploads and returns audio_url path", async () => {
+    const { persistCallRecordingToStorage } = await import(
+      "@/lib/call-recording-storage.server"
+    );
+
+    const result = await persistCallRecordingToStorage(
+      {
+        workspaceId: "w1",
+        callSid: "CA1",
+        accountSid: "ACmain",
+        recordingSid: "RE1",
+      },
+      {
+        fetch: mocks.fetch,
+        uploadObject: mocks.uploadObject,
+        loadCredentials: mocks.loadWorkspaceTwilioCredentials,
+        maxAttempts: 1,
+        baseDelayMs: 0,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      audioUrl: "w1/recording-CA1.mp3",
+      skipped: false,
+    });
+    expect(mocks.uploadObject).toHaveBeenCalledWith(
+      "workspaceAudio",
+      "w1/recording-CA1.mp3",
+      expect.any(Buffer),
+      expect.objectContaining({
+        contentType: "audio/mpeg",
+        upsert: true,
+      }),
+    );
+  });
+
+  test("persistCallRecordingToStorage skips when audio_url already set", async () => {
+    const { persistCallRecordingToStorage } = await import(
+      "@/lib/call-recording-storage.server"
+    );
+
+    const result = await persistCallRecordingToStorage(
+      {
+        workspaceId: "w1",
+        callSid: "CA1",
+        accountSid: "ACmain",
+        recordingSid: "RE1",
+        existingAudioUrl: "w1/recording-CA1.mp3",
+      },
+      {
+        fetch: mocks.fetch,
+        uploadObject: mocks.uploadObject,
+        loadCredentials: mocks.loadWorkspaceTwilioCredentials,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      audioUrl: "w1/recording-CA1.mp3",
+      skipped: true,
+      reason: "already_persisted",
+    });
+    expect(mocks.fetch).not.toHaveBeenCalled();
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+
+  test("persistCallRecordingToStorage returns download_failed without throwing", async () => {
+    const { persistCallRecordingToStorage } = await import(
+      "@/lib/call-recording-storage.server"
+    );
+
+    mocks.fetch.mockResolvedValue(
+      new Response(null, { status: 404, statusText: "Not Found" }),
+    );
+
+    const result = await persistCallRecordingToStorage(
+      {
+        workspaceId: "w1",
+        callSid: "CA1",
+        accountSid: "ACmain",
+        recordingSid: "RE1",
+      },
+      {
+        fetch: mocks.fetch,
+        uploadObject: mocks.uploadObject,
+        loadCredentials: mocks.loadWorkspaceTwilioCredentials,
+        maxAttempts: 1,
+        baseDelayMs: 0,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "download_failed",
+      error: expect.stringContaining("404"),
+    });
+    expect(mocks.uploadObject).not.toHaveBeenCalled();
+  });
+});

--- a/test/coaching-billing.test.ts
+++ b/test/coaching-billing.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  batchTranscriptionKey,
+  bucketFromIdempotencyKey,
+  coachingCueKey,
+  liveTranscriptionKey,
+} from "../shared/billing-keys";
+import { TRANSCRIPTION_RATE_CREDITS } from "../shared/billing-rates";
+
+const ledgerMocks = vi.hoisted(() => ({
+  insertTransactionHistoryIdempotent: vi.fn(),
+}));
+
+vi.mock("@/lib/transaction-history.server", () => ({
+  insertTransactionHistoryIdempotent: (...args: unknown[]) =>
+    ledgerMocks.insertTransactionHistoryIdempotent(...args),
+}));
+
+describe("billing key classification", () => {
+  test.each([
+    ["live transcription", liveTranscriptionKey("CA123"), "transcription:CA123"],
+    ["batch transcription", batchTranscriptionKey("CA123"), "transcription_batch:CA123"],
+    ["coaching cue", coachingCueKey("CA123", "evt-1"), "coaching:CA123:evt-1"],
+  ])("%s key has a stable shape", (_label, actual, expected) => {
+    expect(actual).toBe(expected);
+  });
+
+  test.each([
+    ["live transcription", liveTranscriptionKey("CA123")],
+    ["batch transcription", batchTranscriptionKey("CA123")],
+    ["coaching cue", coachingCueKey("CA123", "evt-1")],
+  ])("%s classifies into the ai bucket, not other", (_label, key) => {
+    expect(bucketFromIdempotencyKey(key)).toBe("ai");
+  });
+
+  test("ai keys do not leak into the voice bucket that is reconciled against Twilio", () => {
+    expect(bucketFromIdempotencyKey(liveTranscriptionKey("CA123"))).not.toBe("voice");
+    expect(bucketFromIdempotencyKey("call:CA123")).toBe("voice");
+  });
+
+  test("batch keys are not swallowed by the live transcription prefix", () => {
+    expect(batchTranscriptionKey("CA1").startsWith("transcription:")).toBe(false);
+    expect(liveTranscriptionKey("CA1")).not.toBe(batchTranscriptionKey("CA1"));
+  });
+
+  test("pre-existing buckets are unchanged", () => {
+    expect(bucketFromIdempotencyKey("sms:SM1")).toBe("sms");
+    expect(bucketFromIdempotencyKey("number_rent:1:2026-07")).toBe("numbers");
+    expect(bucketFromIdempotencyKey("stripe_evt:evt_1")).toBe("purchase");
+    expect(bucketFromIdempotencyKey("something-else")).toBe("other");
+    expect(bucketFromIdempotencyKey(null)).toBe("other");
+  });
+});
+
+describe("coaching-billing", () => {
+  beforeEach(() => {
+    ledgerMocks.insertTransactionHistoryIdempotent.mockReset();
+    ledgerMocks.insertTransactionHistoryIdempotent.mockResolvedValue({ inserted: true });
+  });
+
+  test("liveTranscriptionCredits rounds a partial minute up", async () => {
+    const { liveTranscriptionCredits } = await import(
+      "../services/media-stream/coaching-billing"
+    );
+    expect(liveTranscriptionCredits(60_000)).toBe(Math.ceil(TRANSCRIPTION_RATE_CREDITS));
+    expect(liveTranscriptionCredits(10 * 60_000)).toBe(Math.ceil(10 * TRANSCRIPTION_RATE_CREDITS));
+  });
+
+  test.each([
+    ["zero duration", 0],
+    ["negative duration", -5_000],
+    ["NaN duration", Number.NaN],
+  ])("%s bills nothing rather than a zero/negative debit", async (_label, durationMs) => {
+    const { billLiveTranscription } = await import(
+      "../services/media-stream/coaching-billing"
+    );
+
+    await expect(
+      billLiveTranscription({ workspaceId: "ws-1", callSid: "CA123", durationMs }),
+    ).resolves.toEqual({ billed: false, credits: 0 });
+    expect(ledgerMocks.insertTransactionHistoryIdempotent).not.toHaveBeenCalled();
+  });
+
+  test("live transcription debit is negative and uses the canonical key", async () => {
+    const { billLiveTranscription } = await import(
+      "../services/media-stream/coaching-billing"
+    );
+
+    await billLiveTranscription({
+      workspaceId: "ws-1",
+      callSid: "CA123",
+      durationMs: 5 * 60_000,
+    });
+
+    const args = ledgerMocks.insertTransactionHistoryIdempotent.mock.calls[0]?.[0] as {
+      amount: number;
+      idempotencyKey: string;
+      type: string;
+    };
+    expect(args.type).toBe("DEBIT");
+    expect(args.amount).toBeLessThan(0);
+    expect(args.idempotencyKey).toBe(liveTranscriptionKey("CA123"));
+  });
+
+  test("cue billing is keyed per coaching_event row so each cue charges once", async () => {
+    const { billCoachingCue } = await import("../services/media-stream/coaching-billing");
+
+    await billCoachingCue({ workspaceId: "ws-1", callSid: "CA123", eventId: "evt-1" });
+    await billCoachingCue({ workspaceId: "ws-1", callSid: "CA123", eventId: "evt-1" });
+    await billCoachingCue({ workspaceId: "ws-1", callSid: "CA123", eventId: "evt-2" });
+
+    const keys = ledgerMocks.insertTransactionHistoryIdempotent.mock.calls.map(
+      (call) => (call[0] as { idempotencyKey: string }).idempotencyKey,
+    );
+    // Two writes for evt-1 collapse on one key (the ledger RPC dedupes on it);
+    // a distinct cue gets a distinct key and is charged separately.
+    expect(keys).toEqual([
+      coachingCueKey("CA123", "evt-1"),
+      coachingCueKey("CA123", "evt-1"),
+      coachingCueKey("CA123", "evt-2"),
+    ]);
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  test("cue debit is negative", async () => {
+    const { billCoachingCue } = await import("../services/media-stream/coaching-billing");
+    await billCoachingCue({ workspaceId: "ws-1", callSid: "CA123", eventId: "evt-1" });
+
+    const args = ledgerMocks.insertTransactionHistoryIdempotent.mock.calls[0]?.[0] as {
+      amount: number;
+    };
+    expect(args.amount).toBeLessThan(0);
+  });
+});

--- a/test/coaching-events.shared.test.ts
+++ b/test/coaching-events.shared.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "vitest";
+import {
+  COACHING_EVENT_TYPES,
+  CoachingCueEventPayload,
+  CoachingMetricsEventPayload,
+  isCoachingEventType,
+  safeParseCoachingEvent,
+  TranscriptSegmentEventPayload,
+} from "@/lib/coaching-events.shared";
+
+describe("coaching event type literals", () => {
+  test("exports the four wire literals as a single source of truth", () => {
+    expect(Object.values(COACHING_EVENT_TYPES)).toEqual([
+      "transcript_segment",
+      "coaching_metrics",
+      "coaching_cue",
+      "coaching_session_final",
+    ]);
+  });
+
+  test("isCoachingEventType narrows only known types", () => {
+    expect(isCoachingEventType("coaching_cue")).toBe(true);
+    expect(isCoachingEventType("postgres_change")).toBe(false);
+  });
+});
+
+describe("safeParseCoachingEvent — success", () => {
+  test("parses a transcript_segment payload", () => {
+    const result = safeParseCoachingEvent("transcript_segment", {
+      callSid: "CA1",
+      segmentId: "seg-1",
+      speaker: 0,
+      speakerLabel: "agent",
+      text: "hello there",
+      startMs: 100,
+      endMs: 900,
+      fillerCount: 2,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.event.type).toBe("transcript_segment");
+    expect(result.event.payload).toMatchObject({
+      segmentId: "seg-1",
+      speakerLabel: "agent",
+      fillerCount: 2,
+    });
+  });
+
+  test("normalises the nullable columns the DB actually allows", () => {
+    const parsed = TranscriptSegmentEventPayload.parse({
+      callSid: "CA1",
+      segmentId: "seg-1",
+      speaker: 1,
+      speakerLabel: null,
+      text: "",
+      startMs: 0,
+      endMs: 0,
+      fillerCount: null,
+    });
+
+    expect(parsed.speakerLabel).toBe("speaker");
+    expect(parsed.fillerCount).toBe(0);
+  });
+
+  test("parses coaching_metrics, coaching_cue and coaching_session_final", () => {
+    expect(
+      safeParseCoachingEvent("coaching_metrics", {
+        callSid: "CA1",
+        wpm: 140,
+        fillerCount: 1,
+        pauseCount: 2,
+        longPauseCount: 0,
+      }).ok,
+    ).toBe(true);
+
+    expect(
+      safeParseCoachingEvent("coaching_cue", {
+        callSid: "CA1",
+        eventId: "evt-1",
+        type: "suggestion",
+        severity: "warn",
+        heading: "Slow down",
+        suggestion: "Try pausing.",
+      }).ok,
+    ).toBe(true);
+
+    expect(
+      safeParseCoachingEvent("coaching_session_final", {
+        callSid: "CA1",
+        sessionId: "sess-1",
+        wpmAvg: 130,
+        fillerCount: 3,
+        pauseCount: 4,
+        longPauseCount: 1,
+        score: 82,
+        summary: "Solid call.",
+      }).ok,
+    ).toBe(true);
+  });
+
+  test("cue severity falls back to info when the column is null", () => {
+    const parsed = CoachingCueEventPayload.parse({
+      callSid: "CA1",
+      eventId: "evt-1",
+      type: "filler",
+      severity: null,
+      heading: "h",
+      suggestion: "s",
+    });
+    expect(parsed.severity).toBe("info");
+    expect(parsed.acknowledgedAt).toBeUndefined();
+  });
+});
+
+describe("safeParseCoachingEvent — failure", () => {
+  test("flags an unknown event type without an error string", () => {
+    const result = safeParseCoachingEvent("postgres_change", { table: "call" });
+    expect(result).toEqual({ ok: false, unknownType: true });
+  });
+
+  test("rejects a coaching event with a wrong-typed field", () => {
+    const result = safeParseCoachingEvent("coaching_metrics", {
+      callSid: "CA1",
+      wpm: "fast",
+      fillerCount: 1,
+      pauseCount: 2,
+      longPauseCount: 0,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok || result.unknownType) throw new Error("expected a typed failure");
+    expect(result.error).toContain("wpm");
+  });
+
+  test("rejects a payload missing required identifiers", () => {
+    const result = safeParseCoachingEvent("transcript_segment", {
+      callSid: "CA1",
+      text: "hi",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok || result.unknownType) throw new Error("expected a typed failure");
+    expect(result.error).toContain("segmentId");
+  });
+
+  test("rejects an empty callSid rather than matching every call", () => {
+    const result = safeParseCoachingEvent("coaching_metrics", {
+      callSid: "",
+      wpm: 1,
+      fillerCount: 1,
+      pauseCount: 1,
+      longPauseCount: 1,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("never throws on hostile input", () => {
+    for (const bad of [null, undefined, 42, "string", [], { callSid: {} }]) {
+      expect(() => safeParseCoachingEvent("coaching_cue", bad)).not.toThrow();
+      expect(safeParseCoachingEvent("coaching_cue", bad).ok).toBe(false);
+    }
+  });
+
+  test("producer-side parse throws so a bad publisher fails loudly", () => {
+    expect(() =>
+      CoachingMetricsEventPayload.parse({ callSid: "CA1", wpm: 100 }),
+    ).toThrow();
+  });
+});

--- a/test/coaching-llm.test.ts
+++ b/test/coaching-llm.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { CoachingConfig } from "../app/lib/coaching-schemas";
+import { createCoachingState, type CoachingState } from "../services/media-stream/coaching-state";
+import {
+  generateCallSummary,
+  generateLlmCue,
+  parseLlmCue,
+} from "../services/media-stream/coaching-llm";
+import type { TranscriptSegmentRow } from "../services/media-stream/db-writer";
+
+const config: CoachingConfig = {
+  fillerWords: ["uh"],
+  wpmMin: 120,
+  wpmMax: 160,
+  pauseThresholdMs: 1500,
+  llmCadenceMs: 30_000,
+  llmPersona: "coach",
+  disclosureEnabled: false,
+};
+
+function stateWithSegments(): CoachingState {
+  const state = createCoachingState({
+    callSid: "CA123",
+    workspaceId: "ws-1",
+    direction: "outbound",
+    config,
+  });
+  state.segments.push({
+    id: "seg-1",
+    call_sid: "CA123",
+    speaker: 0,
+    speaker_label: "agent",
+    text: "hello there",
+    start_ms: 0,
+    end_ms: 1_000,
+    confidence: 0.9,
+    filler_count: 0,
+    is_final: true,
+    created_at: new Date().toISOString(),
+  } as TranscriptSegmentRow);
+  return state;
+}
+
+function cohereReplying(text: string) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ generations: [{ text }] }),
+  });
+}
+
+describe("parseLlmCue", () => {
+  test("accepts a well-formed cue", () => {
+    expect(parseLlmCue('{"heading":"Slow down","suggestion":"Take a breath."}')).toEqual({
+      type: "suggestion",
+      severity: "info",
+      payload: { heading: "Slow down", suggestion: "Take a breath." },
+      heading: "Slow down",
+      suggestion: "Take a breath.",
+    });
+  });
+
+  test.each([
+    ["malformed json", "not json at all"],
+    ["truncated json", '{"heading":"Slow down","sugg'],
+    ["missing suggestion", '{"heading":"Slow down"}'],
+    ["empty heading", '{"heading":"","suggestion":"Take a breath."}'],
+    ["wrong types", '{"heading":42,"suggestion":["a"]}'],
+    ["json but not an object", '"just a string"'],
+    ["empty string", ""],
+  ])("returns null and does not throw on %s", (_label, raw) => {
+    expect(() => parseLlmCue(raw)).not.toThrow();
+    expect(parseLlmCue(raw)).toBeNull();
+  });
+});
+
+describe("generateLlmCue", () => {
+  beforeEach(() => {
+    process.env.COHERE_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    delete process.env.COHERE_API_KEY;
+    vi.unstubAllGlobals();
+  });
+
+  test("returns a validated cue on a good response", async () => {
+    vi.stubGlobal("fetch", cohereReplying('{"heading":"Ask more","suggestion":"Try an open question."}'));
+    await expect(generateLlmCue(stateWithSegments())).resolves.toMatchObject({
+      type: "suggestion",
+      heading: "Ask more",
+    });
+  });
+
+  test("malformed LLM output is non-fatal", async () => {
+    vi.stubGlobal("fetch", cohereReplying("Sure! Here's a cue: be nicer."));
+    await expect(generateLlmCue(stateWithSegments())).resolves.toBeNull();
+  });
+
+  test("a thrown fetch is non-fatal", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    await expect(generateLlmCue(stateWithSegments())).resolves.toBeNull();
+  });
+
+  test("a non-ok response is non-fatal", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    await expect(generateLlmCue(stateWithSegments())).resolves.toBeNull();
+  });
+
+  test("an unexpected response envelope is non-fatal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ generations: "nope" }) }),
+    );
+    await expect(generateLlmCue(stateWithSegments())).resolves.toBeNull();
+  });
+
+  test("skips the call entirely without an API key", async () => {
+    delete process.env.COHERE_API_KEY;
+    const fetchMock = cohereReplying("{}");
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(generateLlmCue(stateWithSegments())).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("generateCallSummary", () => {
+  beforeEach(() => {
+    process.env.COHERE_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    delete process.env.COHERE_API_KEY;
+    vi.unstubAllGlobals();
+  });
+
+  test("returns the summary text", async () => {
+    vi.stubGlobal("fetch", cohereReplying("  Good call.  "));
+    await expect(generateCallSummary(stateWithSegments())).resolves.toBe("Good call.");
+  });
+
+  test("a thrown fetch is non-fatal and yields an empty summary", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("boom")));
+    await expect(generateCallSummary(stateWithSegments())).resolves.toBe("");
+  });
+});

--- a/test/coaching-rules.test.ts
+++ b/test/coaching-rules.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "vitest";
+import type { CoachingConfig } from "../app/lib/coaching-schemas";
+import { createCoachingState, type CoachingState } from "../services/media-stream/coaching-state";
+import {
+  computeScore,
+  evaluateUtterance,
+  extractFillers,
+} from "../services/media-stream/coaching-rules";
+import type { TranscriptSegmentRow } from "../services/media-stream/db-writer";
+
+// coaching-rules is pure by contract: no vi.mock of db-writer, no network stub,
+// no billing stub anywhere in this file. If a rule ever reaches for an effect,
+// this suite fails to run rather than silently passing against a mock.
+
+const config: CoachingConfig = {
+  fillerWords: ["uh", "um"],
+  wpmMin: 120,
+  wpmMax: 160,
+  pauseThresholdMs: 1500,
+  llmCadenceMs: 30_000,
+  llmPersona: "coach",
+  disclosureEnabled: false,
+};
+
+function state(overrides: Partial<CoachingState> = {}): CoachingState {
+  return {
+    ...createCoachingState({
+      callSid: "CA123",
+      workspaceId: "ws-1",
+      direction: "outbound",
+      config,
+    }),
+    ...overrides,
+  };
+}
+
+function segment(overrides: Partial<TranscriptSegmentRow> = {}): TranscriptSegmentRow {
+  return {
+    id: "seg-1",
+    call_sid: "CA123",
+    speaker: 0,
+    speaker_label: "agent",
+    text: "hello there friend",
+    start_ms: 0,
+    end_ms: 1_000,
+    confidence: 0.9,
+    filler_count: 0,
+    is_final: true,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  } as TranscriptSegmentRow;
+}
+
+describe("extractFillers", () => {
+  test("matches configured filler words case-insensitively", () => {
+    expect(extractFillers("Uh, well, UM okay", ["uh", "um"])).toEqual(["uh", "um"]);
+  });
+
+  test("returns empty when no fillers present", () => {
+    expect(extractFillers("clean sentence", ["uh", "um"])).toEqual([]);
+  });
+});
+
+describe("evaluateUtterance", () => {
+  test("does not mutate the input state", () => {
+    const before = state();
+    const snapshot = structuredClone({
+      segments: before.segments,
+      fillerTotal: before.fillerTotal,
+      pauseTotal: before.pauseTotal,
+      wpmWindow: before.wpmWindow,
+    });
+
+    evaluateUtterance(before, segment({ filler_count: 4 }), 0);
+
+    expect(before.segments).toEqual(snapshot.segments);
+    expect(before.fillerTotal).toBe(snapshot.fillerTotal);
+    expect(before.pauseTotal).toBe(snapshot.pauseTotal);
+    expect(before.wpmWindow).toEqual(snapshot.wpmWindow);
+  });
+
+  test("raises a filler_burst cue at three or more fillers", () => {
+    const { cues, next } = evaluateUtterance(state(), segment({ filler_count: 3, text: "uh um uh" }), 0);
+
+    const filler = cues.find((cue) => cue.type === "filler_burst");
+    expect(filler).toMatchObject({ severity: "warn", heading: "Filler burst" });
+    expect(next.fillerTotal).toBe(3);
+  });
+
+  test("does not raise a filler_burst cue below the threshold", () => {
+    const { cues } = evaluateUtterance(state(), segment({ filler_count: 2 }), 0);
+    expect(cues.map((cue) => cue.type)).not.toContain("filler_burst");
+  });
+
+  test("raises a pace cue only after three consecutive out-of-range utterances", () => {
+    // 3 words over 1s => 180 wpm, above wpmMax of 160.
+    const fast = segment({ text: "one two three", start_ms: 0, end_ms: 1_000 });
+
+    const first = evaluateUtterance(state(), fast, 0);
+    expect(first.cues.map((cue) => cue.type)).not.toContain("pace");
+    expect(first.next.outOfRangeStreak).toBe(1);
+
+    const second = evaluateUtterance(state({ outOfRangeStreak: 1 }), fast, 0);
+    expect(second.cues.map((cue) => cue.type)).not.toContain("pace");
+
+    const third = evaluateUtterance(state({ outOfRangeStreak: 2 }), fast, 0);
+    const pace = third.cues.find((cue) => cue.type === "pace");
+    expect(pace).toMatchObject({ heading: "Slow down" });
+    expect(third.next.outOfRangeStreak).toBe(0);
+  });
+
+  test("raises a long pause cue past twice the pause threshold", () => {
+    const { cues, next } = evaluateUtterance(
+      state({ lastUtteranceEndMs: 1_000 }),
+      segment({ start_ms: 6_000, end_ms: 7_000 }),
+      0,
+    );
+
+    const pause = cues.find((cue) => cue.type === "pause");
+    expect(pause).toMatchObject({ severity: "warn", heading: "Long pause" });
+    expect(next.longPauseTotal).toBe(1);
+    expect(next.pauseTotal).toBe(1);
+  });
+
+  test("reports metrics including the current segment's fillers", () => {
+    const { metrics } = evaluateUtterance(
+      state({ fillerTotal: 2 }),
+      segment({ filler_count: 1 }),
+      0,
+    );
+    expect(metrics.fillerCount).toBe(3);
+  });
+
+  test("flags llmCueDue only once the cadence has elapsed", () => {
+    const base = state({ lastCueAt: 10_000 });
+
+    expect(evaluateUtterance(base, segment(), 20_000).llmCueDue).toBe(false);
+    expect(evaluateUtterance(base, segment(), 40_000).llmCueDue).toBe(true);
+    expect(evaluateUtterance(base, segment(), 40_000).next.lastCueAt).toBe(40_000);
+  });
+});
+
+describe("computeScore", () => {
+  test("a flawless session scores 100 — no hardcoded ceiling", () => {
+    const perfect = state({
+      wpmWindow: { words: 140, ms: 60_000 },
+      fillerTotal: 0,
+      longPauseTotal: 0,
+    });
+    expect(computeScore(perfect)).toBe(100);
+  });
+
+  test("a worst-case session scores below the old hardcoded floor of 15", () => {
+    const worst = state({
+      wpmWindow: { words: 400, ms: 60_000 },
+      fillerTotal: 40,
+      longPauseTotal: 20,
+    });
+    // pace 60 only; filler and pause both clamp to 0 => 60 * .25 / .8 = 18.75.
+    expect(computeScore(worst)).toBe(19);
+  });
+
+  test("weights are renormalized over the three real signals", () => {
+    const s = state({
+      wpmWindow: { words: 140, ms: 60_000 },
+      fillerTotal: 4,
+      longPauseTotal: 2,
+    });
+    // pace 100, filler 80, pause 80 => (25 + 24 + 20) / 0.8 = 86.25.
+    expect(computeScore(s)).toBe(86);
+  });
+});

--- a/test/data-plane-role-gate.test.ts
+++ b/test/data-plane-role-gate.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/database/workspace.server", () => ({
 
 vi.mock("@/server/tenant-db", () => ({ createTenantDb: vi.fn(() => ({})) }));
 
-// getContactWorkspaceId / getCampaignWorkspaceId both resolve to "w1".
+// resolveResourceWorkspaceId for contact/campaign both resolve to "w1".
 vi.mock("@/server/db", () => ({
   db: {
     select: () => ({
@@ -44,7 +44,7 @@ vi.mock("@/server/db", () => ({
   },
 }));
 
-// Keep the REAL authForContact / authForCampaign (the gate under test); stub the
+// Keep the REAL authForResource (the gate under test); stub the
 // downstream mutation handlers so we can assert whether they were reached.
 vi.mock("@/lib/platform-data.server", async (importOriginal) => {
   const actual =
@@ -77,20 +77,21 @@ function allowAccess() {
   mocks.requireWorkspaceAccess.mockResolvedValue(undefined);
 }
 
-describe("data-plane mutation role gate (authForContact / authForCampaign)", () => {
+describe("data-plane mutation role gate (authForResource)", () => {
   beforeEach(() => {
     for (const fn of Object.values(mocks)) {
       (fn as { mockReset?: () => void }).mockReset?.();
     }
   });
 
-  test("authForContact('member') returns 403 for a below-member caller", async () => {
+  test("authForResource('contact', 'member') returns 403 for a below-member caller", async () => {
     asSessionUser("u-caller");
     forbidBelowMember();
-    const { authForContact } = await import("@/lib/platform-data.server");
+    const { authForResource } = await import("@/lib/platform-data.server");
 
-    const result = await authForContact(
+    const result = await authForResource(
       new Request("http://x/api/contacts/5", { method: "DELETE" }),
+      "contact",
       "5",
       "member",
     );
@@ -103,13 +104,14 @@ describe("data-plane mutation role gate (authForContact / authForCampaign)", () 
     );
   });
 
-  test("authForContact('member') resolves context for a member", async () => {
+  test("authForResource('contact', 'member') resolves context for a member", async () => {
     asSessionUser("u-member");
     allowAccess();
-    const { authForContact } = await import("@/lib/platform-data.server");
+    const { authForResource } = await import("@/lib/platform-data.server");
 
-    const result = await authForContact(
+    const result = await authForResource(
       new Request("http://x/api/contacts/5", { method: "DELETE" }),
+      "contact",
       "5",
       "member",
     );
@@ -118,13 +120,14 @@ describe("data-plane mutation role gate (authForContact / authForCampaign)", () 
     expect(result).toEqual({ userId: "u-member", workspaceId: "w1" });
   });
 
-  test("authForContact read path (no minRole) stays open to callers", async () => {
+  test("authForResource('contact') read path (no minRole) stays open to callers", async () => {
     asSessionUser("u-caller");
     allowAccess();
-    const { authForContact } = await import("@/lib/platform-data.server");
+    const { authForResource } = await import("@/lib/platform-data.server");
 
-    const result = await authForContact(
+    const result = await authForResource(
       new Request("http://x/api/contacts/5"),
+      "contact",
       "5",
     );
 
@@ -135,13 +138,14 @@ describe("data-plane mutation role gate (authForContact / authForCampaign)", () 
     );
   });
 
-  test("authForCampaign('member') returns 403 for a below-member caller", async () => {
+  test("authForResource('campaign', 'member') returns 403 for a below-member caller", async () => {
     asSessionUser("u-caller");
     forbidBelowMember();
-    const { authForCampaign } = await import("@/lib/platform-data.server");
+    const { authForResource } = await import("@/lib/platform-data.server");
 
-    const result = await authForCampaign(
+    const result = await authForResource(
       new Request("http://x/api/campaigns/9", { method: "POST" }),
+      "campaign",
       "9",
       "member",
     );
@@ -150,13 +154,14 @@ describe("data-plane mutation role gate (authForContact / authForCampaign)", () 
     expect((result as Response).status).toBe(403);
   });
 
-  test("authForCampaign('member') resolves context for a member", async () => {
+  test("authForResource('campaign', 'member') resolves context for a member", async () => {
     asSessionUser("u-member");
     allowAccess();
-    const { authForCampaign } = await import("@/lib/platform-data.server");
+    const { authForResource } = await import("@/lib/platform-data.server");
 
-    const result = await authForCampaign(
+    const result = await authForResource(
       new Request("http://x/api/campaigns/9", { method: "POST" }),
+      "campaign",
       "9",
       "member",
     );
@@ -169,10 +174,11 @@ describe("data-plane mutation role gate (authForContact / authForCampaign)", () 
       authType: "api_key",
       workspaceId: "w1",
     });
-    const { authForContact } = await import("@/lib/platform-data.server");
+    const { authForResource } = await import("@/lib/platform-data.server");
 
-    const result = await authForContact(
+    const result = await authForResource(
       new Request("http://x/api/contacts/5", { method: "DELETE" }),
+      "contact",
       "5",
       "member",
     );

--- a/test/db-campaign.server.test.ts
+++ b/test/db-campaign.server.test.ts
@@ -533,8 +533,9 @@ describe("app/lib/database/campaign.server.ts", () => {
 
     queueSearchMocks.countDialableCampaignQueueRows.mockResolvedValueOnce(10);
     queueSearchMocks.countDialableQueuedCampaignQueueRows.mockResolvedValueOnce(3);
+    queueSearchMocks.countDialableCompletedCampaignQueueRows.mockResolvedValueOnce(7);
     const ok = await mod.fetchQueueCounts({ workspaceId: "w1", campaignId: "1" });
-    expect(ok).toEqual({ fullCount: 10, queuedCount: 3 });
+    expect(ok).toEqual({ fullCount: 10, queuedCount: 3, completedCount: 7 });
   });
 
   test("fetchCampaignAudience returns data and throws for any query error", async () => {

--- a/test/feature-flags.test.ts
+++ b/test/feature-flags.test.ts
@@ -1,11 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 import {
   CoachingConfig,
   WorkspaceFeatureFlags,
   TranscriptMetadata,
   CoachingEventPayload,
 } from "@/lib/coaching-schemas";
-import { coachingEnabled, hasFeatureFlag } from "@/lib/feature-flags";
+import { hasFeatureFlag } from "@/lib/feature-flags";
+import { liveMediaCapabilities } from "@/lib/live-media-capabilities";
 
 describe("coaching-schemas", () => {
   test("WorkspaceFeatureFlags defaults", () => {
@@ -31,10 +32,61 @@ describe("coaching-schemas", () => {
 });
 
 describe("feature-flags", () => {
-  test("hasFeatureFlag / coachingEnabled", () => {
+  test("hasFeatureFlag", () => {
     expect(hasFeatureFlag(null, "liveTranscription")).toBe(false);
     expect(hasFeatureFlag({ liveTranscription: true }, "liveTranscription")).toBe(true);
-    expect(coachingEnabled({ liveCoaching: true })).toBe(true);
-    expect(coachingEnabled({})).toBe(false);
+    expect(hasFeatureFlag({}, "liveCoaching")).toBe(false);
+  });
+});
+
+describe("liveMediaCapabilities", () => {
+  test("neither flag: nothing runs", () => {
+    expect(liveMediaCapabilities({})).toEqual({
+      attachStream: false,
+      runCoaching: false,
+      showTranscript: false,
+      showCoaching: false,
+    });
+  });
+
+  test("transcription only: stream + transcript UI, no coaching", () => {
+    expect(liveMediaCapabilities({ liveTranscription: true })).toEqual({
+      attachStream: true,
+      runCoaching: false,
+      showTranscript: true,
+      showCoaching: false,
+    });
+  });
+
+  test("coaching only: stream attaches (STT is coaching's input), transcript UI stays off", () => {
+    expect(liveMediaCapabilities({ liveCoaching: true })).toEqual({
+      attachStream: true,
+      runCoaching: true,
+      showTranscript: false,
+      showCoaching: true,
+    });
+  });
+
+  test("both flags: everything on", () => {
+    expect(
+      liveMediaCapabilities({ liveTranscription: true, liveCoaching: true }),
+    ).toEqual({
+      attachStream: true,
+      runCoaching: true,
+      showTranscript: true,
+      showCoaching: true,
+    });
+  });
+
+  test("null / undefined / garbage flags default to everything off", () => {
+    const off = {
+      attachStream: false,
+      runCoaching: false,
+      showTranscript: false,
+      showCoaching: false,
+    };
+    expect(liveMediaCapabilities(null)).toEqual(off);
+    expect(liveMediaCapabilities(undefined)).toEqual(off);
+    expect(liveMediaCapabilities({ liveCoaching: "yes" })).toEqual(off);
   });
 });

--- a/test/ivr-block-response.route.test.ts
+++ b/test/ivr-block-response.route.test.ts
@@ -39,6 +39,15 @@ const ivrTestState = vi.hoisted(() => ({
   campaignError: null as Error | null,
   outreachResult: {} as unknown,
   outreachError: null as Error | null,
+  contactUpdate: vi.fn(),
+}));
+
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: () => ({
+    contact: {
+      update: (...args: unknown[]) => ivrTestState.contactUpdate(...args),
+    },
+  }),
 }));
 
 vi.mock("@/lib/campaign-ivr.server", async (importOriginal) => {
@@ -150,6 +159,7 @@ describe("app/routes/api+/ivr/route.$campaignId.$pageId.$blockId.response.tsx", 
     ivrTestState.campaignError = null;
     ivrTestState.outreachResult = {};
     ivrTestState.outreachError = null;
+    ivrTestState.contactUpdate.mockReset();
     configureTelephonyStub();
     mocks.createClient.mockReset();
     mocks.requireTwilioSignature.mockReset();
@@ -388,6 +398,44 @@ describe("app/routes/api+/ivr/route.$campaignId.$pageId.$blockId.response.tsx", 
       request: makeReq({ CallSid: "CA1", Digits: "1" }),
     } as any);
     expect(await res.text()).toContain("An error occurred. Please try again later.");
+  });
+
+  test("writes typed outreach columns and syncs contact.support_level cache", async () => {
+    const script = {
+      pages: { page_1: { blocks: ["b1"] } },
+      blocks: {
+        b1: { id: "b1", title: "Support Level", options: [{ value: "2", next: "hangup" }] },
+      },
+    };
+    const campaignData = { script: { steps: script } };
+    mocks.createClient.mockReturnValueOnce(
+      makeDbClient({
+        call: { sid: "CA1", workspace: "w1", outreach_attempt_id: 9, contact_id: 42 },
+        campaignData,
+        outreachResult: {},
+      }),
+    );
+    const mod = await import("../app/routes/api+/ivr/$campaignId/$pageId/$blockId/response.route");
+    const res = await mod.action({
+      params: { campaignId: "1", pageId: "page_1", blockId: "b1" },
+      request: makeReq({ CallSid: "CA1", Digits: "2" }),
+    } as any);
+    expect(await res.text()).toContain("hangup");
+    expect(telephonyDbMocks.updateOutreachAttemptForWorkspace).toHaveBeenCalledWith(
+      "w1",
+      9,
+      expect.objectContaining({
+        support_level: 2,
+        result: expect.objectContaining({
+          page_1: expect.objectContaining({ "Support Level": "2" }),
+        }),
+      }),
+      expect.objectContaining({ tdb: expect.anything() }),
+    );
+    expect(ivrTestState.contactUpdate).toHaveBeenCalledWith({
+      set: { support_level: 2 },
+      where: expect.anything(),
+    });
   });
 
   test("returns hangup when campaign_id mismatches URL or call is missing", async () => {

--- a/test/media-stream-elevenlabs-realtime-client.test.ts
+++ b/test/media-stream-elevenlabs-realtime-client.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  isCommittedTranscriptEvent,
+  openElevenLabsRealtimeStream,
+  parseElevenLabsRealtimeMessage,
+} from "../services/media-stream/elevenlabs-realtime-client";
+
+describe("elevenlabs-realtime-client", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("parseElevenLabsRealtimeMessage parses committed transcript payload", () => {
+    const raw = JSON.stringify({
+      message_type: "committed_transcript_with_timestamps",
+      text: "Hello there",
+      words: [
+        { text: "Hello", start: 0.1, end: 0.4, type: "word", speaker_id: "speaker_0", logprob: -0.1 },
+        { text: "there", start: 0.5, end: 0.9, type: "word", speaker_id: "speaker_0", logprob: -0.2 },
+      ],
+    });
+
+    const result = parseElevenLabsRealtimeMessage(raw);
+    expect(result.message_type).toBe("committed_transcript_with_timestamps");
+    expect(result.text).toBe("Hello there");
+  });
+
+  test("isCommittedTranscriptEvent requires non-empty timestamped transcript", () => {
+    expect(
+      isCommittedTranscriptEvent({
+        message_type: "committed_transcript_with_timestamps",
+        text: "Hi",
+      }),
+    ).toBe(true);
+
+    expect(
+      isCommittedTranscriptEvent({
+        message_type: "committed_transcript_with_timestamps",
+        text: "   ",
+      }),
+    ).toBe(false);
+
+    expect(
+      isCommittedTranscriptEvent({
+        message_type: "committed_transcript",
+        text: "ignored without timestamps",
+      }),
+    ).toBe(false);
+  });
+
+  test("openElevenLabsRealtimeStream returns null without API key", async () => {
+    const warnSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const stream = await openElevenLabsRealtimeStream("ws-1", vi.fn(), { apiKey: "" });
+    expect(stream).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test("openElevenLabsRealtimeStream forwards committed transcripts to callback", async () => {
+    type WsListener = (event: { data: string }) => void;
+
+    class MockWebSocket {
+      static OPEN = 1;
+      readyState = MockWebSocket.OPEN;
+      private listeners = new Map<string, WsListener[]>();
+
+      constructor(
+        _url: string,
+        _options?: { headers?: Record<string, string> },
+      ) {
+        queueMicrotask(() => {
+          this.emit("open", {});
+          this.emit("message", {
+            data: JSON.stringify({
+              message_type: "committed_transcript_with_timestamps",
+              text: "Test utterance",
+              words: [
+                {
+                  text: "test",
+                  start: 0,
+                  end: 0.5,
+                  type: "word",
+                  speaker_id: "speaker_1",
+                  logprob: -0.1,
+                },
+              ],
+            }),
+          });
+        });
+      }
+
+      addEventListener(type: string, listener: WsListener) {
+        const bucket = this.listeners.get(type) ?? [];
+        bucket.push(listener);
+        this.listeners.set(type, bucket);
+      }
+
+      send(_data: unknown) {}
+
+      close() {}
+
+      private emit(type: string, event: { data: string }) {
+        for (const listener of this.listeners.get(type) ?? []) {
+          listener(event);
+        }
+      }
+    }
+
+    const onCommitted = vi.fn();
+    const stream = await openElevenLabsRealtimeStream("ws-1", onCommitted, {
+      apiKey: "test-key",
+      WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+    });
+
+    expect(stream).not.toBeNull();
+    await vi.waitFor(() => expect(onCommitted).toHaveBeenCalledTimes(1));
+    expect(onCommitted.mock.calls[0]?.[0]?.text).toBe("Test utterance");
+
+    stream?.close();
+  });
+});

--- a/test/media-stream-transcription-billing.test.ts
+++ b/test/media-stream-transcription-billing.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { liveTranscriptionKey } from "../shared/billing-keys";
+import type { MediaStreamSocketData } from "../services/media-stream/types";
+
+const sttMocks = vi.hoisted(() => ({
+  openElevenLabsRealtimeStream: vi.fn(),
+}));
+
+const workspaceConfigMocks = vi.hoisted(() => ({
+  loadWorkspaceMediaStreamConfig: vi.fn(),
+}));
+
+const dbWriterMocks = vi.hoisted(() => ({
+  writeTranscriptSegment: vi.fn(),
+  publishTranscriptSegmentEvent: vi.fn(),
+}));
+
+const coachingEngineMocks = vi.hoisted(() => ({
+  createCoachingState: vi.fn(),
+  processUtterance: vi.fn(),
+  finalizeCoachingSession: vi.fn(),
+}));
+
+const ledgerMocks = vi.hoisted(() => ({
+  insertTransactionHistoryIdempotent: vi.fn(),
+}));
+
+vi.mock("../services/media-stream/elevenlabs-realtime-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../services/media-stream/elevenlabs-realtime-client")>();
+  return {
+    ...actual,
+    openElevenLabsRealtimeStream: sttMocks.openElevenLabsRealtimeStream,
+  };
+});
+
+vi.mock("../services/media-stream/db-writer", () => ({
+  writeTranscriptSegment: (...args: unknown[]) => dbWriterMocks.writeTranscriptSegment(...args),
+  publishTranscriptSegmentEvent: (...args: unknown[]) =>
+    dbWriterMocks.publishTranscriptSegmentEvent(...args),
+}));
+
+vi.mock("../services/media-stream/workspace-config", () => ({
+  loadWorkspaceMediaStreamConfig: (...args: unknown[]) =>
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig(...args),
+}));
+
+vi.mock("../services/media-stream/coaching-engine", () => ({
+  createCoachingState: (...args: unknown[]) => coachingEngineMocks.createCoachingState(...args),
+  processUtterance: (...args: unknown[]) => coachingEngineMocks.processUtterance(...args),
+  finalizeCoachingSession: (...args: unknown[]) =>
+    coachingEngineMocks.finalizeCoachingSession(...args),
+}));
+
+// coaching-billing is NOT mocked — the real debit helper runs against a mocked
+// ledger, so these tests exercise the actual key and amount the service writes.
+vi.mock("@/lib/transaction-history.server", () => ({
+  insertTransactionHistoryIdempotent: (...args: unknown[]) =>
+    ledgerMocks.insertTransactionHistoryIdempotent(...args),
+}));
+
+function createMockWebSocket(): import("bun").ServerWebSocket<MediaStreamSocketData> {
+  return {
+    data: {
+      workspaceId: "ws-1",
+      campaignId: "camp-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      requestId: "req-1",
+    },
+  } as import("bun").ServerWebSocket<MediaStreamSocketData>;
+}
+
+const START_MESSAGE = {
+  event: "start",
+  streamSid: "MZstream",
+  start: {
+    streamSid: "MZstream",
+    accountSid: "AC123",
+    callSid: "CA123",
+    tracks: ["inbound"],
+    mediaFormat: { encoding: "audio/x-mulaw", sampleRate: 8000, channels: 1 },
+    customParameters: { direction: "outbound" },
+  },
+} as const;
+
+function capabilities(overrides: Partial<Record<string, boolean>> = {}) {
+  return {
+    featureFlags: {},
+    coachingConfig: {},
+    capabilities: {
+      attachStream: true,
+      runCoaching: false,
+      showTranscript: true,
+      showCoaching: false,
+      ...overrides,
+    },
+  };
+}
+
+function transcriptionDebits() {
+  return ledgerMocks.insertTransactionHistoryIdempotent.mock.calls
+    .map((call) => call[0] as { idempotencyKey: string; amount: number; note: string })
+    .filter((args) => args.idempotencyKey === liveTranscriptionKey("CA123"));
+}
+
+describe("live transcription billing follows the STT lifecycle", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useRealTimers();
+
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig.mockReset();
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig.mockResolvedValue(capabilities());
+
+    sttMocks.openElevenLabsRealtimeStream.mockReset();
+    sttMocks.openElevenLabsRealtimeStream.mockResolvedValue({ send: vi.fn(), close: vi.fn() });
+
+    dbWriterMocks.writeTranscriptSegment.mockReset();
+    dbWriterMocks.publishTranscriptSegmentEvent.mockReset();
+
+    coachingEngineMocks.createCoachingState.mockReset();
+    coachingEngineMocks.createCoachingState.mockReturnValue({ callSid: "CA123" });
+    coachingEngineMocks.finalizeCoachingSession.mockReset();
+    coachingEngineMocks.finalizeCoachingSession.mockResolvedValue(undefined);
+
+    ledgerMocks.insertTransactionHistoryIdempotent.mockReset();
+    ledgerMocks.insertTransactionHistoryIdempotent.mockResolvedValue({ inserted: true });
+  });
+
+  test("a transcription-only workspace with no coaching is billed on stop", async () => {
+    // The regression this locks: STT opens unconditionally, but the debit used
+    // to live inside finalizeCoachingSession, so these workspaces ran for free.
+    vi.useFakeTimers();
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket();
+
+    await handleTwilioStreamMessage(ws, START_MESSAGE);
+    vi.advanceTimersByTime(3 * 60_000);
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+
+    expect(coachingEngineMocks.finalizeCoachingSession).not.toHaveBeenCalled();
+    expect(transcriptionDebits()).toHaveLength(1);
+    expect(transcriptionDebits()[0]).toMatchObject({
+      idempotencyKey: liveTranscriptionKey("CA123"),
+      note: "Live transcription CA123",
+    });
+    expect(transcriptionDebits()[0]!.amount).toBeLessThan(0);
+  });
+
+  test("bills from the STT clock, not the coaching state's clock", async () => {
+    vi.useFakeTimers();
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket();
+
+    await handleTwilioStreamMessage(ws, START_MESSAGE);
+    vi.advanceTimersByTime(10 * 60_000);
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+
+    // 10 min * 0.43 credits/min = 4.3 -> ceil 5.
+    expect(transcriptionDebits()[0]!.amount).toBe(-5);
+  });
+
+  test("a coaching workspace is billed exactly once — no double-bill", async () => {
+    vi.useFakeTimers();
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig.mockResolvedValue(
+      capabilities({ runCoaching: true, showCoaching: true }),
+    );
+
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket();
+
+    await handleTwilioStreamMessage(ws, START_MESSAGE);
+    vi.advanceTimersByTime(2 * 60_000);
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+
+    expect(coachingEngineMocks.finalizeCoachingSession).toHaveBeenCalledTimes(1);
+    expect(transcriptionDebits()).toHaveLength(1);
+  });
+
+  test("a repeated stop does not bill twice", async () => {
+    vi.useFakeTimers();
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket();
+
+    await handleTwilioStreamMessage(ws, START_MESSAGE);
+    vi.advanceTimersByTime(2 * 60_000);
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+
+    expect(transcriptionDebits()).toHaveLength(1);
+  });
+
+  test("an STT stream that never opened is not billed", async () => {
+    sttMocks.openElevenLabsRealtimeStream.mockResolvedValue(null);
+
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket();
+
+    await handleTwilioStreamMessage(ws, START_MESSAGE);
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+
+    expect(transcriptionDebits()).toHaveLength(0);
+  });
+
+  test("an instantly-stopped stream writes no zero debit", async () => {
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket();
+
+    // Real timers: start and stop land in the same millisecond => 0ms of STT.
+    await handleTwilioStreamMessage(ws, START_MESSAGE);
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+
+    for (const debit of transcriptionDebits()) {
+      expect(debit.amount).toBeLessThan(0);
+    }
+  });
+});

--- a/test/media-stream-twilio-handler.test.ts
+++ b/test/media-stream-twilio-handler.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { MediaStreamSocketData } from "../services/media-stream/types";
+
+const sttMocks = vi.hoisted(() => ({
+  openElevenLabsRealtimeStream: vi.fn(),
+}));
+
+const workspaceConfigMocks = vi.hoisted(() => ({
+  loadWorkspaceMediaStreamConfig: vi.fn(),
+}));
+
+const dbWriterMocks = vi.hoisted(() => ({
+  writeTranscriptSegment: vi.fn(),
+  publishTranscriptSegmentEvent: vi.fn(),
+}));
+
+vi.mock("../services/media-stream/elevenlabs-realtime-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../services/media-stream/elevenlabs-realtime-client")>();
+  return {
+    ...actual,
+    openElevenLabsRealtimeStream: sttMocks.openElevenLabsRealtimeStream,
+  };
+});
+
+vi.mock("../services/media-stream/db-writer", () => ({
+  writeTranscriptSegment: (...args: unknown[]) => dbWriterMocks.writeTranscriptSegment(...args),
+  publishTranscriptSegmentEvent: (...args: unknown[]) =>
+    dbWriterMocks.publishTranscriptSegmentEvent(...args),
+}));
+
+vi.mock("../services/media-stream/workspace-config", () => ({
+  loadWorkspaceMediaStreamConfig: (...args: unknown[]) =>
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig(...args),
+}));
+
+const coachingEngineMocks = vi.hoisted(() => ({
+  createCoachingState: vi.fn(),
+  processUtterance: vi.fn(),
+  finalizeCoachingSession: vi.fn(),
+}));
+
+vi.mock("../services/media-stream/coaching-engine", () => ({
+  createCoachingState: (...args: unknown[]) => coachingEngineMocks.createCoachingState(...args),
+  processUtterance: (...args: unknown[]) => coachingEngineMocks.processUtterance(...args),
+  finalizeCoachingSession: (...args: unknown[]) =>
+    coachingEngineMocks.finalizeCoachingSession(...args),
+}));
+
+// The stop path debits live transcription from the STT clock. Stub the ledger
+// so this suite stays a protocol test; the debit itself is covered in
+// test/media-stream-transcription-billing.test.ts.
+const billingMocks = vi.hoisted(() => ({
+  billLiveTranscription: vi.fn(),
+}));
+
+vi.mock("../services/media-stream/coaching-billing", () => ({
+  billLiveTranscription: (...args: unknown[]) => billingMocks.billLiveTranscription(...args),
+}));
+
+function createMockWebSocket(data: MediaStreamSocketData) {
+  return { data } as import("bun").ServerWebSocket<MediaStreamSocketData>;
+}
+
+describe("twilio-handler", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sttMocks.openElevenLabsRealtimeStream.mockReset();
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig.mockReset();
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig.mockResolvedValue({
+      featureFlags: {},
+      coachingConfig: {},
+      capabilities: {
+        attachStream: true,
+        runCoaching: false,
+        showTranscript: true,
+        showCoaching: false,
+      },
+    });
+    dbWriterMocks.writeTranscriptSegment.mockReset();
+    dbWriterMocks.publishTranscriptSegmentEvent.mockReset();
+    coachingEngineMocks.createCoachingState.mockReset();
+    coachingEngineMocks.createCoachingState.mockReturnValue({ callSid: "CA123" });
+    coachingEngineMocks.processUtterance.mockReset();
+    coachingEngineMocks.processUtterance.mockResolvedValue(undefined);
+    coachingEngineMocks.finalizeCoachingSession.mockReset();
+    coachingEngineMocks.finalizeCoachingSession.mockResolvedValue(undefined);
+    billingMocks.billLiveTranscription.mockReset();
+    billingMocks.billLiveTranscription.mockResolvedValue({ billed: true, credits: 1 });
+
+    const send = vi.fn();
+    const close = vi.fn();
+    sttMocks.openElevenLabsRealtimeStream.mockResolvedValue({ send, close });
+
+    dbWriterMocks.writeTranscriptSegment.mockResolvedValue({
+      id: "seg-uuid-1",
+      call_sid: "CA123",
+      speaker: 0,
+      speaker_label: "agent",
+      text: "Hello",
+      start_ms: 100,
+      end_ms: 500,
+      confidence: 0.95,
+      filler_count: 0,
+      is_final: true,
+      created_at: new Date().toISOString(),
+    });
+    dbWriterMocks.publishTranscriptSegmentEvent.mockResolvedValue(undefined);
+  });
+
+  test("connected is a no-op", async () => {
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket({
+      workspaceId: "ws-1",
+      campaignId: "camp-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      requestId: "req-1",
+    });
+
+    await handleTwilioStreamMessage(ws, { event: "connected", protocol: "Call", version: "1.0.0" });
+    expect(sttMocks.openElevenLabsRealtimeStream).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["runs coaching when runCoaching is true", true, true],
+    ["skips coaching when runCoaching is false", false, false],
+  ])("start %s", async (_name, runCoaching, expectCreated) => {
+    workspaceConfigMocks.loadWorkspaceMediaStreamConfig.mockResolvedValue({
+      featureFlags: {},
+      coachingConfig: {},
+      capabilities: {
+        attachStream: true,
+        runCoaching,
+        showTranscript: false,
+        showCoaching: runCoaching,
+      },
+    });
+
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket({
+      workspaceId: "ws-1",
+      campaignId: "camp-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      requestId: "req-1",
+    });
+
+    await handleTwilioStreamMessage(ws, {
+      event: "start",
+      streamSid: "MZstream",
+      start: {
+        streamSid: "MZstream",
+        accountSid: "AC123",
+        callSid: "CA123",
+        tracks: ["inbound"],
+        mediaFormat: { encoding: "audio/x-mulaw", sampleRate: 8000, channels: 1 },
+        customParameters: { direction: "outbound" },
+      },
+    });
+
+    expect(coachingEngineMocks.createCoachingState.mock.calls.length > 0).toBe(expectCreated);
+  });
+
+  test("start opens ElevenLabs STT and media forwards decoded mulaw audio", async () => {
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket({
+      workspaceId: "ws-1",
+      campaignId: "camp-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      requestId: "req-1",
+    });
+
+    await handleTwilioStreamMessage(ws, {
+      event: "start",
+      streamSid: "MZstream",
+      start: {
+        streamSid: "MZstream",
+        accountSid: "AC123",
+        callSid: "CA123",
+        tracks: ["inbound"],
+        mediaFormat: { encoding: "audio/x-mulaw", sampleRate: 8000, channels: 1 },
+        customParameters: { direction: "outbound" },
+      },
+    });
+
+    expect(sttMocks.openElevenLabsRealtimeStream).toHaveBeenCalledWith("ws-1", expect.any(Function));
+
+    const audioPayload = Buffer.from("mulaw-audio").toString("base64");
+    await handleTwilioStreamMessage(ws, {
+      event: "media",
+      streamSid: "MZstream",
+      media: {
+        track: "inbound",
+        chunk: "1",
+        timestamp: "5",
+        payload: audioPayload,
+      },
+    });
+
+    const stream = await sttMocks.openElevenLabsRealtimeStream.mock.results[0]?.value;
+    expect(stream?.send).toHaveBeenCalledWith(Buffer.from("mulaw-audio"));
+  });
+
+  test("committed transcript persists segment and publishes workspace event", async () => {
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket({
+      workspaceId: "ws-1",
+      campaignId: "camp-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      requestId: "req-1",
+    });
+
+    await handleTwilioStreamMessage(ws, {
+      event: "start",
+      start: {
+        streamSid: "MZstream",
+        accountSid: "AC123",
+        callSid: "CA123",
+        tracks: ["inbound"],
+        mediaFormat: { encoding: "audio/x-mulaw", sampleRate: 8000, channels: 1 },
+      },
+    });
+
+    const onCommitted = sttMocks.openElevenLabsRealtimeStream.mock.calls[0]?.[1] as (
+      event: unknown,
+    ) => Promise<void>;
+
+    await onCommitted({
+      message_type: "committed_transcript_with_timestamps",
+      text: "uh hello there",
+      words: [
+        { text: "uh", start: 0.1, end: 0.2, type: "word", speaker_id: "speaker_0", logprob: -0.1 },
+        {
+          text: "hello",
+          start: 0.3,
+          end: 0.6,
+          type: "word",
+          speaker_id: "speaker_0",
+          logprob: -0.1,
+        },
+        {
+          text: "there",
+          start: 0.7,
+          end: 1.0,
+          type: "word",
+          speaker_id: "speaker_0",
+          logprob: -0.1,
+        },
+      ],
+    });
+
+    expect(dbWriterMocks.writeTranscriptSegment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        call_sid: "CA123",
+        speaker: 0,
+        speaker_label: "agent",
+        text: "uh hello there",
+        filler_count: 1,
+        is_final: true,
+      }),
+    );
+    expect(dbWriterMocks.publishTranscriptSegmentEvent).toHaveBeenCalledWith(
+      "ws-1",
+      "CA123",
+      expect.objectContaining({ id: "seg-uuid-1" }),
+    );
+  });
+
+  test("stop closes ElevenLabs STT stream", async () => {
+    const { handleTwilioStreamMessage } = await import("../services/media-stream/twilio-handler");
+    const ws = createMockWebSocket({
+      workspaceId: "ws-1",
+      campaignId: "camp-1",
+      userId: "user-1",
+      sessionId: "session-1",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      requestId: "req-1",
+    });
+
+    await handleTwilioStreamMessage(ws, {
+      event: "start",
+      start: {
+        streamSid: "MZstream",
+        accountSid: "AC123",
+        callSid: "CA123",
+        tracks: ["inbound"],
+        mediaFormat: { encoding: "audio/x-mulaw", sampleRate: 8000, channels: 1 },
+      },
+    });
+
+    const stt = await sttMocks.openElevenLabsRealtimeStream.mock.results[0]?.value;
+
+    await handleTwilioStreamMessage(ws, { event: "stop", streamSid: "MZstream" });
+
+    expect(stt.close).toHaveBeenCalled();
+    expect(ws.data.twilio?.phase).toBe("stopped");
+  });
+});

--- a/test/media-stream-twiml.test.ts
+++ b/test/media-stream-twiml.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import VoiceResponse from "twilio/lib/twiml/VoiceResponse.js";
+import { env } from "@/lib/env.server";
+import { logger } from "@/lib/logger.server";
+import {
+  appendLiveTranscriptionStreamTwiml,
+  type LiveTranscriptionStreamParams,
+} from "@/lib/media-stream-twiml.server";
+
+const params: LiveTranscriptionStreamParams = {
+  workspaceId: "ws-1",
+  userId: "user-1",
+  direction: "outbound",
+  callId: 42,
+  campaignId: "camp-1",
+  callSid: "CA123",
+};
+
+function appendWith(
+  featureFlags: Record<string, unknown> | null | undefined,
+  overrides: Partial<LiveTranscriptionStreamParams> = {},
+) {
+  const voice = new VoiceResponse();
+  const attached = appendLiveTranscriptionStreamTwiml({
+    twiml: voice,
+    featureFlags,
+    params: { ...params, ...overrides },
+  });
+  return { attached, xml: voice.toString() };
+}
+
+describe("appendLiveTranscriptionStreamTwiml — flag matrix", () => {
+  beforeEach(() => {
+    process.env.MEDIA_STREAM_HOST = "stream.example.com";
+  });
+
+  test("neither flag: no <Stream>", () => {
+    const { attached, xml } = appendWith({});
+    expect(attached).toBe(false);
+    expect(xml).not.toContain("<Stream");
+  });
+
+  test("transcription only: attaches <Stream>", () => {
+    const { attached, xml } = appendWith({ liveTranscription: true });
+    expect(attached).toBe(true);
+    expect(xml).toContain("<Stream");
+    expect(xml).toContain("both_tracks");
+  });
+
+  // Regression: coaching-only workspaces previously got no <Stream> at all,
+  // so the coaching engine never received STT input.
+  test("coaching only: still attaches <Stream> (coaching needs STT input)", () => {
+    const { attached, xml } = appendWith({ liveCoaching: true });
+    expect(attached).toBe(true);
+    expect(xml).toContain("<Stream");
+  });
+
+  test("both flags: attaches <Stream>", () => {
+    const { attached, xml } = appendWith({
+      liveTranscription: true,
+      liveCoaching: true,
+    });
+    expect(attached).toBe(true);
+    expect(xml).toContain("<Stream");
+  });
+
+  test("passes call context as stream parameters", () => {
+    const { xml } = appendWith({ liveTranscription: true });
+    expect(xml).toContain('name="workspaceId"');
+    expect(xml).toContain('value="ws-1"');
+    expect(xml).toContain('name="callSid"');
+    expect(xml).toContain('value="CA123"');
+  });
+
+  test("no <Stream> without workspaceId / userId", () => {
+    expect(appendWith({ liveCoaching: true }, { workspaceId: "" }).attached).toBe(false);
+    expect(appendWith({ liveCoaching: true }, { userId: "" }).attached).toBe(false);
+  });
+});
+
+describe("appendLiveTranscriptionStreamTwiml — missing MEDIA_STREAM_HOST", () => {
+  beforeEach(() => {
+    vi.spyOn(env, "MEDIA_STREAM_HOST").mockReturnValue(undefined as unknown as string);
+  });
+
+  test.each([
+    ["transcription only", { liveTranscription: true }],
+    ["coaching only", { liveCoaching: true }],
+    ["both", { liveTranscription: true, liveCoaching: true }],
+  ])("fails closed and logs loudly (%s)", (_name, flags) => {
+    const voice = new VoiceResponse();
+    voice.say("hello");
+
+    // Never throws out of TwiML generation.
+    const attached = appendLiveTranscriptionStreamTwiml({
+      twiml: voice,
+      featureFlags: flags,
+      params,
+    });
+
+    // Fails closed: no stream attached...
+    expect(attached).toBe(false);
+    expect(voice.toString()).not.toContain("<Stream");
+    // ...but the call itself proceeds normally.
+    expect(voice.toString()).toContain("hello");
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("MEDIA_STREAM_HOST"),
+      expect.objectContaining({
+        guard: "media-stream-host-missing",
+        workspaceId: "ws-1",
+      }),
+    );
+  });
+
+  test("stays silent when live media is disabled entirely", () => {
+    const { attached } = appendWith({});
+    expect(attached).toBe(false);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The `localhost:3001` default used to apply in every environment, which made
+ * the fail-closed guard above unreachable in production: prod with the var
+ * unset handed Twilio a `wss://localhost:3001` URL it could never reach, so
+ * every call carried a silently broken `<Stream>` instead of a loud error.
+ * The default is now dev-only.
+ */
+describe("env.MEDIA_STREAM_HOST — dev-only localhost default", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test("production + unset: resolves to undefined (guard can fire)", () => {
+    delete process.env.MEDIA_STREAM_HOST;
+    process.env.NODE_ENV = "production";
+    expect(env.MEDIA_STREAM_HOST()).toBeUndefined();
+  });
+
+  test("production + set: uses the configured host", () => {
+    process.env.MEDIA_STREAM_HOST = "stream.example.com";
+    process.env.NODE_ENV = "production";
+    expect(env.MEDIA_STREAM_HOST()).toBe("stream.example.com");
+  });
+
+  test("non-production + unset: keeps the localhost dev default", () => {
+    delete process.env.MEDIA_STREAM_HOST;
+    process.env.NODE_ENV = "development";
+    expect(env.MEDIA_STREAM_HOST()).toBe("localhost:3001");
+  });
+
+  test("non-production + set: still prefers the configured host", () => {
+    process.env.MEDIA_STREAM_HOST = "tunnel.example.com";
+    process.env.NODE_ENV = "development";
+    expect(env.MEDIA_STREAM_HOST()).toBe("tunnel.example.com");
+  });
+});
+
+describe("appendLiveTranscriptionStreamTwiml — production with MEDIA_STREAM_HOST unset", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    // No env mocking here: this exercises the real accessor, which is the
+    // whole point — the guard was previously unreachable via real config.
+    delete process.env.MEDIA_STREAM_HOST;
+    process.env.NODE_ENV = "production";
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test("attaches no <Stream>, logs the guard, and still emits the rest of the TwiML", () => {
+    const voice = new VoiceResponse();
+    voice.say("connecting you now");
+    const dial = voice.dial();
+    dial.client("agent-1");
+
+    const attached = appendLiveTranscriptionStreamTwiml({
+      twiml: voice,
+      featureFlags: { liveCoaching: true, liveTranscription: true },
+      params,
+    });
+
+    const xml = voice.toString();
+
+    // Fails closed rather than emitting wss://localhost:3001.
+    expect(attached).toBe(false);
+    expect(xml).not.toContain("<Stream");
+    expect(xml).not.toContain("localhost:3001");
+
+    // The call itself is unaffected.
+    expect(xml).toContain("connecting you now");
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("<Client>agent-1</Client>");
+
+    // And the misconfiguration is loud.
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("MEDIA_STREAM_HOST"),
+      expect.objectContaining({
+        guard: "media-stream-host-missing",
+        workspaceId: "ws-1",
+        direction: "outbound",
+      }),
+    );
+  });
+
+  test("non-production with the var unset still streams to the localhost default", () => {
+    process.env.NODE_ENV = "development";
+
+    const voice = new VoiceResponse();
+    const attached = appendLiveTranscriptionStreamTwiml({
+      twiml: voice,
+      featureFlags: { liveTranscription: true },
+      params,
+    });
+
+    expect(attached).toBe(true);
+    expect(voice.toString()).toContain("ws://localhost:3001/");
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/test/outreach-attempts-id.route.test.ts
+++ b/test/outreach-attempts-id.route.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => {
     process.env.DATABASE_URL ?? "postgres://test:test@localhost:5432/test";
   return {
     safeParseJson: vi.fn(),
-    authForOutreachAttempt: vi.fn(),
+    authForResource: vi.fn(),
     updateOutreachAttemptForWorkspace: vi.fn(),
   };
 });
@@ -24,7 +24,7 @@ vi.mock("@/lib/request-utils.server", () => ({
   safeParseJson: (...args: unknown[]) => mocks.safeParseJson(...args),
 }));
 vi.mock("@/lib/platform-data.server", () => ({
-  authForOutreachAttempt: (...args: unknown[]) => mocks.authForOutreachAttempt(...args),
+  authForResource: (...args: unknown[]) => mocks.authForResource(...args),
 }));
 vi.mock("@/lib/telephony-db.server", () => ({
   updateOutreachAttemptForWorkspace: (...args: unknown[]) =>
@@ -35,11 +35,10 @@ describe("app/routes/api+/outreach_attempts/$id/route.js", () => {
   beforeEach(() => {
     vi.resetModules();
     mocks.safeParseJson.mockReset();
-    mocks.authForOutreachAttempt.mockReset();
+    mocks.authForResource.mockReset();
     mocks.updateOutreachAttemptForWorkspace.mockReset();
-    mocks.authForOutreachAttempt.mockResolvedValue({
-      client: {},
-      user: { id: "u1" },
+    mocks.authForResource.mockResolvedValue({
+      userId: "u1",
       workspaceId: "w1",
     });
   });

--- a/test/outreach-typed-fields.server.test.ts
+++ b/test/outreach-typed-fields.server.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  extractTypedOutreachFields,
+  syncContactSupportLevelCache,
+} from "@/lib/outreach-typed-fields.server";
+
+describe("extractTypedOutreachFields", () => {
+  test("returns empty object for non-object updates", () => {
+    expect(extractTypedOutreachFields(undefined)).toEqual({});
+    expect(extractTypedOutreachFields(null as never)).toEqual({});
+    expect(extractTypedOutreachFields([])).toEqual({});
+  });
+
+  test("extracts typed columns from flat and nested IVR-style result JSON", () => {
+    const fields = extractTypedOutreachFields({
+      page_1: { "Support Level": "2", "Lawn Sign": "yes" },
+      volunteer_interest: "maybe",
+      issue_tags: ["healthcare", "housing"],
+      vote_by_mail: true,
+      membership_sold: "no",
+      callback_audit: 1,
+    });
+
+    expect(fields).toEqual({
+      support_level: 2,
+      volunteer_interest: "maybe",
+      lawn_sign: true,
+      vote_by_mail: true,
+      issue_tags: ["healthcare", "housing"],
+      membership_sold: false,
+      callback_audit: true,
+    });
+  });
+
+  test("parses support level labels and ignores invalid values", () => {
+    expect(extractTypedOutreachFields({ support: "lean opposition" })).toEqual({
+      support_level: 4,
+    });
+    expect(extractTypedOutreachFields({ support_level: 9 })).toEqual({});
+  });
+});
+
+describe("syncContactSupportLevelCache", () => {
+  test("updates contact.support_level when support level is present", async () => {
+    const contactUpdate = vi.fn().mockResolvedValue([{ id: 5 }]);
+    const tdb = { contact: { update: contactUpdate } };
+
+    await syncContactSupportLevelCache(tdb as never, 5, 3);
+
+    expect(contactUpdate).toHaveBeenCalledWith({
+      set: { support_level: 3 },
+      where: expect.anything(),
+    });
+  });
+
+  test("skips contact update when support level is absent", async () => {
+    const contactUpdate = vi.fn();
+    const tdb = { contact: { update: contactUpdate } };
+
+    await syncContactSupportLevelCache(tdb as never, 5, undefined);
+    await syncContactSupportLevelCache(tdb as never, 5, null);
+
+    expect(contactUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/test/questions.route.test.ts
+++ b/test/questions.route.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
 const tenantDbMocks = vi.hoisted(() => ({
   findFirst: vi.fn(),
   update: vi.fn(),
+  contactUpdate: vi.fn(),
 }));
 
 vi.mock("@/lib/auth.server", () => ({
@@ -40,6 +41,9 @@ vi.mock("@/server/tenant-db", () => ({
     outreach_attempt: {
       findFirst: (...args: any[]) => tenantDbMocks.findFirst(...args),
       update: (...args: any[]) => tenantDbMocks.update(...args),
+    },
+    contact: {
+      update: (...args: any[]) => tenantDbMocks.contactUpdate(...args),
     },
   }),
 }));
@@ -74,6 +78,7 @@ describe("app/routes/api+/questions/route.tsx", () => {
     mocks.logger.error.mockReset();
     tenantDbMocks.findFirst.mockReset();
     tenantDbMocks.update.mockReset();
+    tenantDbMocks.contactUpdate.mockReset();
 
     mocks.getSession.mockResolvedValue({ headers, user: { id: "u1" } });
     mocks.requireJsonAuth.mockResolvedValue({ user: { id: "u1" } });
@@ -178,6 +183,35 @@ describe("app/routes/api+/questions/route.tsx", () => {
     tenantDbMocks.update.mockRejectedValueOnce(new Error("final bad"));
     const mod = await import("../app/routes/api+/questions");
     await expect(mod.action({ request: makeRequest(defaultBody) } as any)).rejects.toThrow("final bad");
+  });
+
+  test("writes typed outreach columns and syncs contact.support_level cache", async () => {
+    tenantDbMocks.findFirst.mockResolvedValueOnce(null);
+    mocks.rpcCreateOutreachAttempt.mockResolvedValueOnce(7);
+    mocks.safeParseJson.mockResolvedValueOnce({
+      ...defaultBody,
+      update: {
+        support_level: 2,
+        volunteer_interest: "yes",
+        lawn_sign: true,
+      },
+    });
+    const mod = await import("../app/routes/api+/questions");
+    const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
+    expect(res.status).toBe(200);
+    expect(tenantDbMocks.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          support_level: 2,
+          volunteer_interest: "yes",
+          lawn_sign: true,
+        }),
+      }),
+    );
+    expect(tenantDbMocks.contactUpdate).toHaveBeenCalledWith({
+      set: { support_level: 2 },
+      where: expect.anything(),
+    });
   });
 
   test("returns 500 when outreach attempt id is null after creation", async () => {

--- a/test/route-live-media-stream.test.ts
+++ b/test/route-live-media-stream.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Route-level stream-attachment coverage for the four Twilio TwiML routes that
+ * can carry a live media stream.
+ *
+ * `test/media-stream-twiml.test.ts` already covers the flag matrix inside
+ * `appendLiveTranscriptionStreamTwiml`. This file covers the *wiring*: that each
+ * route reaches the helper with the right workspace flags and the right
+ * route-specific call metadata (direction/ids), and — critically — that when the
+ * capabilities are off the route's own TwiML is byte-for-byte unaffected.
+ *
+ * `twilio` is deliberately NOT mocked here: assertions run against real
+ * VoiceResponse XML, so a regression in the `<Start><Stream>` shape is caught.
+ */
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { routeArgs } from "./helpers/route-result";
+
+const mocks = vi.hoisted(() => ({
+  env: new Proxy(
+    {
+      BASE_URL: () => "https://base.example",
+      MEDIA_STREAM_HOST: () => "stream.example.com",
+      MEDIA_STREAM_SECRET: () => "test-secret",
+      TWILIO_PHONE_NUMBER: () => "+15550009999",
+    } as Record<string, () => string>,
+    { get: (t, p: string) => t[p] ?? (() => "test") },
+  ),
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  getWorkspaceById: vi.fn(),
+  getWorkspaceWebhookRow: vi.fn(async () => null),
+  getHandsetNumberForWorkspace: vi.fn(),
+  createWorkspaceTwilioInstance: vi.fn(),
+  findActiveHandsetSession: vi.fn(),
+  findActiveHandsetSessionClientIdentity: vi.fn(),
+  insertCallForWorkspace: vi.fn(async () => null),
+  findCallBySid: vi.fn(),
+  updateOutreachAttemptForWorkspace: vi.fn(async () => ({})),
+  findWorkspaceNumberByPhoneNumber: vi.fn(),
+  upsertInboundCallRecord: vi.fn(),
+  findInboundIvrScriptSteps: vi.fn(async () => null),
+  resolveInboundVoicemailAudio: vi.fn(async () => null),
+  sendWebhookNotification: vi.fn(),
+  runAutoDialerTurn: vi.fn(async () => undefined),
+  getUserVerifiedAudioNumbers: vi.fn(),
+  fetchCampaignByIdForWorkspace: vi.fn(),
+  dequeueCampaignQueueByContact: vi.fn(),
+  rpcDequeueContact: vi.fn(),
+  createSignedObjectUrl: vi.fn(async () => null),
+  createTenantDb: vi.fn(() => ({})),
+}));
+
+// `twilio`'s package entrypoint pulls in a jsonwebtoken → jwa chain that fails
+// to load under vitest. Stub the entrypoint but keep the REAL VoiceResponse, so
+// every assertion below still runs against genuine TwiML XML.
+vi.mock("twilio", async () => {
+  const VoiceResponse = (await import("twilio/lib/twiml/VoiceResponse.js")).default;
+  return { default: { twiml: { VoiceResponse }, Twilio: class {} } };
+});
+
+vi.mock("@/lib/env.server", () => ({ env: mocks.env }));
+vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
+// Mocked outright rather than via importOriginal: the real module pulls in a
+// JWT dep chain that does not load under this suite's module mocks.
+vi.mock("@/lib/twilio-webhook.server", () => ({
+  requireTwilioSignature: vi.fn(async () => null),
+  twilioWebhookForbidden: (message = "Invalid Twilio signature") =>
+    new Response(message, { status: 403 }),
+  twilioWebhookBadRequest: (message: string) => new Response(message, { status: 400 }),
+  twilioWebhookNotFound: (message = "Not Found") => new Response(message, { status: 404 }),
+  twilioWebhookInternalError: (message = "Internal Server Error") =>
+    new Response(message, { status: 500 }),
+}));
+vi.mock("@/lib/workspace-members-db.server", () => ({
+  getWorkspaceById: (...a: unknown[]) => mocks.getWorkspaceById(...a),
+  getWorkspaceWebhookRow: (...a: unknown[]) => mocks.getWorkspaceWebhookRow(...a),
+}));
+vi.mock("@/lib/database/workspace.server", () => ({
+  getHandsetNumberForWorkspace: (...a: unknown[]) =>
+    mocks.getHandsetNumberForWorkspace(...a),
+  createWorkspaceTwilioInstance: (...a: unknown[]) =>
+    mocks.createWorkspaceTwilioInstance(...a),
+}));
+vi.mock("@/lib/handset/handset-session.server", () => ({
+  findActiveHandsetSession: (...a: unknown[]) => mocks.findActiveHandsetSession(...a),
+  findActiveHandsetSessionClientIdentity: (...a: unknown[]) =>
+    mocks.findActiveHandsetSessionClientIdentity(...a),
+}));
+vi.mock("@/lib/telephony-db.server", () => ({
+  insertCallForWorkspace: (...a: unknown[]) => mocks.insertCallForWorkspace(...a),
+  findCallBySid: (...a: unknown[]) => mocks.findCallBySid(...a),
+  updateOutreachAttemptForWorkspace: (...a: unknown[]) =>
+    mocks.updateOutreachAttemptForWorkspace(...a),
+}));
+vi.mock("@/lib/inbound-call-db.server", () => ({
+  findWorkspaceNumberByPhoneNumber: (...a: unknown[]) =>
+    mocks.findWorkspaceNumberByPhoneNumber(...a),
+  upsertInboundCallRecord: (...a: unknown[]) => mocks.upsertInboundCallRecord(...a),
+  findInboundIvrScriptSteps: (...a: unknown[]) => mocks.findInboundIvrScriptSteps(...a),
+  workspaceWebhookHasInboundCallInsert: () => false,
+}));
+vi.mock("@/lib/inbound-voicemail-twiml.server", () => ({
+  resolveInboundVoicemailAudio: (...a: unknown[]) =>
+    mocks.resolveInboundVoicemailAudio(...a),
+  appendInboundVoicemailTwiml: vi.fn(),
+}));
+vi.mock("@/lib/workspace-settings/WorkspaceSettingUtils.server", () => ({
+  sendWebhookNotification: (...a: unknown[]) => mocks.sendWebhookNotification(...a),
+}));
+vi.mock("@/lib/auto-dial.server", () => ({
+  runAutoDialerTurn: (...a: unknown[]) => mocks.runAutoDialerTurn(...a),
+}));
+vi.mock("@/lib/user-audio.server", () => ({
+  getUserVerifiedAudioNumbers: (...a: unknown[]) =>
+    mocks.getUserVerifiedAudioNumbers(...a),
+}));
+vi.mock("@/lib/campaign-ivr.server", () => ({
+  fetchCampaignByIdForWorkspace: (...a: unknown[]) =>
+    mocks.fetchCampaignByIdForWorkspace(...a),
+}));
+vi.mock("@/lib/campaign-queue-db.server", () => ({
+  dequeueCampaignQueueByContact: (...a: unknown[]) =>
+    mocks.dequeueCampaignQueueByContact(...a),
+}));
+vi.mock("@/lib/db-rpc.server", () => ({
+  rpcDequeueContact: (...a: unknown[]) => mocks.rpcDequeueContact(...a),
+}));
+vi.mock("@/lib/object-storage.server", () => ({
+  createSignedObjectUrl: (...a: unknown[]) => mocks.createSignedObjectUrl(...a),
+}));
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: (...a: unknown[]) => mocks.createTenantDb(...a),
+}));
+
+/** The three capability states each route is exercised against. */
+const FLAGS_OFF = {};
+const FLAGS_TRANSCRIPTION = { liveTranscription: true };
+const FLAGS_COACHING_ONLY = { liveCoaching: true };
+
+function workspaceWithFlags(flags: Record<string, unknown>) {
+  return { id: "ws-1", feature_flags: flags };
+}
+
+/** Parse the `<Parameter name=... value=.../>` pairs out of a `<Stream>` block. */
+function streamParameters(xml: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const m of xml.matchAll(/<Parameter name="([^"]+)" value="([^"]*)"\s*\/>/g)) {
+    out[m[1]!] = m[2]!;
+  }
+  return out;
+}
+
+async function readXml(result: unknown): Promise<string> {
+  const res = (await result) as Response;
+  expect(res.headers.get("Content-Type")).toBe("text/xml");
+  return await res.text();
+}
+
+// Pay the route + real-TwiML module import cost once, up front. Otherwise the
+// first test in the file absorbs several seconds of cold transform and flakes
+// against the 5s default timeout.
+beforeAll(async () => {
+  await Promise.all([
+    import("../app/routes/api+/call.action.server"),
+    import("../app/routes/api+/dial/$number.action.server"),
+    import("../app/routes/api+/auto-dial/$roomId.action.server"),
+    import("../app/routes/api+/inbound.action.server"),
+  ]);
+}, 60000);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getWorkspaceWebhookRow.mockResolvedValue(null);
+  mocks.insertCallForWorkspace.mockResolvedValue(null);
+  mocks.runAutoDialerTurn.mockResolvedValue(undefined);
+});
+
+describe("api/call — outbound handset call", () => {
+  beforeEach(() => {
+    mocks.findActiveHandsetSession.mockResolvedValue({ user_id: "user-1" });
+    mocks.getHandsetNumberForWorkspace.mockResolvedValue({
+      data: { phone_number: "+15550001111" },
+    });
+  });
+
+  function callRequest() {
+    const fd = new FormData();
+    fd.set("To", "+15552223333");
+    fd.set("workspace_id", "ws-1");
+    fd.set("client_identity", "agent-1");
+    fd.set("CallSid", "CA-outbound");
+    return new Request("http://localhost/api/call", { method: "POST", body: fd });
+  }
+
+  async function run() {
+    const mod = await import("../app/routes/api+/call.action.server");
+    return await readXml(mod.action(routeArgs(callRequest()) as never));
+  }
+
+  test("capabilities off: no <Stream>, dial behavior unchanged", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_OFF));
+    const xml = await run();
+
+    expect(xml).not.toContain("<Stream");
+    expect(xml).not.toContain("<Start");
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("+15552223333");
+  });
+
+  test("liveTranscription on: attaches outbound <Stream> and still dials", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_TRANSCRIPTION));
+    const xml = await run();
+
+    expect(xml).toContain("<Stream");
+    expect(xml).toContain('track="both_tracks"');
+    expect(xml).toContain('name="call-CA-outbound"');
+    expect(xml).toContain("<Dial");
+
+    expect(streamParameters(xml)).toMatchObject({
+      workspaceId: "ws-1",
+      userId: "user-1",
+      direction: "outbound",
+      callSid: "CA-outbound",
+    });
+  });
+
+  test("liveCoaching only: still attaches <Stream> (coaching needs the audio)", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_COACHING_ONLY));
+    const xml = await run();
+
+    expect(xml).toContain("<Stream");
+    expect(streamParameters(xml)).toMatchObject({ direction: "outbound" });
+  });
+
+  test("reads flags from the call's own workspace", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_TRANSCRIPTION));
+    await run();
+    expect(mocks.getWorkspaceById).toHaveBeenCalledWith("ws-1");
+  });
+});
+
+describe("api/dial/$number — outbound dial", () => {
+  beforeEach(() => {
+    mocks.findCallBySid.mockResolvedValue({
+      sid: "CA-dial",
+      workspace: "ws-1",
+      user_id: "user-1",
+      contact_id: 77,
+      campaign_id: 5,
+    });
+  });
+
+  async function run() {
+    const mod = await import("../app/routes/api+/dial/$number.action.server");
+    const fd = new FormData();
+    fd.set("From", "+15550001111");
+    fd.set("CallSid", "CA-dial");
+    const request = new Request("http://localhost/api/dial/+15552223333", {
+      method: "POST",
+      body: fd,
+    });
+    return await readXml(
+      mod.action(routeArgs(request, { number: "+15552223333" }) as never),
+    );
+  }
+
+  test("capabilities off: no <Stream>, dial behavior unchanged", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_OFF));
+    const xml = await run();
+
+    expect(xml).not.toContain("<Stream");
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("+15552223333");
+  });
+
+  test("liveTranscription on: attaches <Stream> with contact/campaign metadata", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_TRANSCRIPTION));
+    const xml = await run();
+
+    expect(xml).toContain("<Stream");
+    expect(xml).toContain("<Dial");
+    expect(streamParameters(xml)).toMatchObject({
+      workspaceId: "ws-1",
+      userId: "user-1",
+      direction: "outbound",
+      contactId: "77",
+      campaignId: "5",
+      callSid: "CA-dial",
+    });
+  });
+
+  test("liveCoaching only: still attaches <Stream>", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_COACHING_ONLY));
+    expect(await run()).toContain("<Stream");
+  });
+
+  test("no <Stream> when the call row has no user to attribute the stream to", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_TRANSCRIPTION));
+    mocks.findCallBySid.mockResolvedValue({
+      sid: "CA-dial",
+      workspace: "ws-1",
+      user_id: null,
+    });
+    const xml = await run();
+
+    expect(xml).not.toContain("<Stream");
+    expect(xml).toContain("<Dial");
+  });
+});
+
+describe("api/auto-dial/$roomId — predictive conference", () => {
+  beforeEach(() => {
+    mocks.findCallBySid.mockResolvedValue({
+      sid: "CA-auto",
+      workspace: "ws-1",
+      campaign_id: 5,
+      contact_id: null,
+      conference_id: "user-1~room-abc",
+    });
+    mocks.fetchCampaignByIdForWorkspace.mockResolvedValue({
+      voicemail_file: null,
+      group_household_queue: false,
+      caller_id: "+15550001111",
+    });
+    // Non-empty verified numbers + a `client` Called value routes the webhook
+    // down the device-check branch, which is the branch that attaches a stream.
+    mocks.getUserVerifiedAudioNumbers.mockResolvedValue(["+15550001111"]);
+  });
+
+  async function run() {
+    const mod = await import("../app/routes/api+/auto-dial/$roomId.action.server");
+    const fd = new FormData();
+    fd.set("CallSid", "CA-auto");
+    fd.set("Called", "client:agent-1");
+    fd.set("CallStatus", "in-progress");
+    const request = new Request("http://localhost/api/auto-dial/user-1~room-abc", {
+      method: "POST",
+      body: fd,
+    });
+    return await readXml(
+      mod.action(routeArgs(request, { roomId: "user-1~room-abc" }) as never),
+    );
+  }
+
+  test("capabilities off: no <Stream>, conference behavior unchanged", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_OFF));
+    const xml = await run();
+
+    expect(xml).not.toContain("<Stream");
+    expect(xml).toContain("<Conference");
+    expect(xml).toContain("user-1~room-abc");
+  });
+
+  test("liveTranscription on: attaches predictive <Stream> and still conferences", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_TRANSCRIPTION));
+    const xml = await run();
+
+    expect(xml).toContain("<Stream");
+    expect(xml).toContain('name="conf-user-1~room-abc"');
+    expect(xml).toContain("<Conference");
+    expect(streamParameters(xml)).toMatchObject({
+      workspaceId: "ws-1",
+      userId: "user-1",
+      direction: "predictive",
+      campaignId: "5",
+    });
+  });
+
+  test("liveCoaching only: still attaches <Stream>", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_COACHING_ONLY));
+    const xml = await run();
+
+    expect(xml).toContain("<Stream");
+    expect(streamParameters(xml)).toMatchObject({ direction: "predictive" });
+  });
+});
+
+describe("api/inbound — inbound handset call", () => {
+  beforeEach(() => {
+    mocks.findWorkspaceNumberByPhoneNumber.mockResolvedValue({
+      id: "num-1",
+      workspaceId: "ws-1",
+      handset_enabled: true,
+      inbound_ring_count: 4,
+      inbound_script_id: null,
+      inbound_queue_id: null,
+      inbound_action: null,
+      inbound_audio: null,
+    });
+    mocks.upsertInboundCallRecord.mockResolvedValue({
+      sid: "CA-inbound",
+      from: "+15552223333",
+      to: "+15550001111",
+      status: "completed",
+      direction: "inbound",
+      start_time: new Date().toISOString(),
+    });
+    mocks.findActiveHandsetSessionClientIdentity.mockResolvedValue("agent-1");
+    mocks.findActiveHandsetSession.mockResolvedValue({ user_id: "user-1" });
+  });
+
+  async function run() {
+    const mod = await import("../app/routes/api+/inbound.action.server");
+    const fd = new FormData();
+    fd.set("Called", "+15550001111");
+    fd.set("From", "+15552223333");
+    fd.set("CallSid", "CA-inbound");
+    fd.set("Direction", "inbound");
+    const request = new Request("http://localhost/api/inbound", {
+      method: "POST",
+      body: fd,
+    });
+    return await readXml(mod.action(routeArgs(request) as never));
+  }
+
+  test("capabilities off: no <Stream>, handset dial behavior unchanged", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_OFF));
+    const xml = await run();
+
+    expect(xml).not.toContain("<Stream");
+    expect(xml).toContain("<Client>agent-1</Client>");
+  });
+
+  test("liveTranscription on: attaches inbound <Stream> and still dials the client", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_TRANSCRIPTION));
+    const xml = await run();
+
+    expect(xml).toContain("<Stream");
+    expect(xml).toContain('name="inbound-CA-inbound"');
+    expect(xml).toContain("<Client>agent-1</Client>");
+    expect(streamParameters(xml)).toMatchObject({
+      workspaceId: "ws-1",
+      userId: "user-1",
+      direction: "inbound",
+      callSid: "CA-inbound",
+    });
+  });
+
+  test("liveCoaching only: still attaches <Stream>", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_COACHING_ONLY));
+    const xml = await run();
+
+    expect(xml).toContain("<Stream");
+    expect(streamParameters(xml)).toMatchObject({ direction: "inbound" });
+  });
+
+  test("no <Stream> when there is no resolvable handset session user", async () => {
+    mocks.getWorkspaceById.mockResolvedValue(workspaceWithFlags(FLAGS_TRANSCRIPTION));
+    mocks.findActiveHandsetSession.mockResolvedValue(null);
+    const xml = await run();
+
+    expect(xml).not.toContain("<Stream");
+    expect(xml).toContain("<Client>agent-1</Client>");
+  });
+});
+
+describe("stream attachment is workspace-scoped", () => {
+  test("a second workspace with flags off gets no <Stream> on the same route", async () => {
+    mocks.findCallBySid.mockResolvedValue({
+      sid: "CA-dial",
+      workspace: "ws-2",
+      user_id: "user-2",
+    });
+    mocks.getWorkspaceById.mockResolvedValue({
+      id: "ws-2",
+      feature_flags: FLAGS_OFF,
+    });
+
+    const mod = await import("../app/routes/api+/dial/$number.action.server");
+    const fd = new FormData();
+    fd.set("From", "+15550001111");
+    fd.set("CallSid", "CA-dial");
+    const request = new Request("http://localhost/api/dial/+15552223333", {
+      method: "POST",
+      body: fd,
+    });
+    const xml = await readXml(
+      mod.action(routeArgs(request, { number: "+15552223333" }) as never),
+    );
+
+    expect(mocks.getWorkspaceById).toHaveBeenCalledWith("ws-2");
+    expect(xml).not.toContain("<Stream");
+  });
+});

--- a/test/ui/call-screen-coaching-hydration.test.tsx
+++ b/test/ui/call-screen-coaching-hydration.test.tsx
@@ -17,7 +17,15 @@ vi.mock("@/lib/logger.client", () => ({
 }));
 
 const eventSourceCtor = vi.fn();
-const listeners = new Set<(event: MessageEvent<string>) => void>();
+/**
+ * Keyed by event name. The hook registers a `workspace_event` handler and a
+ * terminal `access_revoked` handler; a type-agnostic set would hand every frame
+ * to both, so a plain transcript event would trip the revoked path and close
+ * the stream.
+ */
+type SseHandler = (event: MessageEvent<string>) => void;
+const listeners = new Map<string, Set<SseHandler>>();
+const workspaceEventListeners = () => listeners.get("workspace_event") ?? new Set();
 
 class FakeEventSource {
   onerror: ((event: Event) => void) | null = null;
@@ -26,12 +34,14 @@ class FakeEventSource {
     eventSourceCtor(url);
   }
 
-  addEventListener(_type: string, handler: (event: MessageEvent<string>) => void) {
-    listeners.add(handler);
+  addEventListener(type: string, handler: SseHandler) {
+    const set = listeners.get(type) ?? new Set<SseHandler>();
+    set.add(handler);
+    listeners.set(type, set);
   }
 
-  removeEventListener(_type: string, handler: (event: MessageEvent<string>) => void) {
-    listeners.delete(handler);
+  removeEventListener(type: string, handler: SseHandler) {
+    listeners.get(type)?.delete(handler);
   }
 
   close = vi.fn();
@@ -47,7 +57,7 @@ function emitWorkspaceEvent(eventType: string, payload: Record<string, unknown>)
     created_at: "2026-07-15T00:00:00Z",
   });
   act(() => {
-    for (const handler of listeners) {
+    for (const handler of [...workspaceEventListeners()]) {
       handler(new MessageEvent("workspace_event", { data }));
     }
   });
@@ -100,7 +110,7 @@ describe("CallScreenLiveCoachingPanels hydration", () => {
 
     // Transcript tab is the default; the segment is on screen with no traffic.
     expect(screen.getByText("Hello from before the reload")).toBeInTheDocument();
-    expect(listeners.size).toBe(1);
+    expect(workspaceEventListeners().size).toBe(1);
   });
 
   test("hydrated cues are rendered, not just hydrated segments", () => {

--- a/test/ui/call-screen-coaching-hydration.test.tsx
+++ b/test/ui/call-screen-coaching-hydration.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Hydration reaches the panels.
+ *
+ * `initialCoaching` is threaded loader -> useCallScreen -> CallScreen.Layout ->
+ * CallScreenLiveCoachingPanels -> useCallCoaching. These tests drive the last
+ * two links (the component boundary the loader payload actually lands on) and
+ * assert the reload-mid-call behaviour the prop exists for: pre-existing
+ * segments and cues are on screen at first paint, without waiting for SSE.
+ */
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { CallScreenLiveCoachingPanels } from "@/components/call/CallScreen.LiveCoachingPanels";
+import type { CallCoachingHydration } from "@/hooks/call/useCallCoaching";
+
+vi.mock("@/lib/logger.client", () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const eventSourceCtor = vi.fn();
+const listeners = new Set<(event: MessageEvent<string>) => void>();
+
+class FakeEventSource {
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    eventSourceCtor(url);
+  }
+
+  addEventListener(_type: string, handler: (event: MessageEvent<string>) => void) {
+    listeners.add(handler);
+  }
+
+  removeEventListener(_type: string, handler: (event: MessageEvent<string>) => void) {
+    listeners.delete(handler);
+  }
+
+  close = vi.fn();
+}
+
+/** Push one `workspace_event` SSE frame at every mounted subscriber. */
+function emitWorkspaceEvent(eventType: string, payload: Record<string, unknown>) {
+  const data = JSON.stringify({
+    id: 1,
+    workspace_id: "ws-1",
+    event_type: eventType,
+    payload,
+    created_at: "2026-07-15T00:00:00Z",
+  });
+  act(() => {
+    for (const handler of listeners) {
+      handler(new MessageEvent("workspace_event", { data }));
+    }
+  });
+}
+
+const hydration: CallCoachingHydration = {
+  callSid: "CA123",
+  segments: [
+    {
+      id: "seg-1",
+      speaker: 0,
+      speakerLabel: "agent",
+      text: "Hello from before the reload",
+      startMs: 0,
+      endMs: 400,
+      fillerCount: 0,
+    },
+  ],
+  metrics: null,
+  cues: [
+    {
+      eventId: "evt-1",
+      type: "pace",
+      severity: "warn",
+      heading: "Slow down",
+      suggestion: "Breathe between sentences.",
+    },
+  ],
+  session: null,
+};
+
+const bothFlags = { liveTranscription: true, liveCoaching: true };
+
+beforeEach(() => {
+  eventSourceCtor.mockReset();
+  listeners.clear();
+  vi.stubGlobal("EventSource", FakeEventSource);
+});
+
+describe("CallScreenLiveCoachingPanels hydration", () => {
+  test("a late mount mid-call paints pre-existing segments and cues before any SSE frame", () => {
+    render(
+      <CallScreenLiveCoachingPanels
+        workspaceId="ws-1"
+        callSid="CA123"
+        featureFlags={bothFlags}
+        initialCoaching={hydration}
+      />,
+    );
+
+    // Transcript tab is the default; the segment is on screen with no traffic.
+    expect(screen.getByText("Hello from before the reload")).toBeInTheDocument();
+    expect(listeners.size).toBe(1);
+  });
+
+  test("hydrated cues are rendered, not just hydrated segments", () => {
+    render(
+      <CallScreenLiveCoachingPanels
+        workspaceId="ws-1"
+        callSid="CA123"
+        featureFlags={{ liveCoaching: true }}
+        initialCoaching={hydration}
+      />,
+    );
+
+    expect(screen.getByText("Slow down")).toBeInTheDocument();
+    expect(screen.getByText("Breathe between sentences.")).toBeInTheDocument();
+  });
+
+  test("an SSE replay of an already-hydrated segment does not duplicate it", () => {
+    render(
+      <CallScreenLiveCoachingPanels
+        workspaceId="ws-1"
+        callSid="CA123"
+        featureFlags={bothFlags}
+        initialCoaching={hydration}
+      />,
+    );
+
+    // A fresh EventSource has no Last-Event-ID, so the stream replays segments
+    // hydration already delivered. Same segmentId => one row, not two.
+    emitWorkspaceEvent("transcript_segment", {
+      callSid: "CA123",
+      segmentId: "seg-1",
+      speaker: 0,
+      speakerLabel: "agent",
+      text: "Hello from before the reload",
+      startMs: 0,
+      endMs: 400,
+      fillerCount: 0,
+    });
+
+    expect(screen.getAllByText("Hello from before the reload")).toHaveLength(1);
+
+    // A genuinely new segment still lands.
+    emitWorkspaceEvent("transcript_segment", {
+      callSid: "CA123",
+      segmentId: "seg-2",
+      speaker: 1,
+      speakerLabel: "contact",
+      text: "Live segment after hydration",
+      startMs: 500,
+      endMs: 900,
+      fillerCount: 0,
+    });
+
+    expect(screen.getByText("Live segment after hydration")).toBeInTheDocument();
+  });
+
+  test("an SSE replay of a hydrated cue neither duplicates it nor drops its ack", () => {
+    const acknowledged: CallCoachingHydration = {
+      ...hydration,
+      cues: [{ ...hydration.cues[0]!, acknowledgedAt: "2026-07-15T00:00:00Z" }],
+    };
+
+    render(
+      <CallScreenLiveCoachingPanels
+        workspaceId="ws-1"
+        callSid="CA123"
+        featureFlags={{ liveCoaching: true }}
+        initialCoaching={acknowledged}
+      />,
+    );
+
+    // The replayed live event carries no acknowledgedAt; keeping the hydrated
+    // entry is what preserves the ack.
+    emitWorkspaceEvent("coaching_cue", {
+      callSid: "CA123",
+      eventId: "evt-1",
+      type: "pace",
+      severity: "warn",
+      heading: "Slow down",
+      suggestion: "Breathe between sentences.",
+    });
+
+    expect(screen.getAllByText("Slow down")).toHaveLength(1);
+    // An acknowledged cue offers no "Got it" control.
+    expect(
+      screen.queryByRole("button", { name: "Got it" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("hydration for a different call is ignored rather than pinned onto this one", () => {
+    render(
+      <CallScreenLiveCoachingPanels
+        workspaceId="ws-1"
+        callSid="CA-other"
+        featureFlags={bothFlags}
+        initialCoaching={hydration}
+      />,
+    );
+
+    expect(
+      screen.queryByText("Hello from before the reload"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("flags off: hydration is not rendered and no EventSource is opened", () => {
+    const { container } = render(
+      <CallScreenLiveCoachingPanels
+        workspaceId="ws-1"
+        callSid="CA123"
+        featureFlags={{}}
+        initialCoaching={hydration}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(eventSourceCtor).not.toHaveBeenCalled();
+  });
+});

--- a/test/ui/call-screen-live-coaching-panels.test.tsx
+++ b/test/ui/call-screen-live-coaching-panels.test.tsx
@@ -1,0 +1,90 @@
+import { render, renderHook, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { CallScreenLiveCoachingPanels } from "@/components/call/CallScreen.LiveCoachingPanels";
+import { useCallCoaching } from "@/hooks/call/useCallCoaching";
+
+vi.mock("@/lib/logger.client", () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+const eventSourceCtor = vi.fn();
+
+class TrackingEventSource {
+  readonly url: string;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    eventSourceCtor(url);
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  close = vi.fn();
+}
+
+beforeEach(() => {
+  eventSourceCtor.mockReset();
+  vi.stubGlobal("EventSource", TrackingEventSource);
+});
+
+describe("useCallCoaching subscribe gate", () => {
+  test("does not construct an EventSource when subscribe is false", () => {
+    renderHook(() => useCallCoaching("ws-1", "CA123", false));
+    expect(eventSourceCtor).not.toHaveBeenCalled();
+  });
+
+  test("constructs an EventSource when subscribe is true", () => {
+    renderHook(() => useCallCoaching("ws-1", "CA123", true));
+    expect(eventSourceCtor).toHaveBeenCalledWith("/api/workspaces/ws-1/events");
+  });
+
+  test("subscribes by default", () => {
+    renderHook(() => useCallCoaching("ws-1", "CA123"));
+    expect(eventSourceCtor).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not subscribe without a callSid even when enabled", () => {
+    renderHook(() => useCallCoaching("ws-1", null, true));
+    expect(eventSourceCtor).not.toHaveBeenCalled();
+  });
+});
+
+describe("CallScreenLiveCoachingPanels flag matrix", () => {
+  function renderPanels(featureFlags: Record<string, unknown>) {
+    return render(
+      <CallScreenLiveCoachingPanels
+        workspaceId="ws-1"
+        callSid="CA123"
+        featureFlags={featureFlags}
+      />,
+    );
+  }
+
+  test("neither flag: renders nothing and opens no SSE connection", () => {
+    const { container } = renderPanels({});
+    expect(container).toBeEmptyDOMElement();
+    expect(eventSourceCtor).not.toHaveBeenCalled();
+  });
+
+  test("transcription only: transcript tab only", () => {
+    renderPanels({ liveTranscription: true });
+    expect(screen.getByRole("tab", { name: "Transcript" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Coaching" })).not.toBeInTheDocument();
+    expect(eventSourceCtor).toHaveBeenCalledTimes(1);
+  });
+
+  test("coaching only: coaching tab only, no transcript tab", () => {
+    renderPanels({ liveCoaching: true });
+    expect(screen.queryByRole("tab", { name: "Transcript" })).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Coaching" })).toBeInTheDocument();
+    expect(eventSourceCtor).toHaveBeenCalledTimes(1);
+  });
+
+  test("both flags: both tabs", () => {
+    renderPanels({ liveTranscription: true, liveCoaching: true });
+    expect(screen.getByRole("tab", { name: "Transcript" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Coaching" })).toBeInTheDocument();
+    expect(eventSourceCtor).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/ui/campaign-queue-progress.test.tsx
+++ b/test/ui/campaign-queue-progress.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+import {
+  CampaignQueueProgress,
+  campaignQueueProgressTooltip,
+} from "@/components/campaign/CampaignQueueProgress";
+
+describe("CampaignQueueProgress", () => {
+  test("renders completed/total and tooltip text", async () => {
+    render(
+      <CampaignQueueProgress completedCount={142} totalCount={500} />,
+    );
+
+    expect(screen.getByTestId("campaign-queue-progress")).toHaveTextContent(
+      "142 / 500",
+    );
+
+    await userEvent.hover(screen.getByTestId("campaign-queue-progress"));
+    expect(campaignQueueProgressTooltip(142, 500)).toBe("358 left");
+  });
+
+  test("renders nothing when total is zero", () => {
+    render(<CampaignQueueProgress completedCount={0} totalCount={0} />);
+    expect(screen.queryByTestId("campaign-queue-progress")).toBeNull();
+  });
+});

--- a/test/ui/use-call-coaching.test.tsx
+++ b/test/ui/use-call-coaching.test.tsx
@@ -1,0 +1,433 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  useCallCoaching,
+  type CallCoachingHydration,
+} from "@/hooks/call/useCallCoaching";
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+vi.mock("@/lib/logger.client", () => ({ logger: loggerMock }));
+
+const toastMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+/** Captures the handler so tests can push frames the way the SSE loader would. */
+const listeners = new Set<(message: MessageEvent<string>) => void>();
+const eventSourceCtor = vi.fn();
+
+class FakeEventSource {
+  onerror: ((event: Event) => void) | null = null;
+  close = vi.fn();
+
+  constructor(url: string) {
+    eventSourceCtor(url);
+  }
+
+  addEventListener(_type: string, handler: (message: MessageEvent<string>) => void) {
+    listeners.add(handler);
+  }
+
+  removeEventListener(_type: string, handler: (message: MessageEvent<string>) => void) {
+    listeners.delete(handler);
+  }
+}
+
+function emit(record: unknown) {
+  const data = typeof record === "string" ? record : JSON.stringify(record);
+  act(() => {
+    for (const handler of listeners) {
+      handler({ data } as MessageEvent<string>);
+    }
+  });
+}
+
+function frame(event_type: string, payload: unknown) {
+  return { id: 1, workspace_id: "ws-1", event_type, payload, created_at: "2026-07-15T00:00:00Z" };
+}
+
+beforeEach(() => {
+  listeners.clear();
+  eventSourceCtor.mockReset();
+  loggerMock.error.mockReset();
+  toastMock.error.mockReset();
+  vi.stubGlobal("EventSource", FakeEventSource);
+});
+
+describe("SSE subscribe gate (WS-1 behaviour, preserved)", () => {
+  test("does not construct an EventSource when subscribe is false", () => {
+    renderHook(() => useCallCoaching("ws-1", "CA123", false));
+    expect(eventSourceCtor).not.toHaveBeenCalled();
+  });
+
+  test("does not subscribe when subscribe is false even with hydration present", () => {
+    const hydration: CallCoachingHydration = {
+      callSid: "CA123",
+      segments: [
+        {
+          id: "seg-1",
+          speaker: 0,
+          speakerLabel: "agent",
+          text: "hi",
+          startMs: 0,
+          endMs: 10,
+          fillerCount: 0,
+        },
+      ],
+      metrics: null,
+      cues: [],
+      session: null,
+    };
+
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123", false, hydration));
+
+    expect(eventSourceCtor).not.toHaveBeenCalled();
+    // Hydration is loader data, not a subscription — it still seeds.
+    expect(result.current.segments).toHaveLength(1);
+  });
+
+  test("subscribes when enabled and a callSid is present", () => {
+    renderHook(() => useCallCoaching("ws-1", "CA123", true));
+    expect(eventSourceCtor).toHaveBeenCalledWith("/api/workspaces/ws-1/events");
+  });
+});
+
+describe("schema-validated SSE consumption", () => {
+  test("applies a valid transcript_segment event", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+
+    emit(
+      frame("transcript_segment", {
+        callSid: "CA123",
+        segmentId: "seg-1",
+        speaker: 0,
+        speakerLabel: "agent",
+        text: "hello",
+        startMs: 0,
+        endMs: 500,
+        fillerCount: 1,
+      }),
+    );
+
+    expect(result.current.segments).toEqual([
+      {
+        id: "seg-1",
+        speaker: 0,
+        speakerLabel: "agent",
+        text: "hello",
+        startMs: 0,
+        endMs: 500,
+        fillerCount: 1,
+      },
+    ]);
+  });
+
+  test("applies valid metrics, cue and session_final events", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+
+    emit(
+      frame("coaching_metrics", {
+        callSid: "CA123",
+        wpm: 145,
+        fillerCount: 2,
+        pauseCount: 3,
+        longPauseCount: 1,
+      }),
+    );
+    emit(
+      frame("coaching_cue", {
+        callSid: "CA123",
+        eventId: "evt-1",
+        type: "pace",
+        severity: "warn",
+        heading: "Slow down",
+        suggestion: "Breathe.",
+      }),
+    );
+    emit(
+      frame("coaching_session_final", {
+        callSid: "CA123",
+        sessionId: "sess-1",
+        wpmAvg: 140,
+        fillerCount: 2,
+        pauseCount: 3,
+        longPauseCount: 1,
+        score: 88,
+        summary: "Good call.",
+      }),
+    );
+
+    expect(result.current.metrics).toEqual({
+      wpm: 145,
+      fillerCount: 2,
+      pauseCount: 3,
+      longPauseCount: 1,
+    });
+    expect(result.current.cues[0]).toMatchObject({ eventId: "evt-1", heading: "Slow down" });
+    expect(result.current.session).toMatchObject({ score: 88, summary: "Good call." });
+  });
+
+  test("logs and ignores a malformed payload without corrupting state", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+
+    emit(
+      frame("transcript_segment", {
+        callSid: "CA123",
+        segmentId: "seg-1",
+        speaker: 0,
+        speakerLabel: "agent",
+        text: "good",
+        startMs: 0,
+        endMs: 5,
+        fillerCount: 0,
+      }),
+    );
+    // wpm is a string, segmentId missing: both must be dropped, not coerced.
+    emit(frame("coaching_metrics", { callSid: "CA123", wpm: "very fast" }));
+    emit(frame("transcript_segment", { callSid: "CA123", text: "orphan" }));
+
+    expect(result.current.segments).toHaveLength(1);
+    expect(result.current.segments[0]?.text).toBe("good");
+    expect(result.current.metrics).toBeNull();
+    expect(loggerMock.error).toHaveBeenCalledTimes(2);
+  });
+
+  test("logs and ignores a frame that is not valid JSON", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+    expect(() => emit("{not json")).not.toThrow();
+    expect(result.current.segments).toEqual([]);
+    expect(loggerMock.error).toHaveBeenCalledWith("Discarded malformed workspace event frame");
+  });
+
+  test("ignores unrelated workspace events silently", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+    emit(frame("postgres_change", { table: "call", new: {}, old: null }));
+    expect(result.current.segments).toEqual([]);
+    expect(loggerMock.error).not.toHaveBeenCalled();
+  });
+
+  test("ignores events for a different call", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+    emit(
+      frame("coaching_metrics", {
+        callSid: "CA999",
+        wpm: 200,
+        fillerCount: 0,
+        pauseCount: 0,
+        longPauseCount: 0,
+      }),
+    );
+    expect(result.current.metrics).toBeNull();
+  });
+});
+
+describe("hydration", () => {
+  const hydration: CallCoachingHydration = {
+    callSid: "CA123",
+    segments: [
+      {
+        id: "seg-1",
+        speaker: 0,
+        speakerLabel: "agent",
+        text: "earlier line",
+        startMs: 0,
+        endMs: 400,
+        fillerCount: 1,
+      },
+    ],
+    metrics: null,
+    cues: [
+      {
+        eventId: "evt-1",
+        type: "filler",
+        severity: "info",
+        heading: "Fillers",
+        suggestion: "Fewer ums.",
+        acknowledgedAt: "2026-07-15T00:00:00Z",
+      },
+    ],
+    session: null,
+  };
+
+  test("seeds state on the first render, before any SSE frame arrives", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123", true, hydration));
+
+    expect(result.current.segments).toHaveLength(1);
+    expect(result.current.segments[0]?.text).toBe("earlier line");
+    expect(result.current.cues[0]?.acknowledgedAt).toBe("2026-07-15T00:00:00Z");
+  });
+
+  test("ignores hydration belonging to a different call", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA999", true, hydration));
+    expect(result.current.segments).toEqual([]);
+    expect(result.current.cues).toEqual([]);
+  });
+
+  test("live events append onto hydrated state", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123", true, hydration));
+
+    emit(
+      frame("transcript_segment", {
+        callSid: "CA123",
+        segmentId: "seg-2",
+        speaker: 1,
+        speakerLabel: "contact",
+        text: "later line",
+        startMs: 500,
+        endMs: 900,
+        fillerCount: 0,
+      }),
+    );
+
+    expect(result.current.segments.map((s) => s.id)).toEqual(["seg-1", "seg-2"]);
+  });
+
+  test("SSE replay of an already-hydrated segment does not duplicate it", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123", true, hydration));
+
+    emit(
+      frame("transcript_segment", {
+        callSid: "CA123",
+        segmentId: "seg-1",
+        speaker: 0,
+        speakerLabel: "agent",
+        text: "earlier line",
+        startMs: 0,
+        endMs: 400,
+        fillerCount: 1,
+      }),
+    );
+
+    expect(result.current.segments).toHaveLength(1);
+  });
+
+  test("SSE replay of a hydrated cue keeps its acknowledged stamp", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123", true, hydration));
+
+    // Replayed cue events never carry acknowledgedAt; a naive append would
+    // resurrect the "Got it" button on an already-acknowledged cue.
+    emit(
+      frame("coaching_cue", {
+        callSid: "CA123",
+        eventId: "evt-1",
+        type: "filler",
+        severity: "info",
+        heading: "Fillers",
+        suggestion: "Fewer ums.",
+      }),
+    );
+
+    expect(result.current.cues).toHaveLength(1);
+    expect(result.current.cues[0]?.acknowledgedAt).toBe("2026-07-15T00:00:00Z");
+  });
+
+  test("a re-render with a new hydration object identity does not reset live state", () => {
+    const { result, rerender } = renderHook(
+      ({ h }: { h: CallCoachingHydration }) => useCallCoaching("ws-1", "CA123", true, h),
+      { initialProps: { h: hydration } },
+    );
+
+    emit(
+      frame("transcript_segment", {
+        callSid: "CA123",
+        segmentId: "seg-2",
+        speaker: 1,
+        speakerLabel: "contact",
+        text: "live",
+        startMs: 500,
+        endMs: 900,
+        fillerCount: 0,
+      }),
+    );
+
+    // A loader revalidation hands back a structurally-equal but new object.
+    rerender({ h: { ...hydration, segments: [...hydration.segments] } });
+
+    expect(result.current.segments.map((s) => s.id)).toEqual(["seg-1", "seg-2"]);
+  });
+
+  test("switching to a call without hydration clears state", () => {
+    const { result, rerender } = renderHook(
+      ({ sid }: { sid: string }) => useCallCoaching("ws-1", sid, true, hydration),
+      { initialProps: { sid: "CA123" } },
+    );
+    expect(result.current.segments).toHaveLength(1);
+
+    rerender({ sid: "CA456" });
+    expect(result.current.segments).toEqual([]);
+    expect(result.current.cues).toEqual([]);
+  });
+});
+
+describe("acknowledgeCue", () => {
+  const cueFrame = frame("coaching_cue", {
+    callSid: "CA123",
+    eventId: "evt-1",
+    type: "pace",
+    severity: "warn",
+    heading: "Slow down",
+    suggestion: "Breathe.",
+  });
+
+  test("stamps acknowledgedAt when the server accepts", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ ok: true }))));
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+    emit(cueFrame);
+
+    await act(async () => {
+      await result.current.acknowledgeCue("evt-1");
+    });
+
+    expect(result.current.cues[0]?.acknowledgedAt).toBeTruthy();
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  test("a 403 does not leave the cue falsely acknowledged", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("nope", { status: 403 })));
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+    emit(cueFrame);
+
+    await act(async () => {
+      await result.current.acknowledgeCue("evt-1");
+    });
+
+    await waitFor(() => expect(result.current.cues[0]?.acknowledgedAt).toBeUndefined());
+    expect(toastMock.error).toHaveBeenCalledWith(
+      "Could not acknowledge that cue. Please try again.",
+    );
+  });
+
+  test("a 404 does not leave the cue falsely acknowledged", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("gone", { status: 404 })));
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+    emit(cueFrame);
+
+    await act(async () => {
+      await result.current.acknowledgeCue("evt-1");
+    });
+
+    await waitFor(() => expect(result.current.cues[0]?.acknowledgedAt).toBeUndefined());
+  });
+
+  test("a network failure reverts the optimistic stamp and does not throw", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+    emit(cueFrame);
+
+    await act(async () => {
+      await expect(result.current.acknowledgeCue("evt-1")).resolves.toBeUndefined();
+    });
+
+    expect(result.current.cues[0]?.acknowledgedAt).toBeUndefined();
+    expect(toastMock.error).toHaveBeenCalled();
+  });
+});

--- a/test/ui/use-call-coaching.test.tsx
+++ b/test/ui/use-call-coaching.test.tsx
@@ -16,9 +16,17 @@ vi.mock("@/lib/logger.client", () => ({ logger: loggerMock }));
 const toastMock = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
 vi.mock("sonner", () => ({ toast: toastMock }));
 
-/** Captures the handler so tests can push frames the way the SSE loader would. */
-const listeners = new Set<(message: MessageEvent<string>) => void>();
+/**
+ * Captures handlers so tests can push frames the way the SSE loader would.
+ * Keyed by event name: the loader distinguishes `workspace_event` from the
+ * terminal `access_revoked` frame, so the double must too.
+ */
+type SseHandler = (message: MessageEvent<string>) => void;
+const listeners = new Map<string, Set<SseHandler>>();
 const eventSourceCtor = vi.fn();
+/** Constructed instances, so tests can assert close() on the live one. */
+const instances: FakeEventSource[] = [];
+const lastEventSource = () => instances.at(-1)!;
 
 class FakeEventSource {
   onerror: ((event: Event) => void) | null = null;
@@ -26,24 +34,33 @@ class FakeEventSource {
 
   constructor(url: string) {
     eventSourceCtor(url);
+    instances.push(this);
   }
 
-  addEventListener(_type: string, handler: (message: MessageEvent<string>) => void) {
-    listeners.add(handler);
+  addEventListener(type: string, handler: SseHandler) {
+    const set = listeners.get(type) ?? new Set<SseHandler>();
+    set.add(handler);
+    listeners.set(type, set);
   }
 
-  removeEventListener(_type: string, handler: (message: MessageEvent<string>) => void) {
-    listeners.delete(handler);
+  removeEventListener(type: string, handler: SseHandler) {
+    listeners.get(type)?.delete(handler);
   }
 }
 
-function emit(record: unknown) {
-  const data = typeof record === "string" ? record : JSON.stringify(record);
+function emitAs(type: string, data: string) {
   act(() => {
-    for (const handler of listeners) {
+    for (const handler of [...(listeners.get(type) ?? [])]) {
       handler({ data } as MessageEvent<string>);
     }
   });
+}
+
+function emit(record: unknown) {
+  emitAs(
+    "workspace_event",
+    typeof record === "string" ? record : JSON.stringify(record),
+  );
 }
 
 function frame(event_type: string, payload: unknown) {
@@ -52,10 +69,51 @@ function frame(event_type: string, payload: unknown) {
 
 beforeEach(() => {
   listeners.clear();
+  instances.length = 0;
   eventSourceCtor.mockReset();
   loggerMock.error.mockReset();
+  loggerMock.warn.mockReset();
   toastMock.error.mockReset();
   vi.stubGlobal("EventSource", FakeEventSource);
+});
+
+describe("access revoked mid-stream", () => {
+  test("closes the EventSource instead of letting it reconnect", () => {
+    renderHook(() => useCallCoaching("ws-1", "CA123"));
+    const source = lastEventSource();
+    expect(source.close).not.toHaveBeenCalled();
+
+    emitAs("access_revoked", JSON.stringify({ reason: "workspace_access_revoked" }));
+
+    // Without an explicit close, EventSource retries a stream the middleware
+    // will reject every time — a silent reconnect loop.
+    expect(source.close).toHaveBeenCalled();
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+
+  test("leaves already-received transcript state intact", () => {
+    const { result } = renderHook(() => useCallCoaching("ws-1", "CA123"));
+
+    emit(
+      frame("transcript_segment", {
+        callSid: "CA123",
+        segmentId: "seg-1",
+        speaker: 0,
+        speakerLabel: "agent",
+        text: "already delivered",
+        startMs: 0,
+        endMs: 500,
+        fillerCount: 0,
+      }),
+    );
+    expect(result.current.segments).toHaveLength(1);
+
+    emitAs("access_revoked", JSON.stringify({ reason: "workspace_access_revoked" }));
+
+    // Blanking the panel mid-call would read as a transcription failure; the
+    // stream simply stops.
+    expect(result.current.segments).toHaveLength(1);
+  });
 });
 
 describe("SSE subscribe gate (WS-1 behaviour, preserved)", () => {

--- a/test/ui/use-workspace-event-subscription.test.tsx
+++ b/test/ui/use-workspace-event-subscription.test.tsx
@@ -1,0 +1,108 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { useWorkspaceEventSubscription } from "@/hooks/realtime/useWorkspaceEventSubscription";
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+vi.mock("@/lib/logger.client", () => ({ logger: loggerMock }));
+
+type SseHandler = (message: MessageEvent<string>) => void;
+const listeners = new Map<string, Set<SseHandler>>();
+const eventSourceCtor = vi.fn();
+const instances: FakeEventSource[] = [];
+const lastEventSource = () => instances.at(-1)!;
+
+class FakeEventSource {
+  onerror: ((event: Event) => void) | null = null;
+  close = vi.fn();
+
+  constructor(url: string) {
+    eventSourceCtor(url);
+    instances.push(this);
+  }
+
+  addEventListener(type: string, handler: SseHandler) {
+    const set = listeners.get(type) ?? new Set<SseHandler>();
+    set.add(handler);
+    listeners.set(type, set);
+  }
+
+  removeEventListener(type: string, handler: SseHandler) {
+    listeners.get(type)?.delete(handler);
+  }
+}
+
+function emitAs(type: string, data: string) {
+  act(() => {
+    for (const handler of [...(listeners.get(type) ?? [])]) {
+      handler({ data } as MessageEvent<string>);
+    }
+  });
+}
+
+function changeFrame(table: string) {
+  return JSON.stringify({
+    id: 1,
+    workspace_id: "ws-1",
+    event_type: "postgres_change",
+    payload: { table, eventType: "INSERT", new: { id: "c1", workspace: "ws-1" } },
+    created_at: "2026-07-15T00:00:00Z",
+  });
+}
+
+beforeEach(() => {
+  listeners.clear();
+  instances.length = 0;
+  eventSourceCtor.mockReset();
+  loggerMock.warn.mockReset();
+  vi.stubGlobal("EventSource", FakeEventSource);
+});
+
+describe("useWorkspaceEventSubscription", () => {
+  test("dispatches matching postgres_change events to onChange", () => {
+    const onChange = vi.fn();
+    renderHook(() =>
+      useWorkspaceEventSubscription({ workspaceId: "ws-1", table: "campaign", onChange }),
+    );
+
+    emitAs("workspace_event", changeFrame("campaign"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes the EventSource on access_revoked instead of reconnecting", () => {
+    const onChange = vi.fn();
+    renderHook(() =>
+      useWorkspaceEventSubscription({ workspaceId: "ws-1", table: "campaign", onChange }),
+    );
+    const source = lastEventSource();
+    expect(source.close).not.toHaveBeenCalled();
+
+    emitAs("access_revoked", JSON.stringify({ reason: "workspace_access_revoked" }));
+
+    // EventSource reconnects on its own after a server-side close, and the
+    // data-plane middleware would reject every retry — so a revoked tab would
+    // otherwise sit in a reconnect loop.
+    expect(source.close).toHaveBeenCalled();
+    expect(loggerMock.warn).toHaveBeenCalled();
+  });
+
+  test("stops dispatching once access is revoked", () => {
+    const onChange = vi.fn();
+    renderHook(() =>
+      useWorkspaceEventSubscription({ workspaceId: "ws-1", table: "campaign", onChange }),
+    );
+
+    emitAs("access_revoked", JSON.stringify({ reason: "workspace_access_revoked" }));
+    onChange.mockClear();
+
+    // The real EventSource delivers nothing after close(); this asserts the
+    // hook has no path that would keep feeding a revoked subscriber.
+    expect(lastEventSource().close).toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/test/ui/workspace-realtime-revalidation.test.tsx
+++ b/test/ui/workspace-realtime-revalidation.test.tsx
@@ -83,7 +83,7 @@ describe("workspace campaign realtime revalidation", () => {
     ).toBeInTheDocument();
     expect(mocks.subscriptionOptions).toMatchObject({
       workspaceId: "ws-1",
-      table: "campaign",
+      table: ["campaign", "campaign_queue"],
     });
 
     act(() => mocks.subscriptionOptions?.onChange());

--- a/test/webhook-side-effects.test.ts
+++ b/test/webhook-side-effects.test.ts
@@ -15,7 +15,19 @@ const mocks = vi.hoisted(() => ({
   insertTransactionHistoryIdempotent: vi.fn(),
   sendWorkspaceWebhookNotification: vi.fn(async () => ({ success: true })),
   updateCallBySid: vi.fn(),
+  persistCallRecordingToStorage: vi.fn(),
+  isBatchTranscriptionEnabled: vi.fn(),
+  enqueueJob: vi.fn(),
   logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@/lib/worker/handlers/elevenlabs-batch-transcribe.server", () => ({
+  isBatchTranscriptionEnabled: (...args: unknown[]) =>
+    mocks.isBatchTranscriptionEnabled(...args),
+}));
+
+vi.mock("@/lib/worker/enqueue-job.server", () => ({
+  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
 }));
 
 vi.mock("@/lib/telephony-db.server", () => ({
@@ -88,6 +100,11 @@ vi.mock("@/lib/env.server", () => {
 
 vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
 
+vi.mock("@/lib/call-recording-storage.server", () => ({
+  persistCallRecordingToStorage: (...args: unknown[]) =>
+    mocks.persistCallRecordingToStorage(...args),
+}));
+
 describe("webhook side-effect handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,6 +116,9 @@ describe("webhook side-effect handlers", () => {
       outreach_attempt_id: 10,
     });
     mocks.billTerminalCallStatus.mockResolvedValue({ inserted: true });
+    // Batch transcription is default-off; individual tests opt in.
+    mocks.isBatchTranscriptionEnabled.mockResolvedValue(false);
+    mocks.enqueueJob.mockResolvedValue(undefined);
     mocks.resolveCallOutreachContext.mockResolvedValue({
       outreachAttemptId: 10,
       workspaceId: "w1",
@@ -115,6 +135,11 @@ describe("webhook side-effect handlers", () => {
       status: "delivered",
       num_segments: "1",
       num_media: "0",
+    });
+    mocks.persistCallRecordingToStorage.mockResolvedValue({
+      ok: true,
+      audioUrl: "w1/recording-CA1.mp3",
+      skipped: false,
     });
   });
 
@@ -164,18 +189,112 @@ describe("webhook side-effect handlers", () => {
       callSid: "CA1",
       twilioParams: {
         CallSid: "CA1",
+        AccountSid: "ACmain",
         RecordingSid: "RE1",
         RecordingDuration: "12",
       },
     });
 
+    expect(mocks.persistCallRecordingToStorage).toHaveBeenCalledWith({
+      workspaceId: "w1",
+      callSid: "CA1",
+      accountSid: "ACmain",
+      recordingSid: "RE1",
+      existingAudioUrl: undefined,
+    });
     expect(mocks.updateCallBySid).toHaveBeenCalledWith(
       "w1",
       "CA1",
       expect.objectContaining({
         recording_sid: "RE1",
         recording_duration: "12",
+        audio_url: "w1/recording-CA1.mp3",
       }),
     );
+  });
+
+  test("runRecordingSideEffects does not enqueue batch transcription while the flag is off", async () => {
+    const { runRecordingSideEffects } = await import(
+      "@/lib/worker/webhook-side-effects.server"
+    );
+
+    await runRecordingSideEffects({
+      callSid: "CA1",
+      twilioParams: {
+        CallSid: "CA1",
+        AccountSid: "ACmain",
+        RecordingSid: "RE1",
+        RecordingDuration: "12",
+      },
+    });
+
+    // Default-off: the recording still persists, but no batch job is queued.
+    expect(mocks.isBatchTranscriptionEnabled).toHaveBeenCalledWith("w1");
+    expect(mocks.enqueueJob).not.toHaveBeenCalled();
+    expect(mocks.persistCallRecordingToStorage).toHaveBeenCalled();
+  });
+
+  test("runRecordingSideEffects enqueues batch transcription once the flag is on", async () => {
+    mocks.isBatchTranscriptionEnabled.mockResolvedValue(true);
+
+    const { runRecordingSideEffects } = await import(
+      "@/lib/worker/webhook-side-effects.server"
+    );
+
+    await runRecordingSideEffects({
+      callSid: "CA1",
+      twilioParams: {
+        CallSid: "CA1",
+        AccountSid: "ACmain",
+        RecordingSid: "RE1",
+        RecordingDuration: "12",
+      },
+    });
+
+    expect(mocks.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "elevenlabs_batch_transcribe",
+        workspaceId: "w1",
+        params: { callSid: "CA1" },
+      }),
+    );
+  });
+
+  test("runRecordingSideEffects logs and continues when persist fails", async () => {
+    mocks.persistCallRecordingToStorage.mockResolvedValueOnce({
+      ok: false,
+      reason: "download_failed",
+      error: "Twilio recording fetch failed (404 Not Found)",
+    });
+
+    const { runRecordingSideEffects } = await import(
+      "@/lib/worker/webhook-side-effects.server"
+    );
+
+    await expect(
+      runRecordingSideEffects({
+        callSid: "CA1",
+        twilioParams: {
+          CallSid: "CA1",
+          AccountSid: "ACmain",
+          RecordingSid: "RE1",
+          RecordingDuration: "12",
+        },
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      "call_recording.persist_skipped",
+      expect.objectContaining({ reason: "download_failed" }),
+    );
+    expect(mocks.updateCallBySid).toHaveBeenCalledWith("w1", "CA1", {
+      recording_sid: "RE1",
+      recording_duration: "12",
+    });
+    const updatePayload = mocks.updateCallBySid.mock.calls.at(-1)?.[2] as Record<
+      string,
+      string
+    >;
+    expect(updatePayload.audio_url).toBeUndefined();
   });
 });

--- a/test/workspace-events.route.test.ts
+++ b/test/workspace-events.route.test.ts
@@ -10,6 +10,11 @@ const mocks = vi.hoisted(() => ({
   fetchWorkspaceEventsAfter: vi.fn(),
   listen: vi.fn(),
   getSession: vi.fn(),
+  getUserRole: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace-membership.server", () => ({
+  getUserRole: (...args: unknown[]) => mocks.getUserRole(...args),
 }));
 
 vi.mock("@/lib/workspace-events.server", () => ({
@@ -37,6 +42,135 @@ describe("app/routes/api+/workspaces+/$workspaceId/events", () => {
     mocks.getSession.mockResolvedValue({ user: { id: "u1" }, headers: new Headers() });
     mocks.fetchWorkspaceEventsAfter.mockResolvedValue([]);
     mocks.listen.mockRejectedValue(new Error("LISTEN unavailable"));
+    mocks.getUserRole.mockReset();
+    mocks.getUserRole.mockResolvedValue({ role: "member" });
+  });
+
+  /** Drain an SSE body in the background, accumulating decoded text. */
+  function drain(response: Response) {
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    const state = { text: "", done: false };
+    void (async () => {
+      try {
+        for (;;) {
+          const chunk = await reader.read();
+          if (chunk.done) break;
+          state.text += decoder.decode(chunk.value, { stream: true });
+        }
+      } catch {
+        // Stream torn down; `done` below is what the assertions care about.
+      }
+      state.done = true;
+    })();
+    return state;
+  }
+
+  function eventRow(id: number, text: string) {
+    return {
+      id,
+      workspace_id: "ws-1",
+      event_type: "transcript_segment",
+      payload: { callSid: "CA1", text },
+      created_at: "2026-07-15T00:00:00.000Z",
+    };
+  }
+
+  test("stops streaming once the member's access is revoked mid-stream", async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await import(
+        "../app/routes/api+/workspaces+/$workspaceId/events.loader.server"
+      );
+      const response = await mod.loader(
+        await withDataPlaneRouteArgs({
+          request: new Request("http://localhost/api/workspaces/ws-1/events"),
+          params: { workspaceId: "ws-1" },
+        }),
+      );
+      const sse = drain(response as Response);
+
+      // Still a member: transcript content flows as normal.
+      mocks.fetchWorkspaceEventsAfter
+        .mockResolvedValueOnce([eventRow(1, "while-a-member")])
+        .mockResolvedValue([]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(sse.text).toContain("while-a-member");
+
+      // Access is revoked. The re-check rides the heartbeat, so exposure is
+      // bounded by one heartbeat interval — not zero.
+      mocks.getUserRole.mockResolvedValue(null);
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(sse.text).toContain("access_revoked");
+      expect(sse.done).toBe(true);
+
+      // Nothing further reaches a revoked member, even as events keep landing.
+      mocks.fetchWorkspaceEventsAfter
+        .mockResolvedValueOnce([eventRow(2, "after-revocation")])
+        .mockResolvedValue([]);
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(sse.text).not.toContain("after-revocation");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("keeps streaming while membership holds, and re-checks on heartbeat", async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await import(
+        "../app/routes/api+/workspaces+/$workspaceId/events.loader.server"
+      );
+      const response = await mod.loader(
+        await withDataPlaneRouteArgs({
+          request: new Request("http://localhost/api/workspaces/ws-1/events"),
+          params: { workspaceId: "ws-1" },
+        }),
+      );
+      const sse = drain(response as Response);
+
+      await vi.advanceTimersByTimeAsync(45_000);
+
+      expect(mocks.getUserRole).toHaveBeenCalled();
+      expect(sse.text).not.toContain("access_revoked");
+      expect(sse.done).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a transient membership-lookup failure does not drop the stream", async () => {
+    vi.useFakeTimers();
+    try {
+      const mod = await import(
+        "../app/routes/api+/workspaces+/$workspaceId/events.loader.server"
+      );
+      const response = await mod.loader(
+        await withDataPlaneRouteArgs({
+          request: new Request("http://localhost/api/workspaces/ws-1/events"),
+          params: { workspaceId: "ws-1" },
+        }),
+      );
+      const sse = drain(response as Response);
+
+      // A DB blip is not evidence of revocation; connect-time auth already
+      // passed. Tearing every stream down on a hiccup would be a self-inflicted
+      // outage, and the next tick re-checks anyway.
+      mocks.getUserRole.mockRejectedValue(new Error("connection terminated"));
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(sse.text).not.toContain("access_revoked");
+      expect(sse.done).toBe(false);
+
+      // ...but a real revocation still closes it on a later tick.
+      mocks.getUserRole.mockResolvedValue(null);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(sse.text).toContain("access_revoked");
+      expect(sse.done).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("loader returns SSE stream when data-plane context is present", async () => {


### PR DESCRIPTION
Live transcription and coaching, plus the remediation that made it safe to ship. Split out of one 65-file commit into six reviewable commits — the first four are unrelated to coaching and can be reviewed independently.

## Ships dark

All three flags (`liveTranscription`, `liveCoaching`, `batchTranscription`) default `false`, and the `workspace.feature_flags` DB default contains no coaching keys, so every existing workspace parses to all-off. With flags off there is no `<Stream>`, no STT, no EventSource, no hydration, no coaching UI, and no billing. `hasFeatureFlag` fails closed on a parse error.

The one user-visible change on merge is the campaign queue progress UI (its own commit, unrelated to coaching).

## Commits

| Commit | What |
|---|---|
| `refactor(data-plane)` | Collapse five `authForX` helpers into `authForResource`. **Not purely mechanical** — `authForScript`/`authForSurvey` now route through `enforceWorkspaceRole`. Behaviour-preserving at every current call site; split out so the auth path gets reviewed on its own. |
| `refactor(routes)` | Adopt `parseActionRequest` (2 files). |
| `refactor(outreach)` | Extract typed-field parsing from `questions.action.server.ts` (−138 lines), reuse in IVR. |
| `feat(campaign)` | Queue progress in nav + header. Also fixes a test that had been failing since the subscription began covering `campaign_queue`. |
| `docs` | e2e nitpick plan (its own "Out of scope" section names live coaching as separate work). |
| `feat(coaching)` | The feature + remediation. |
| `fix(events)` | SSE access re-check (independent of coaching — see below). |

## Bugs fixed along the way

**Unbilled STT.** STT opened unconditionally, but the debit lived inside `finalizeCoachingSession()`, which only ran when coaching was on — so every transcription-only call ran ElevenLabs STT free, and the debit that did fire measured the coaching clock, not the STT clock. Billing now follows the STT lifecycle.

**Why the guards missed it.** `services/` was outside both safety nets: `check-credit-write-paths.mjs` didn't scan it, and `tsconfig.json` didn't typecheck it. Both closed. Typechecking the service immediately found a real bug — an `as ArrayBuffer` cast on a value Bun delivers as a `Buffer`.

**False reconciliation alerts.** Transcription/coaching keys were handwritten and fell into the `other` bucket, which feeds `unrecognizedDebitEvents` — any value > 0 raises an alert. Now canonical keys in a new `ai` bucket, kept out of `voice` (which reconciles unit-for-unit against Twilio minutes).

**Coaching-only workspaces got no stream.** TwiML gated on `liveTranscription` while the UI gated on either flag, so coaching-only rendered panels that could never receive events. One `liveMediaCapabilities()` now interprets the flags for TwiML, the service, the UI, and the SSE hook.

**SSE access was never re-checked.** Membership was verified once at connect; the stream then outlived that check indefinitely, so a removed member kept receiving events — including verbatim transcripts — on an open tab. Now re-checked on the heartbeat with a terminal `access_revoked` frame. This endpoint predates coaching; coaching only raised what flows through it.

Also: `coaching-ack` no longer reaches the unscoped admin client from a route (ADR-0004) and proves workspace ownership before reading cue data; `MEDIA_STREAM_HOST` defaults to localhost only outside production, so an unset host in prod fails closed and logs instead of emitting an unreachable `wss://localhost` URL.

## Decisions recorded

- `liveCoaching` implies `liveTranscription` **at runtime only** — persisted flags stay independent.
- Batch transcription is **gated off pending a product decision** (paid golden transcript vs fallback). Handler intact; flipping the flag is the only change needed.
- Cue acknowledgement stays open to **any workspace member**, unchanged.
- Access re-check rides the 15s heartbeat: revocation takes up to 15s rather than costing 7.5× the lookups on the 2s poll. A failed lookup keeps the stream — a DB blip isn't evidence of revocation.

## Verification

Typecheck clean (root + `services/`), full lint clean, `check:route-server-leaks` / `check:twilio-webhooks` / `check:middleware` / `check:credit-writes` pass.

Two known failures are **pre-existing on `dev`** and fixed by #1052, not by this PR: `typecheck` on `normalize.server.ts` and `check:effects` on `mode-toggle.tsx` / `workspaces+/index.tsx`. Verified against a clean `dev` worktree; this branch newly breaks zero test files and fixes one (`feature-flags.test.ts` imported `bun:test` and had never run).

Merges cleanly with #1052; the merged tree typechecks green. Note `typecheck` chains `tsc && tsc -p services/tsconfig.json`, so the new services check is skipped until #1052 lands and `dev` is green again.

Local Node 25 vs CI's 22 manufactures ~218 unrelated failures locally; attribution above is against a clean `dev` baseline, not raw counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)