### PR TITLE
Fix e2e nitpick follow-ups: pool timeouts, SMS send window, polish

### DIFF
--- a/app/components/campaign/settings/basic/CampaignBasicInfo.Dates.tsx
+++ b/app/components/campaign/settings/basic/CampaignBasicInfo.Dates.tsx
@@ -93,9 +93,10 @@ function parseSchedule(schedule: Campaign["schedule"]): Record<DayName, Schedule
 }
 
 /**
- * SMS campaigns dispatch messages rather than dial, so the same weekly schedule
- * is presented as a "send window". The stored field is `campaign.schedule`
- * either way — only the wording changes.
+ * SMS campaigns dispatch messages rather than dial, so the same weekly editor
+ * is presented as a "send window". Message campaigns persist
+ * `campaign.sms_send_window` (server-enforced); voice campaigns keep
+ * `campaign.schedule` (calling hours).
  */
 const SCHEDULE_COPY = {
   call: {
@@ -105,6 +106,7 @@ const SCHEDULE_COPY = {
     apply: "Apply Calling Hours",
     empty: "No calling hours set",
     endTooltip: "The latest time to begin dialing.",
+    field: "schedule" as const,
   },
   message: {
     label: "Send Window",
@@ -113,8 +115,15 @@ const SCHEDULE_COPY = {
     apply: "Apply Send Window",
     empty: "No send window set",
     endTooltip: "The latest time to send messages.",
+    field: "sms_send_window" as const,
   },
 } as const;
+
+function scheduleSourceForCampaign(campaignData: Campaign): unknown {
+  return campaignData.type === "message"
+    ? (campaignData as Campaign & { sms_send_window?: unknown }).sms_send_window
+    : campaignData.schedule;
+}
 
 export default function SelectDates({
   campaignData,
@@ -123,13 +132,14 @@ export default function SelectDates({
   const copy =
     campaignData.type === "message" ? SCHEDULE_COPY.message : SCHEDULE_COPY.call;
   const [showSchedule, setShowSchedule] = useState(false);
+  const scheduleSource = scheduleSourceForCampaign(campaignData);
   const [currentSchedule, setCurrentSchedule] = useState<Record<DayName, ScheduleDay>>(() =>
-    parseSchedule(campaignData.schedule),
+    parseSchedule(scheduleSource as Campaign["schedule"]),
   );
-  const [prevSchedule, setPrevSchedule] = useState(campaignData.schedule);
-  if (prevSchedule !== campaignData.schedule) {
-    setPrevSchedule(campaignData.schedule);
-    setCurrentSchedule(parseSchedule(campaignData.schedule));
+  const [prevScheduleSource, setPrevScheduleSource] = useState(scheduleSource);
+  if (prevScheduleSource !== scheduleSource) {
+    setPrevScheduleSource(scheduleSource);
+    setCurrentSchedule(parseSchedule(scheduleSource as Campaign["schedule"]));
   }
 
   const utcToLocal = (utcTime: string) => {
@@ -238,7 +248,7 @@ export default function SelectDates({
     }), {} as Record<DayName, ScheduleDay>);
     
     // Convert to a JSONB-compatible string for Postgres
-    handleInputChange("schedule", JSON.stringify(cleanSchedule));
+    handleInputChange(copy.field, JSON.stringify(cleanSchedule));
     setShowSchedule(false);
   };
 
@@ -360,7 +370,7 @@ export default function SelectDates({
                   applyScheduleToAll({ start: localToUTC("09:00"), end: localToUTC("17:00") })
                 }}
               >
-                Apply 9-5 to All Days
+                Apply 09:00–17:00 local to All Days
               </Button>
               <Button
                 variant="outline"
@@ -370,7 +380,7 @@ export default function SelectDates({
                   applyScheduleToWeekdays({ start: localToUTC("09:00"), end: localToUTC("17:00") })
                 }}
               >
-                Apply 9-5 to Weekdays
+                Apply 09:00–17:00 local to Weekdays
               </Button>
             </div>
             <WeeklyScheduleTable

--- a/app/components/campaign/settings/basic/CampaignBasicInfo.Schedule.tsx
+++ b/app/components/campaign/settings/basic/CampaignBasicInfo.Schedule.tsx
@@ -51,6 +51,7 @@ const WeeklyScheduleTable = ({
             <TableCell>{day}</TableCell>
             <TableCell>
               <Checkbox
+                aria-label={`${day} active`}
                 checked={schedule[day.toLowerCase() as DayName]?.active}
                 onCheckedChange={(e) => {
                   handleCheckboxChange(day.toLowerCase() as DayName)

--- a/app/components/layout/Navbar.MobileMenu.tsx
+++ b/app/components/layout/Navbar.MobileMenu.tsx
@@ -110,8 +110,7 @@ export const MobileMenu = ({
                   onClick={close}
                   className={navLinkClass}
                 >
-                  {user.workspace_invite.length} Pending Invitation
-                  {user.workspace_invite.length !== 1 ? "s" : ""}
+                  {`${user.workspace_invite.length} Pending Invitation${user.workspace_invite.length === 1 ? "" : "s"}`}
                 </NavLink>
               </div>
               <Button

--- a/app/components/layout/Navbar.tsx
+++ b/app/components/layout/Navbar.tsx
@@ -119,8 +119,7 @@ const UserDropdownMenu = ({
               user.workspace_invite.length > 0 ? "bg-primary text-white" : ""
             }
           >
-            {user.workspace_invite.length} Pending Invitation
-            {user.workspace_invite.length !== 1 ? "s" : ""}
+            {`${user.workspace_invite.length} Pending Invitation${user.workspace_invite.length === 1 ? "" : "s"}`}
           </NavLink>
         </DropdownMenuItem>
         {workspaceId && (

--- a/app/components/phone-numbers/NumbersTable.tsx
+++ b/app/components/phone-numbers/NumbersTable.tsx
@@ -144,7 +144,7 @@ export const NumbersTable = ({
 
   return (
       <>
-      <Heading className="text-center" branded>
+      <Heading as="h2" className="text-center" branded>
       {title}
     </Heading><div className="flex flex-col py-4">
         {numbers.length === 0 ? (

--- a/app/components/queue/QueueTable.tsx
+++ b/app/components/queue/QueueTable.tsx
@@ -73,9 +73,18 @@ function QueueSortButton<TData>({
             size="sm"
             aria-label={`Sort by ${label}`}
             onClick={() => {
-                column.toggleSorting();
-                const sort = column.getIsSorted();
-                onSortChange('sort', sort ? `${field}.${sort}` : '');
+                // Compute next sort before toggling — getIsSorted() still
+                // returns the pre-toggle value if read immediately after
+                // toggleSorting() (React state update is async).
+                const current = column.getIsSorted();
+                const next: false | "asc" | "desc" =
+                    current === false ? "asc" : current === "asc" ? "desc" : false;
+                if (next === false) {
+                    column.clearSorting();
+                } else {
+                    column.toggleSorting(next === "desc", false);
+                }
+                onSortChange("sort", next ? `${field}.${next}` : "");
             }}
             className="h-6 px-1"
         >

--- a/app/lib/campaign-settings.ts
+++ b/app/lib/campaign-settings.ts
@@ -32,6 +32,10 @@ export function normalizeCampaignData(
   return {
     ...campaignData,
     schedule: normalizeSchedule(campaignData.schedule) as Schedule | null,
+    sms_send_window: normalizeSchedule(
+      (campaignData as CampaignWithAudiences & { sms_send_window?: unknown })
+        .sms_send_window,
+    ),
   } as CampaignWithAudiences;
 }
 

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/settings.action.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/settings.action.server.ts
@@ -130,6 +130,7 @@ export const action = defineAction({
             campaign_id: Number(selected_id),
             workspace: workspace_id,
             schedule: normalizeSchedule(nextCampaignData.schedule),
+            sms_send_window: normalizeSchedule(nextCampaignData.sms_send_window),
           },
           campaignDetails: {
             ...nextCampaignDetails,

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/settings.route.tsx
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/settings.route.tsx
@@ -340,7 +340,7 @@ export default function CampaignSettingsRoute() {
         ? value === "" || value == null
           ? null
           : Number(value)
-        : name === "schedule"
+        : name === "schedule" || name === "sms_send_window"
           ? normalizeSchedule(value)
           : value;
 

--- a/app/routes/workspaces+/$id/settings/numbers.route.tsx
+++ b/app/routes/workspaces+/$id/settings/numbers.route.tsx
@@ -288,6 +288,9 @@ const WorkspaceSettings = () => {
       </Dialog>
       <div className="flex flex-col">
         <BackButton disabled={updateFetcher.state !== "idle"} />
+        <h1 className="px-4 pt-2 text-2xl font-semibold tracking-tight">
+          Phone numbers
+        </h1>
         <div className="flex flex-wrap gap-4 p-4">
           <Panel className="flex-shrink-0 flex-grow basis-full lg:basis-[calc(66.666%-1rem)]">
             <NumbersTable

--- a/app/server/db.ts
+++ b/app/server/db.ts
@@ -12,11 +12,26 @@ if (!DATABASE_URL) {
   );
 }
 
+/**
+ * Shared pool options. Fail closed under contention rather than queue forever
+ * (CI/local may see faster connect failures — that is intentional).
+ * Values are seconds (postgres.js conventions).
+ */
+const poolOpts = {
+  prepare: false,
+  connect_timeout: 10,
+  idle_timeout: 20,
+  max_lifetime: 60 * 30,
+} as const;
+
 /** Connection pool for queries (uses pgbouncer-friendly URL if separate). */
-const queryClient = postgres(DATABASE_URL as string, { prepare: false, max: 10 });
+const queryClient = postgres(DATABASE_URL as string, { ...poolOpts, max: 10 });
 
 /** Direct connection for LISTEN/NOTIFY (no pgbouncer). */
-const directClient = postgres((DATABASE_DIRECT_URL as string) ?? (DATABASE_URL as string), { prepare: false, max: 5 });
+const directClient = postgres(
+  (DATABASE_DIRECT_URL as string) ?? (DATABASE_URL as string),
+  { ...poolOpts, max: 5 },
+);
 
 /** Drizzle instance for all ORM queries. */
 export const db = drizzle(queryClient, { schema: { ...schema, ...authSchema } });

--- a/docs/migration-ledger-drift.md
+++ b/docs/migration-ledger-drift.md
@@ -66,6 +66,14 @@ its failure is total and silent apart from the user-facing error.
 Both paths call `apply_ledger_entry_and_sync_credits`, so a stale ledger
 function breaks both anyway. There is no fallback for schema drift.
 
+## Review-env ops notes (2026-07-15)
+
+- From a laptop, point the ledger check at **`DATABASE_PUBLIC_URL`**, not
+  `DATABASE_URL` (`*.railway.internal` is unreachable outside Railway).
+- The check script queries `AUTH_migrations.schema_migrations` **unquoted**, so
+  Postgres folds the schema name to **`auth_migrations`**. Create/seed that
+  lowercase schema (a quoted `"AUTH_migrations"` schema will not match).
+
 ## Checklist when credits or money behave strangely
 
 1. Run the ledger check against that environment with `--require-db`.

--- a/docs/remediation/PROMPT-fulsome-remediation-plan.md
+++ b/docs/remediation/PROMPT-fulsome-remediation-plan.md
@@ -1,0 +1,63 @@
+# Prompt: Write a fulsome remediation plan from an audit
+
+Paste the block below into a new agent chat after an audit (browser nitpick, thermo-nuclear review, static critical review, etc.). Fill the bracketed placeholders first.
+
+---
+
+```text
+Create a fulsome remediation plan document for CallCaster from the audit below. Do not implement yet — plan only.
+
+## Context to use
+
+- Repo: CallCaster (React Router 8, tenant Drizzle, Railway review env)
+- Read before writing: `AGENTS.md`, `docs/AGENT-PLATFORM-GUIDE.md`, and the closest existing plan under `docs/remediation/` for tone/structure (e.g. `e2e-nitpick-remediation-plan-2026-07-15.md` or `live-coaching-orchestrator-plan-2026-07-15.md` or `critical-review-orchestration-plan-2026-07-12.md`)
+- Audit source: [canvas path / transcript / PR / commit range / env URL]
+- Environment (if live): [review URL, workspace id, role, constraints like 0 credits / 2FA disabled]
+- Already fixed / out of scope: [list]
+- Companion artifacts: [canvas, agent transcript id]
+
+## Audit findings (paste full inventory)
+
+[PASTE findings: severity, symptoms, routes, suspected root causes, file paths if known]
+
+## Output requirements
+
+Write a markdown plan to:
+
+`docs/remediation/<slug>-remediation-plan-YYYY-MM-DD.md`
+
+Use today's date in the filename and header. Match this section structure unless a finding set clearly needs fewer waves:
+
+1. **Header metadata** — date, prepared-from, environment, status (Open), links to companion artifacts
+2. **Commander's intent** — 4–6 numbered outcomes; security/boundary before polish; say what this plan does *not* replace
+3. **Key results / definition of done** — measurable KR table with verification method; secondary wave-2 results as a short list
+4. **Methodology and limitations** — what was exercised, what was not, live infra mitigations / debt
+5. **Already resolved** — closed items so agents do not re-fix
+6. **Findings inventory** — P0/P1/P2/P3 with stable IDs (`SEC-…`, `JOURNEY-…`, `UX-…`, `A11Y-…`, `LOW-…`); each P0/P1 item needs: severity, routes, symptom, root cause, fix strategy, primary files
+7. **Implementation waves** — Wave 0 infra if needed; Wave 1 blockers ordered A→F; Wave 2 polish batches; Wave 3 deferred nitpick. Exit criteria per wave.
+8. **File touchpoint matrix** — finding → files → tests to add/update; call out server-only helpers that must *not* be swapped for client projections
+9. **Test plan** — automated commands (`ci:local`, targeted tests) + manual review-env checklist + regression risks table
+10. **Repository invariants** — short AGENTS.md reminder (tenant db, no secrets in responses, no `.env` edits, etc.)
+11. **Suggested PR structure** — small stacked PRs with merge order
+12. **Coverage matrix** — surface × status (OK / Open / Fixed)
+13. **Out of scope**
+14. **Open questions** — with a default if unanswered
+15. **References**
+
+## Quality bar
+
+- Re-verify suspected root causes against current source before locking fix strategies (grep loaders, components, routes). Prefer file paths that exist today.
+- Prefer concrete acceptance criteria ("`.data` must not contain `authToken`") over vague goals.
+- Security and crash/journey blockers before a11y/copy polish.
+- Do not invent findings not in the audit; mark unknowns as open questions.
+- Do not start implementation, create todos for coding, or commit unless I explicitly ask after the plan lands.
+- Keep the doc self-contained enough that a fresh agent can execute Wave 1 without the original chat.
+```
+
+---
+
+## Shorter variant (when the audit canvas/transcript is already in context)
+
+```text
+Create a fulsome remediation plan from this audit session (canvas + transcript). Write `docs/remediation/<slug>-remediation-plan-YYYY-MM-DD.md` in the style of `docs/remediation/e2e-nitpick-remediation-plan-2026-07-15.md`: commander's intent, KR table, methodology/limitations, already-resolved, P0–P3 inventory with root cause + fix strategy, waves with exit criteria, file touchpoints, test plan, PR split, coverage matrix, open questions. Re-verify root causes against current code. Plan only — no implementation.
+```

--- a/docs/remediation/e2e-nitpick-followup-remediation-plan-2026-07-15.md
+++ b/docs/remediation/e2e-nitpick-followup-remediation-plan-2026-07-15.md
@@ -1,0 +1,336 @@
+# CallCaster E2E Nitpick — Follow-up Remediation Plan (post-#1052)
+
+**Date:** 2026-07-15  
+**Prepared from:** Browser re-verification of Railway review env against current `origin/dev` (`4bc2d032` — Fix e2e nitpick audit findings, and get dev green #1052), plus corrections in [`e2e-nitpick-status-2026-07-15.md`](./e2e-nitpick-status-2026-07-15.md)  
+**Environment:** `https://callcaster-review-visual-asset-review.up.railway.app/`  
+**Test workspace:** `25dcc770-e805-4162-8940-ab7f95fd57c1` (owner, incomplete onboarding, 0 credits) — UI label `Audit Workspace Fixed 1784137242790`  
+**Test campaigns:** `Audit Live Campaign` (id 1), `Audit SMS Campaign` (id 2)  
+**Companion artifacts:** [`e2e-nitpick-status-2026-07-15.md`](./e2e-nitpick-status-2026-07-15.md), [`docs/migration-ledger-drift.md`](../migration-ledger-drift.md), PR [#1052](https://github.com/chester-hill-solutions/callcaster/pull/1052)  
+**Status:** Complete on `fix/e2e-nitpick-followup` (2026-07-15) — Wave 0 review ledger gated; Waves 1–2 app fixes landed; KR-1–4 met on review
+
+---
+
+## 1. Commander's intent
+
+Close the residual risk left after #1052 so review/staging and production cannot silently fail on infra drift or misconfigured send windows, without re-litigating journeys already proven fixed in the browser:
+
+1. **Gate deploy-time schema/ledger sync** so credit purchases and additive columns cannot diverge from app HEAD.
+2. **Make SMS send-window policy editable and honest** — users must set the field the server enforces (`campaign.sms_send_window`), not only the voice `schedule` relabeled as "Send Window".
+3. **Bound Postgres pool wait** so saturated query/LISTEN pools fail closed instead of hanging SSR and API forever.
+4. **Diagnose SSE pool coupling** before treating console noise as cosmetic — confirm whether each EventSource holds a `directPool` LISTEN slot.
+5. **Defer polish** (queue sort lag, heading hierarchy, invite plural a11y, schedule checkbox labels) to a second wave after infra and SMS policy.
+
+This plan does **not** replace the [Critical Review Orchestration Plan](./critical-review-orchestration-plan-2026-07-12.md) or the [live coaching orchestrator plan](./live-coaching-orchestrator-plan-2026-07-15.md). It operationalizes **what is still open** after the original e2e nitpick Wave 1 landed on `dev`.
+
+---
+
+## 2. Key results (definition of done)
+
+| # | Result | Verification |
+|---|--------|--------------|
+| KR-1 | **Review (and other) DBs pass ledger gate** | `DATABASE_URL=<env> node scripts/db/check-migration-ledger.mjs --require-db` exits 0 after migrate, before app redeploy |
+| KR-2 | **SMS send window is user-editable and enforced** | SMS settings persist `sms_send_window`; `api+/sms.action.server.ts` still gates via `isWithinSendWindow`; browser can set Mon–Fri hours and see them round-trip |
+| KR-3 | **Query pool cannot hang forever** | `app/server/db.ts` sets explicit `connect_timeout` / `idle_timeout` / `max_lifetime` (and document chosen values); a saturated pool returns errors within the connect timeout rather than queueing indefinitely |
+| KR-4 | **SSE vs pool documented or fixed** | Written finding: either (a) LISTEN uses dedicated `directPool` with documented max and no query-pool starvation, or (b) code change so SSE does not monopolize connections; include a short repro note |
+
+Secondary (wave 2): queue sort reflects click immediately; page-level `h1` on `settings/numbers`; invite menu plural without spoken gap; schedule day checkboxes named.
+
+---
+
+## 3. Audit methodology and limitations
+
+### What was re-exercised (browser, 2026-07-15)
+
+**Pass A — original KR surfaces**
+
+- Owner session on review env; workspace home → onboarding, campaigns, contacts, voicemails, settings/numbers, billing, join-call, global 404.
+- Route `.data` JSON for contacts / scripts / audiences / audios: **no** `authToken`, `twilio_data`, `stripe_id`, `key`, Twilio SID/SK patterns.
+- Campaign hub `/campaigns/1`: empty-results hero ("Your Campaign Results Will Show Here") — **no** perpetual Loading / React #419.
+- Join call `/campaigns/1/call`: renders (inactive / 0 credits / no script overlays) — **no** disposition crash.
+- Contacts `/contacts/new`: `ContactScreen` form; Edit enables fields.
+- Voicemail setup: CTA `href` = `/workspaces/:id/settings/numbers` (absolute workspace path); numbers page loads.
+- Global 404: "Page not found" with Go home / Try again — **no** throw.
+- Onboarding step 1 empty Save & continue: required fields `aria-invalid` + inline errors; stays on step.
+- SMS campaign settings: UI shows **Send Window** / **Set Send Window** but code still writes `campaign.schedule` (see UX-SMS-01).
+
+**Pass B — continued workspace walk (same session)**
+
+| Surface | Result |
+|---------|--------|
+| SMS settings → expand Send Window | Editor opens; day **Active** checkboxes have **no accessible name**; "Apply 9-5" buttons vs displayed `05:00–13:00` (local TZ) — confusing |
+| Live campaign settings | Correctly labeled **Calling Hours** (not Send Window); script select `aria-invalid` when empty (expected) |
+| Queue (SMS, empty) | Sort/filter controls named; empty table OK (sort-lag not re-proven without rows) |
+| Scripts list + `/scripts/1` | Editor loads; dirty → single **Save Changes** + Reset only (status-doc dual-Save **not reproduced**) |
+| Settings (members/invite/API/webhook) | Renders; invite form present |
+| Audiences / Surveys / Audio / Archives / Exports | Empty states OK, HTTP 200 |
+| Analytics | Date filters + zero metrics OK |
+| Handset | Empty-state with link to workspace settings |
+| Chats | Empty + New Chat composer; From disabled without numbers |
+| Calls | Filters + empty pagination OK |
+| Account menu (dark) | Opens; account control contrast ~16:1; spoken name `0 Pending Invitation s` (newline before plural `s`) |
+| SSE `/api/workspaces/:id/events` | Single EventSource reached `open` within 3s |
+
+### What was not exercised
+
+- Live Twilio device / coaching panels / disposition save loop after join
+- Stripe checkout completion on review (0 credits; ledger drift still a risk until Wave 0)
+- Admin surfaces, survey **editor** (list only), full keyboard-only traversal
+- Multi-tab EventSource load test (pool exhaustion) — single connection OK
+
+### Live infra note
+
+Wave 0 (migration ledger) still requires operator access per environment. App code cannot detect ledger drift alone — see [`docs/migration-ledger-drift.md`](../migration-ledger-drift.md).
+
+---
+
+## 4. Already resolved (do not re-fix)
+
+Landed on `dev` via #1052 (`4bc2d032`). Browser re-check **passed** for each KR below.
+
+| ID | Item | Evidence |
+|----|------|----------|
+| SEC-01 | Workspace secrets stripped from route `.data` | `getWorkspaceForClient()` + `check:workspace-projection` + `test/workspace-loader-secrets.test.ts`; live `.data` fetch clean |
+| JOURNEY-01 | Campaign hub hang / SSR stream | `entry.server.tsx` deferred timeout; hub shows empty state |
+| JOURNEY-02 | Null `disposition_options` crash | `normalizeDispositionOptions` in call-screen data path; join route renders |
+| JOURNEY-03 | Contacts nested outlet | `/contacts/new` renders form |
+| JOURNEY-04 | Onboarding empty advance | Required-field invalid + error copy |
+| JOURNEY-05 | Voicemail CTA + 404 shell | Absolute numbers link; 404 page stable |
+| Wave 2a/2b | Campaign UX + a11y batch | See #1052 commits; status doc for diagnosis corrections |
+| UX-SCRIPT-01 | Dual Save on dirty script | **Not reproduced** on review: only SaveBar **Save Changes** + Reset when dirty |
+| A11Y Navbar account | Dark-mode account control contrast | ~16:1 measured on review (status-doc fix held) |
+| CI green | typecheck / effects / fixtures | Status doc § "Verified green" |
+
+**Diagnosis corrections** (from status doc — agents must not implement the old plan literally):
+
+- `authToken` is not a workspace column; projection must also omit `key` and `twilio_data`.
+- Join CTA gating on `CampaignHeader` was a false lead.
+- Dark-mode sidebar active item was **not** the contrast failure; Navbar account control was.
+- Marketing `Navbar` under `/workspaces/*` is deliberate, not bleed-through.
+
+---
+
+## 5. Findings inventory (remaining)
+
+### P0 — Infra / money integrity
+
+#### INFRA-01: Migration ledger drift on deployed DBs (FIXED on review)
+
+**Ops (2026-07-15):** Applied 11 missing `client/migrations` to review Postgres; created `auth_migrations.schema_migrations` (lowercase — postgres.js folds unquoted `AUTH_migrations`); seeded repo versions.  
+`DATABASE_URL=$DATABASE_PUBLIC_URL node scripts/db/check-migration-ledger.mjs --require-db` → **OK**.  
+`apply_ledger_entry_and_sync_credits` now casts `p_type::public.transaction_type`.  
+**Note:** Always use `DATABASE_PUBLIC_URL` when running the ledger check from a laptop (`DATABASE_URL` is `*.railway.internal`).  
+**Still needed:** same gate on other envs (prod); optional deploy-pipeline wiring.
+
+---
+
+#### INFRA-02: Query pool has no wait timeouts (FIXED)
+
+**Fix:** [`app/server/db.ts`](../../app/server/db.ts) sets `connect_timeout: 10`, `idle_timeout: 20`, `max_lifetime: 60 * 30` on both pools.
+
+---
+
+### P1 — Product correctness
+
+#### UX-SMS-01: `sms_send_window` has no UI; "Send Window" edits `schedule` (FIXED)
+
+**Fix:** Message campaigns persist `sms_send_window` via `CampaignBasicInfo.Dates` + settings action `normalizeSchedule(sms_send_window)`; voice keeps `schedule`. UI tests cover both Apply paths.
+
+---
+
+#### UX-07: SSE console errors / pool coupling (CLOSED — capacity OK)
+
+**Severity:** Was Medium; closed after multi-connection repro  
+**Browser (2026-07-15 follow-up):** Opened **6 concurrent** EventSources to `/api/workspaces/:id/events` on review; all reached `readyState === OPEN` (`opened: 6`).  
+**Verdict:** No code change required this wave. Keep per-connection LISTEN. INFRA-02 timeouts still bound hangs. KR-4 met.
+
+---
+
+### P2 — UX polish
+
+#### UX-SCRIPT-01: Two Save controls when script dirty (CLOSED — not reproduced)
+
+**Browser:** Dirty script editor showed only **Save Changes** + **Reset**. Treat as fixed by Wave 2a unless a second Save control reappears on another script route.
+
+#### UX-QUEUE-01: Queue sort lags one click (FIXED)
+
+**Fix:** Compute next sort order before `toggleSorting` / `clearSorting` in `QueueTable.tsx`; test expects `phone.asc` then `phone.desc`.
+
+#### A11Y-HEAD-01: Heading hierarchy gaps (FIXED on numbers)
+
+**Fix:** Page `h1` "Phone numbers" on settings numbers route; NumbersTable title demoted to `h2`.
+
+#### A11Y-INVITE-01: Account menu plural spoken as "Invitation s" (FIXED)
+
+**Fix:** Template string in `Navbar.tsx` + `Navbar.MobileMenu.tsx`.
+
+#### A11Y-SCHED-01: Schedule/send-window day checkboxes unlabeled (FIXED)
+
+**Fix:** `aria-label={`${day} active`}` on Checkbox in `CampaignBasicInfo.Schedule.tsx`.
+
+#### UX-TZ-01: "Apply 9-5" vs displayed local window (FIXED)
+
+**Fix:** Buttons labeled "Apply 09:00–17:00 local to …".
+
+---
+
+### P3 — Deferred / not exercised
+
+| ID | Item | Notes |
+|----|------|-------|
+| LOW-LIVE-01 | Live call after join | Needs credits + active campaign window |
+| LOW-SURVEY-01 | Survey editor / public flow | Not re-audited |
+| LOW-ADMIN-01 | Admin surfaces | Out of scope |
+| LOW-A11Y-KB | Full keyboard traversal | Wave 3 |
+
+---
+
+## 6. Implementation waves
+
+### Wave 0 — Deploy ledger (ops)
+
+1. For **visual-asset-review** (and prod when ready): migrate → `--require-db` ledger check → redeploy app.
+2. Record pass/fail in operator notes (not in public repo).
+
+**Exit:** KR-1 green on review; billing purchase smoke possible once credits path is unblocked.
+
+### Wave 1 — App blockers (ordered)
+
+| Order | Finding | Exit criterion |
+|-------|---------|----------------|
+| A | INFRA-02 pool timeouts | Client options set; focused unit/smoke; no `.env` edits |
+| B | UX-SMS-01 send window binding | Round-trip `sms_send_window`; SMS gate still enforced |
+| C | UX-07 SSE diagnosis | Written verdict + code change only if slots starve |
+
+**Exit:** KR-2–KR-4 met; `npm run ci:local` green on the branch.
+
+### Wave 2 — Polish
+
+UX-QUEUE-01, A11Y-HEAD-01, A11Y-INVITE-01, A11Y-SCHED-01, UX-TZ-01.
+
+**Exit:** Secondary KRs; no new `check:effects` grandparents without documentation.
+
+### Wave 3 — Deferred nitpick
+
+LOW-* surfaces when a dedicated browser pass is scheduled.
+
+---
+
+## 7. File touchpoint matrix
+
+| Finding | Files | Tests |
+|---------|-------|-------|
+| INFRA-01 | `scripts/db/check-migration-ledger.mjs`, deploy pipeline | Manual `--require-db` per env |
+| INFRA-02 | `app/server/db.ts` | Optional assert on client config; load test note |
+| UX-SMS-01 | `CampaignBasicInfo.Dates.tsx`, campaign settings action/loader, `campaign-send-window.ts` | UI + API send-window tests |
+| UX-07 | `events.loader.server.ts`, `db.ts` | Multi-client SSE harness or documented manual repro |
+| UX-QUEUE-01 | `QueueTable.tsx` | `components-queue` UI test (update pin) |
+| A11Y-HEAD-01 | settings numbers route, nav headings | Snapshot / a11y name test |
+| A11Y-INVITE-01 | `Navbar.tsx`, `Navbar.MobileMenu.tsx` | a11y name assertion |
+| A11Y-SCHED-01 | `CampaignBasicInfo.Schedule.tsx` | a11y name on day checkboxes |
+| UX-TZ-01 | `CampaignBasicInfo.Dates.tsx` | Copy / label test |
+
+**Do not swap:** `getWorkspaceById` remains for server-only Twilio/admin/API credential paths. Route loaders must keep `getWorkspaceForClient` (enforced by `check:workspace-projection`).
+
+---
+
+## 8. Test plan
+
+### Automated
+
+- `npm run ci:local` (includes `check:workspace-projection`, `db:ledger:check` inventory mode)
+- Targeted: campaign settings / SMS window tests; `test/workspace-loader-secrets.test.ts` regression
+- After INFRA-02: any existing db bootstrap tests still pass
+
+### Manual review-env checklist
+
+1. `.data` on contacts/scripts still free of `twilio_data` / `key` / `stripe_id`
+2. Campaign hub + join-call still render
+3. SMS settings: set send window → DB `sms_send_window` populated → send outside window rejected
+4. Billing: after Wave 0, test-mode purchase completes (or fails with a clear app error, not RPC enum cast)
+5. Open 6+ call-screen tabs: SSE errors vs connection exhaustion
+
+### Regression risks
+
+| Change | Risk | Mitigation |
+|--------|------|------------|
+| Pool timeouts | Short timeouts flake under CI load | Separate CI vs prod values via existing env patterns (no secret `.env` edits in-repo) |
+| sms_send_window UI | Voice schedule broken for call campaigns | Branch UI by campaign type |
+| SSE fan-out | Missed events | Keep polling fallback |
+
+---
+
+## 9. Repository invariants
+
+- Tenant routes: `createTenantDb` / data-plane middleware; no `@/server/db` in route modules except documented allowlists (SSE `directPool`).
+- Credits: `debitAmountFromCredits` + `insertTransactionHistoryIdempotent` + `shared/billing-keys.ts`.
+- Do not modify user `.env`.
+- Do not weaken `check:workspace-projection` or secret loader tests.
+- Imports at module top; exhaustive switches.
+
+---
+
+## 10. Suggested PR structure
+
+1. **PR-A (ops/docs):** Wave 0 runbook confirmation + any CI deploy step for `--require-db` (no product UI).
+2. **PR-B:** INFRA-02 pool timeouts.
+3. **PR-C:** UX-SMS-01 `sms_send_window` binding + tests.
+4. **PR-D:** UX-07 SSE diagnosis outcome (fix or "documented benign").
+5. **PR-E:** Wave 2 polish batch (script Save / queue sort / headings).
+
+Merge order: A → B → C → D → E (C independent of B if needed; prefer B first).
+
+---
+
+## 11. Coverage matrix
+
+| Surface | Status |
+|---------|--------|
+| Workspace `.data` secrets | Fixed |
+| Campaign hub results | Fixed |
+| Join call / disposition null | Fixed |
+| Contacts new | Fixed |
+| Voicemail → numbers CTA | Fixed |
+| Global 404 | Fixed |
+| Onboarding step 1 validation | Fixed |
+| Billing purchase E2E | Ledger fixed on review (purchase smoke deferred) |
+| SMS send window policy UI | Fixed |
+| DB pool timeouts | Fixed |
+| SSE / LISTEN coupling | Fixed (documented capacity OK) |
+| Script dual Save | Fixed (not reproduced) |
+| Queue / chats / calls / analytics / handset / archives / exports / settings | OK (empty-state / list) |
+| Queue sort lag | Fixed |
+| Heading hierarchy | Fixed (numbers page h1) |
+| Invite plural a11y / schedule checkbox names / 9-5 label | Fixed |
+| SSE single connection | OK; multi-tab OK (6 open) |
+| Survey editor / live call / admin | Not exercised |
+
+---
+
+## 12. Out of scope
+
+- Re-implementing #1052 journey fixes
+- Live coaching / media-stream thermo-nuclear work (separate plan)
+- Changing deliberate global `Navbar` on workspace routes
+- Broad admin or marketing redesign
+- Inventing new audit findings not in the status doc or this browser pass
+
+---
+
+## 13. Open questions (defaults if unanswered)
+
+| Question | Default |
+|----------|---------|
+| Should `sms_send_window` and voice `schedule` ever share one editor for hybrid campaigns? | **No** — message campaigns only bind `sms_send_window`; voice keeps `schedule`. |
+| Pool timeout values? | Start with `connect_timeout: 10`, `idle_timeout: 20`, `max_lifetime: 60 * 30` (seconds, postgres.js conventions); adjust after review metrics. |
+| Is dual Save on scripts a product preference? | **Closed** — not reproduced on review; single SaveBar when dirty. |
+| SSE: process-wide fan-out vs per-connection LISTEN? | Prefer **keep per-connection LISTEN** if `directPool.max` ≥ expected concurrent agents; else fan-out. |
+
+---
+
+## 14. References
+
+- [`e2e-nitpick-status-2026-07-15.md`](./e2e-nitpick-status-2026-07-15.md) — corrections + landed commits
+- [`docs/migration-ledger-drift.md`](../migration-ledger-drift.md)
+- PR #1052 — `4bc2d032` on `dev`
+- Review env: `https://callcaster-review-visual-asset-review.up.railway.app/`
+- Workspace: `25dcc770-e805-4162-8940-ab7f95fd57c1`

--- a/docs/remediation/e2e-nitpick-status-2026-07-15.md
+++ b/docs/remediation/e2e-nitpick-status-2026-07-15.md
@@ -1,7 +1,8 @@
 # E2E nitpick remediation — status
 
-Branch: `fix/e2e-nitpick-remediation`, cut from `origin/dev` @ `d0b4ed48`.
-Companion to the plan doc (`e2e-nitpick-remediation-plan-2026-07-15.md`).
+Branch: merged to `dev` as #1052 (`4bc2d032`).
+Companion plans: original audit plan removed after landing; follow-up open work is in
+[`e2e-nitpick-followup-remediation-plan-2026-07-15.md`](./e2e-nitpick-followup-remediation-plan-2026-07-15.md).
 
 **Read this before implementing anything from the plan.** The audit's *symptoms*
 were reliable. Its *diagnoses* frequently were not — roughly half of those checked

--- a/test/ui/components-campaign.test.tsx
+++ b/test/ui/components-campaign.test.tsx
@@ -139,23 +139,44 @@ describe("app/components/campaign/settings/basic/CampaignBasicInfo.Dates.tsx", (
     expect(screen.queryByText("Send Window")).not.toBeInTheDocument();
   });
 
-  test("uses send-window wording for message campaigns", async () => {
+  test("message campaign Apply persists sms_send_window, not schedule", async () => {
     const SelectDates = (await import("@/components/campaign/settings/basic/CampaignBasicInfo.Dates")).default;
+    const onChange = vi.fn();
     render(
       <SelectDates
-        campaignData={makeCampaign({ type: "message", schedule: null })}
-        handleInputChange={handleInputChange}
+        campaignData={makeCampaign({ type: "message", schedule: null, sms_send_window: null })}
+        handleInputChange={onChange}
       />,
     );
-    expect(screen.getByText("Send Window")).toBeInTheDocument();
-    expect(screen.getByText("No send window set")).toBeInTheDocument();
-
-    // The schedule editor itself must switch wording too, not just the header.
     fireEvent.click(screen.getByRole("button", { name: "Set Send Window" }));
-    expect(
-      screen.getByRole("button", { name: "Apply Send Window" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/Calling Hours/)).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Apply 09:00–17:00 local to Weekdays" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply Send Window" }));
+    expect(onChange).toHaveBeenCalled();
+    const [field, value] = onChange.mock.calls.at(-1)!;
+    expect(field).toBe("sms_send_window");
+    expect(typeof value).toBe("string");
+    const parsed = JSON.parse(String(value));
+    expect(parsed.monday.active).toBe(true);
+  });
+
+  test("call campaign Apply persists schedule", async () => {
+    const SelectDates = (await import("@/components/campaign/settings/basic/CampaignBasicInfo.Dates")).default;
+    const onChange = vi.fn();
+    render(
+      <SelectDates
+        campaignData={makeCampaign({ type: "live_call", schedule: null })}
+        handleInputChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Set Calling Hours" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Apply 09:00–17:00 local to Weekdays" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply Calling Hours" }));
+    const [field] = onChange.mock.calls.at(-1)!;
+    expect(field).toBe("schedule");
   });
 });
 

--- a/test/ui/components-queue.test.tsx
+++ b/test/ui/components-queue.test.tsx
@@ -141,11 +141,7 @@ describe("app/components/queue/QueueTable.tsx", () => {
     }
   });
 
-  // Pins the behaviour the QueueSortButton extraction had to preserve. Note the
-  // sort param lags by one click: getIsSorted() is read synchronously after
-  // toggleSorting(), so it still returns the pre-toggle value. That is a
-  // pre-existing bug carried over verbatim, not a regression from the refactor
-  // — this test documents it so a future fix has to change it deliberately.
+  // Sort param reflects the click immediately (next order computed before toggle).
   test("the sort control reports the sort field back to the caller", async () => {
     const { QueueTable } = await import("@/components/queue/QueueTable");
     const handleFilterChange = vi.fn();
@@ -155,10 +151,10 @@ describe("app/components/queue/QueueTable.tsx", () => {
     const sortByPhone = screen.getByRole("button", { name: "Sort by Phone" });
 
     fireEvent.click(sortByPhone);
-    expect(handleFilterChange).toHaveBeenNthCalledWith(1, "sort", "");
+    expect(handleFilterChange).toHaveBeenNthCalledWith(1, "sort", "phone.asc");
 
     fireEvent.click(sortByPhone);
-    expect(handleFilterChange).toHaveBeenNthCalledWith(2, "sort", "phone.asc");
+    expect(handleFilterChange).toHaveBeenNthCalledWith(2, "sort", "phone.desc");
   });
 });
 


### PR DESCRIPTION
## Summary
- Fail closed sooner on saturated Postgres pools (`connect_timeout` / `idle_timeout` / `max_lifetime`) so review loaders stop hanging indefinitely.
- Persist message-campaign hours to `sms_send_window` (voice still uses `schedule`); clarify UX copy for local timezone hours.
- Close remaining polish from the post-#1052 browser pass: invite plural, schedule checkbox `aria-label`, numbers page `h1`, queue sort before toggle.
- Document review migration ledger gate + SSE capacity OK; add follow-up remediation plan.

## Test plan
- [ ] CI green on this branch
- [ ] Review deploy: message campaign settings save → DB `sms_send_window` (not `schedule`)
- [ ] Voice campaign still writes `schedule`
- [ ] Numbers settings page has an `h1`; invite badge pluralizes
- [ ] Queue status sort updates order before toggle flips
- [ ] Under load, pool saturation returns errors instead of multi-minute hangs