### PR TITLE
Fix QA net-new findings: chat SMS silent failure, error-boundary leak + duplicate campaign, dev harness

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,10 @@ build/
 # Coverage
 coverage/
 
+# Generated Playwright artifacts
+e2e/playwright-report/
+test-results/
+
 # Local tooling
 .opencode/
 .agents/

--- a/app/components/shared/RouteErrorBoundary.tsx
+++ b/app/components/shared/RouteErrorBoundary.tsx
@@ -1,28 +1,35 @@
 import { isRouteErrorResponse, useRouteError } from "react-router";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { toUserMessage } from "@/lib/user-message";
+
+const FALLBACK_MESSAGE =
+  "Something went wrong. Please try again or contact support if the problem persists.";
 
 /** Route-module ErrorBoundary compatible with React Router 7 typegen. */
 export function RouteErrorBoundary() {
   const error = useRouteError();
   const message = isRouteErrorResponse(error)
     ? `${error.status} ${error.statusText}`
-    : error instanceof Error
-      ? error.message
-      : "An unexpected error occurred";
+    : toUserMessage(error, FALLBACK_MESSAGE);
 
   return (
     <div className="min-h-[12rem] flex items-center justify-center p-6">
       <div className="max-w-md w-full text-center">
-        <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+        <h3 className="text-lg font-medium text-foreground">
           Something went wrong
         </h3>
-        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">{message}</p>
-        <button
+        <Alert variant="destructive" className="mt-2">
+          <AlertDescription>{message}</AlertDescription>
+        </Alert>
+        <Button
           type="button"
+          variant="destructive"
           onClick={() => window.location.reload()}
-          className="mt-4 inline-flex items-center px-4 py-2 rounded-md text-white bg-red-600 hover:bg-red-700"
+          className="mt-4"
         >
           Reload Page
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/app/hooks/chats/useChatsPage.ts
+++ b/app/hooks/chats/useChatsPage.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import {
   useFetcher,
   useLoaderData,
@@ -331,6 +332,13 @@ export function useChatsPage() {
       if (!toNumber || messageFetcher.state !== "idle") return;
 
       const formData = new FormData(target);
+      // ChatInput only renders a hidden `contact_number` field for the
+      // "new number" composer flow (header search); replying inside an
+      // already-open thread has no such field in the DOM, so `toNumber`
+      // (route param or header state) must be set explicitly or the action
+      // receives no destination number at all and 500s before it can even
+      // attempt the send.
+      formData.set("contact_number", toNumber);
       formData.append("media", JSON.stringify(selectedImages));
       const body = (formData.get("body") as string) || "";
       // Resolve the sender the same way the action does, so the optimistic
@@ -391,6 +399,7 @@ export function useChatsPage() {
       return;
     }
 
+    toast.error(data.error);
     chatActionsRef.current?.markOptimisticMessageFailed?.(pending.sid);
     const bodyField = document.getElementById("body") as
       | HTMLTextAreaElement

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/settings.action.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/settings.action.server.ts
@@ -80,8 +80,15 @@ async function handleCampaignDuplicate(
 ) {
   const parsedData = JSON.parse(campaignData);
 
+  // Don't trust the client's (possibly stale/edited) draft for the script
+  // reference — read the source campaign's real script_id off the DB so the
+  // duplicate always points at a script that actually exists in this
+  // workspace. Null it out if the source has none.
+  const sourceCampaign = await findCampaignInWorkspace(workspace_id, selected_id);
+
   const campaign = await insertCampaignForWorkspace(workspace_id, {
     ...parsedData,
+    script_id: sourceCampaign?.script_id ?? null,
     live_questions: parsedData.live_questions ?? parsedData.questions ?? null,
   });
 

--- a/app/routes/workspaces+/$id/chats.action.server.ts
+++ b/app/routes/workspaces+/$id/chats.action.server.ts
@@ -91,12 +91,21 @@ export const action = defineAction({
     }
   }
 
-  const contact_number = normalizePhoneNumber(
-    params["contact_number"] || (data["contact_number"] as string),
-  );
-
   if (!workspaceId) {
     return routeData({ error: "Workspace is required" }, { status: 400 });
+  }
+
+  let contact_number: string;
+  try {
+    contact_number = normalizePhoneNumber(
+      params["contact_number"] || (data["contact_number"] as string),
+    );
+  } catch (error) {
+    logger.error("Error normalizing chat send destination number:", error);
+    return routeData(
+      { error: "A valid destination phone number is required." },
+      { status: 400 },
+    );
   }
 
   let portalConfig: WorkspaceTwilioOpsConfig;

--- a/docs/dev-test-plan-2026-07-16.md
+++ b/docs/dev-test-plan-2026-07-16.md
@@ -1,0 +1,110 @@
+# Dev Test Plan — next round (2026-07-16)
+
+Status snapshot when this plan was written:
+
+- `dev` @ `44343677` was audited end-to-end (full compose E2E, all CI gates, ~200-route
+  surface map, two manual browser passes across all five seeded roles). Findings live in
+  the 2026-07-16 QA session; the durable ones are tracked below as test items.
+- **PR #1055** (`audit/deep-surface-2026-07-16`) fixes the audited P0s (dead dial loop via
+  queue-RPC drift, contact-form data loss, missing server-side role gates, audience enum,
+  survey persistence). Three follow-up fixes are stacked on it: chat-SMS silent failure,
+  RouteErrorBoundary raw-error leak + duplicate-campaign `script_id`, E2E MinIO/eslint
+  hygiene.
+- Everything below assumes those merge first. **Do not sign off any Tier 1 item against a
+  tree that predates them.**
+
+Seeded test logins (committed in `scripts/e2e/seed-data.mjs`): `owner|admin|member|caller|
+sudo|invitee@e2e.test`, password `E2eTestPass1!`. Workspaces: Ready `…0001`, Onboarding
+`…0002`, Empty `…0003`.
+
+---
+
+## Tier 1 — Post-merge regression gate (local compose; blocks everything else)
+
+Run on `dev` after the merges. Environment: `docker compose -f docker-compose.dev.yml up -d
+postgres minio inbucket`, then `npm run test:e2e:compose` (Node 22).
+
+| # | Item | How | Pass criteria |
+|---|---|---|---|
+| 1.1 | Full E2E suite, twice back-to-back | `test:e2e:compose` ×2 without recreating the stack | Both runs green (2nd run proves the MinIO purge fixed ERR-11 cross-run pollution) |
+| 1.2 | Contact create/edit | Browser: `/contacts/new` fill+save; edit existing; reload | Values persist; blank-row bug gone; fields editable |
+| 1.3 | Queue enqueue paths | Browser: new campaign → add from audience AND search/add single contact | Rows appear in queue; no 500; counts correct |
+| 1.4 | Caller RBAC (server-side) | As `caller@`: direct-nav `/billing`, `/campaigns/new`, existing campaign `/settings`, POST replay | 403/redirect from the SERVER, not just hidden UI |
+| 1.5 | Audience create | `/audiences/new` → Create Empty Audience | Audience created; no raw SQL on failure paths |
+| 1.6 | Public survey round-trip | Build survey → open public link anon → submit → responses page | Response recorded and visible; export contains it |
+| 1.7 | Chat SMS failure surfacing | Send SMS in a thread with Twilio unreachable (local) | Error toast, input NOT cleared, no phantom `ok:true` |
+| 1.8 | Duplicate campaign | Campaign settings → duplicate | Copy created with source's script; failure (if any) shows friendly message, never SQL |
+| 1.9 | Queue status actions | Queue row: "dequeued" action | Status does NOT write `COMPLETED`; user gets feedback |
+
+## Tier 2 — Local-closable gaps (never driven; all runnable on the compose stack)
+
+| # | Item | How | Pass criteria |
+|---|---|---|---|
+| 2.1 | Invite acceptance end-to-end | Owner invites fresh email → open invite link (Inbucket at the compose stack's mapped port) → accept as invitee → probe role access | Membership row + correct role gates applied |
+| 2.2 | Email delivery (local) | Check Inbucket for: invite, password reset, voicemail-to-email, contact form | Mail arrives, links work, no broken templates |
+| 2.3 | Password reset loop | `/remember` → Inbucket link → `/reset-password` → sign in with new password | Works; old password rejected; generic success copy (no token oracle) |
+| 2.4 | 2FA enrollment + TOTP login | Run E2E server WITHOUT `DISABLE_2FA_ENFORCEMENT`; enroll at `/account/security`, sign out, log in with TOTP | Enrollment UI actually renders (QA saw none — may be env-hidden, must confirm); login loop works; sudo forced to enroll |
+| 2.5 | Signup end-to-end | `SIGNUP_OPEN=1`: signup → verify email (Inbucket) → land in `/workspaces` → create workspace | Full loop works; closed-signup 403 still enforced when flag off |
+| 2.6 | Onboarding wizard step-through | Owner on Onboarding workspace `…0002`: submit EVERY step incl. skip paths, then member read-only re-check | Each step persists; review/launch state coherent |
+| 2.7 | Workspace danger zone | Transfer ownership + delete workspace | **Known gap: no UI exists** though server actions do — decide build-or-remove, then test |
+| 2.8 | Export content correctness | Campaign + survey CSV exports: open the files | Rows/columns match seeded data, not just "download worked" |
+| 2.9 | Admin write actions | As sudo: edit user, toggle workspace status, manage memberships, dead-letters view | Actions persist; no raw errors |
+| 2.10 | API contract sweep | Scripted pass of the API-key data-plane routes (`docs/api-data-plane.md`) with the seeded key vs `/api/docs/openapi` | Responses match spec shapes; authz classes enforced per `docs/api-auth-matrix.md` |
+| 2.11 | Profile edit | `/account` save first/last name | Persists (QA saw silent 400 — verify fixed or file it) |
+| 2.12 | UX feedback batch | Landing contact form, duplicate-invite warning, voicemail recipient dropdown after save | Every submit gives visible success/failure feedback |
+
+## Tier 3 — Requires the deployed dev/staging environment (real providers)
+
+Precondition (currently BLOCKING, seen on PR #1055's review deploy): the environment must
+boot — provision a mode-correct Stripe key for its `NODE_ENV`, and apply
+`client/migrations/` (the boot guard aborts if `apply_ledger_entry_and_sync_credits` is
+missing). Fix the env provisioning once; it fails every PR until then.
+
+| # | Item | Pass criteria |
+|---|---|---|
+| 3.1 | Stripe purchase → ledger | Real (test-mode) checkout → `/confirm-payment` → credits incremented, transaction row, webhook processed. THE top staging test |
+| 3.2 | Real outbound call | Live-call campaign: dial through browser device; disposition saves; call row + billing debit correct |
+| 3.3 | Predictive/power dial + ACD | Two agents, small queue: distribution, claim, no double-dial (exercises the repaired claim/auto_dial RPCs under real timing) |
+| 3.4 | Real SMS round-trip | Outbound from chat + campaign; inbound reply hits SIGNED `/api/inbound-sms` and threads correctly; scheduled send fires in window |
+| 3.5 | Number purchase + inbound routing | Buy number, configure routing/queue/voicemail, place inbound call, voicemail records + email arrives |
+| 3.6 | Caller-ID verification | Full callback loop |
+| 3.7 | Admin Twilio portal writes | Sync, webhook audit/repair, billing reconciliation on a sandbox workspace; also watch the portal's deferred loader under real Twilio latency (banned `<Await>` pattern — see repo rule) |
+| 3.8 | Webhook signature enforcement | Unsigned POSTs to `/api/inbound-sms`, `/api/call-status`, etc. are REJECTED in deployed env (local E2E accepts unsigned by design); check the known-weak set: `/api/dial/:number`, `/api/twilio/a2p/events`, `/api/verify-*` |
+| 3.9 | Worker + cron | Worker container runs; each `/api/jobs/*` route fired with `x-cron-secret`: low-credit notify, number-rental billing, billing reconcile, twilio-open-sync; dead-letter path on induced failure |
+| 3.10 | SSE under real network | Workspace events stream survives >5 min, reconnects after drop (local QA saw one `ERR_INCOMPLETE_CHUNKED_ENCODING`) |
+
+## Tier 4 — Breadth (schedule after Tiers 1–3 are green)
+
+- Multi-user concurrency: two sessions dialing one campaign; simultaneous queue edits.
+- Browser matrix: Safari + Firefox smoke of dialer, audio recorder, chat.
+- Accessibility audit (screen-reader pass on dialer + settings; PR #1055's a11y batch
+  verified in-browser).
+- Scale: 10k-contact CSV import, paginated lists, big export.
+- Design-system debt burn-down: ~105 hardcoded palette colors across 45 files, `admin+/`
+  PageShell adoption, hand-rolled status indicators (`NumbersTable`), native `alert()` in
+  the mic-permission hook.
+
+## Automated coverage to add (so the above stays tested)
+
+Priority order, from the 2026-07-16 coverage-gap analysis:
+
+1. Signup → verify → workspace-create spec (E2E).
+2. Invite → accept → RBAC-applied spec (E2E).
+3. 2FA enable → TOTP login spec (E2E, enforcement on).
+4. `/confirm-payment` credit-write spec (mock Stripe session retrieve).
+5. Team-management writes + numbers/queues write flows (E2E).
+6. Onboarding wizard step-through (E2E).
+7. Contract tests generated from the OpenAPI spec for the data-plane routes.
+8. Marketing pages + contact-form smoke.
+
+## Standing environment rules (so results are trustworthy)
+
+- Node 22 for every local run (`~/.nvm/versions/node/v22.23.1`); other versions produce
+  phantom test failures.
+- Never trust a single compose-E2E run after storage-touching specs until 1.1's
+  double-run is standard.
+- `db:ledger:check` needs `DATABASE_URL` and a migration-tracked DB; against the compose
+  DB it fails by construction (bootstrap bypasses the ledger) — don't chase it as a bug.
+- The E2E server sets `E2E_TEST=1` + 2FA-enforcement bypass: RBAC/2FA conclusions from
+  that env understate production strictness — confirm auth-hardening items with
+  enforcement on (2.4) or in the deployed env.

--- a/docs/dev-test-plan-2026-07-16.md
+++ b/docs/dev-test-plan-2026-07-16.md
@@ -108,3 +108,10 @@ Priority order, from the 2026-07-16 coverage-gap analysis:
 - The E2E server sets `E2E_TEST=1` + 2FA-enforcement bypass: RBAC/2FA conclusions from
   that env understate production strictness — confirm auth-hardening items with
   enforcement on (2.4) or in the deployed env.
+- Object storage: local/compose uses MinIO as the S3-compatible stand-in; **deployed
+  envs (review and production) use Railway buckets**. Same `@aws-sdk/client-s3` code path —
+  only the endpoint/credentials differ. Storage-dependent flows (audio library, voicemail,
+  MMS media, exports) therefore need Railway bucket env wired in any deployed test target,
+  and the storage-backed audio library (lists whatever objects sit under the workspace
+  prefix) behaves identically against a Railway bucket — orphaned objects still surface as
+  metadata-less rows.

--- a/scripts/e2e/ensure-minio-bucket.mjs
+++ b/scripts/e2e/ensure-minio-bucket.mjs
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 /* eslint-env node */
-import { CreateBucketCommand, HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  CreateBucketCommand,
+  DeleteObjectsCommand,
+  HeadBucketCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
 
 const endpoint = process.env.S3_ENDPOINT ?? "http://127.0.0.1:9000";
 const bucket = process.env.S3_BUCKET ?? "callcaster";
@@ -38,10 +44,40 @@ async function ensureBucket() {
   console.log(`[e2e-minio] created bucket ${bucket}`);
 }
 
+// Objects written by prior runs (e.g. voicemail uploads, audio-clip edits) persist
+// across `docker compose down`-less re-runs since Postgres resets don't touch MinIO.
+// Purge everything so empty-state assertions (e.g. the audios-empty-copy spec) are
+// deterministic. This must run BEFORE any seed step re-populates fixture objects.
+async function purgeBucket() {
+  let continuationToken;
+  let purged = 0;
+  do {
+    const page = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        ContinuationToken: continuationToken,
+      }),
+    );
+    const keys = (page.Contents ?? []).map((object) => ({ Key: object.Key }));
+    if (keys.length > 0) {
+      await client.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: keys, Quiet: true },
+        }),
+      );
+      purged += keys.length;
+    }
+    continuationToken = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (continuationToken);
+  console.log(`[e2e-minio] purged ${purged} object(s) from bucket ${bucket}`);
+}
+
 let lastError;
 for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
   try {
     await ensureBucket();
+    await purgeBucket();
     process.exit(0);
   } catch (error) {
     lastError = error;

--- a/test/campaign-settings.route.test.ts
+++ b/test/campaign-settings.route.test.ts
@@ -298,4 +298,74 @@ describe("workspaces_.$id.campaigns.$selected_id.settings action", () => {
       error: "duplicate failed",
     });
   });
+
+  test("duplicate copies the source campaign's actual script_id, ignoring a mismatched client-supplied value", async () => {
+    makeDbClientForSettingsRoute({
+      campaign: {
+        id: 99,
+        workspace: "w1",
+        type: "robocall",
+        script_id: 42,
+      },
+    });
+    mocks.verifyAuth.mockResolvedValueOnce({
+      user: { id: "u1" },
+    });
+    mocks.parseActionRequest.mockResolvedValueOnce({
+      intent: "duplicate",
+      // Client sends a stale/tampered script_id that doesn't belong to this
+      // campaign's script — the server must ignore it and use the source's.
+      campaignData: JSON.stringify({
+        title: "Copy me",
+        type: "robocall",
+        script_id: 950001,
+      }),
+    });
+
+    const mod = await import("../app/routes/workspaces+/$id/campaigns/$selected_id/settings.route");
+    const res = await asRouteResponse(mod.action(await withWorkspaceRouteArgs({
+      request: new Request("http://x", { method: "POST" }),
+      params: { id: "w1", selected_id: "99" },
+    })));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      success: true,
+      actionType: "duplicate",
+    });
+    expect(campaignIvrMocks.insertCampaignForWorkspace).toHaveBeenCalledWith(
+      "w1",
+      expect.objectContaining({ script_id: 42 }),
+    );
+  });
+
+  test("duplicate nulls out script_id when the source campaign has none", async () => {
+    makeDbClientForSettingsRoute({
+      campaign: {
+        id: 99,
+        workspace: "w1",
+        type: "message",
+        script_id: null,
+      },
+    });
+    mocks.verifyAuth.mockResolvedValueOnce({
+      user: { id: "u1" },
+    });
+    mocks.parseActionRequest.mockResolvedValueOnce({
+      intent: "duplicate",
+      campaignData: JSON.stringify({ title: "Copy me", type: "message" }),
+    });
+
+    const mod = await import("../app/routes/workspaces+/$id/campaigns/$selected_id/settings.route");
+    const res = await asRouteResponse(mod.action(await withWorkspaceRouteArgs({
+      request: new Request("http://x", { method: "POST" }),
+      params: { id: "w1", selected_id: "99" },
+    })));
+
+    expect(res.status).toBe(200);
+    expect(campaignIvrMocks.insertCampaignForWorkspace).toHaveBeenCalledWith(
+      "w1",
+      expect.objectContaining({ script_id: null }),
+    );
+  });
 });

--- a/test/chats-action.route.test.ts
+++ b/test/chats-action.route.test.ts
@@ -106,6 +106,34 @@ describe("app/routes/workspaces+/$id/chats.action.server.ts", () => {
     expect(mocks.sendMessage).not.toHaveBeenCalled();
   });
 
+  test("returns a 400 with a clean message (not an uncaught 500) when the destination number is missing from both params and form data", async () => {
+    // Reproduces the real browser submit target: ChatInput's <Form> has no
+    // `action`, so it defaults to the parent "chats" route (no
+    // `:contact_number` param), and the hidden `contact_number` field is only
+    // rendered for the header's "new number" composer flow — not for a reply
+    // inside an already-open thread. Before the fix, normalizePhoneNumber()
+    // threw synchronously and escaped to defineAction's generic 500 handler
+    // with an internal message ("Phone number input must be a non-empty
+    // string"), which the client rendered as a raw INTERNAL_SERVER_ERROR
+    // instead of surfacing a clear, actionable error.
+    const mod = await import(
+      "../app/routes/workspaces+/$id/chats.action.server"
+    );
+    const res = await asRouteResponse(mod.action(await withWorkspaceRouteArgs({
+        request: makeFormRequest({
+          body: "hi",
+          from: "+15550000000",
+        }),
+        params: { id: "w1" },
+      })),
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "A valid destination phone number is required.",
+    });
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+
   test("sends through the Messaging Service when the composer selects it", async () => {
     mocks.getEffectivePortalConfig.mockResolvedValueOnce({
       sendMode: "messaging_service",

--- a/test/ui/components-shared-smoke.test.tsx
+++ b/test/ui/components-shared-smoke.test.tsx
@@ -192,13 +192,13 @@ describe("app/components/shared/QueryParamBanner.tsx", () => {
 });
 
 describe("app/components/shared/RouteErrorBoundary.tsx", () => {
-  test("shows the message from a thrown Error", async () => {
+  test("shows the message from a legit user-facing Error", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const { RouteErrorBoundary } = await import(
       "@/components/shared/RouteErrorBoundary"
     );
     const Thrower = () => {
-      throw new Error("route render failed");
+      throw new Error("Campaign name is required.");
     };
     const router = createMemoryRouter(
       [
@@ -212,9 +212,40 @@ describe("app/components/shared/RouteErrorBoundary.tsx", () => {
     );
     render(<RouterProvider router={router} />);
     expect(await screen.findByText("Something went wrong")).toBeInTheDocument();
-    expect(screen.getByText("route render failed")).toBeInTheDocument();
+    expect(screen.getByText("Campaign name is required.")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Reload Page" }),
+    ).toBeInTheDocument();
+  });
+
+  test("does not leak a raw/internal error message and shows a friendly fallback instead", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { RouteErrorBoundary } = await import(
+      "@/components/shared/RouteErrorBoundary"
+    );
+    const rawMessage =
+      'Failed query: insert into "campaign" ("workspace", "caller_id") values ($1, $2) - null value in column "script_id" violates not-null constraint';
+    const Thrower = () => {
+      throw new Error(rawMessage);
+    };
+    const router = createMemoryRouter(
+      [
+        {
+          path: "/",
+          element: <Thrower />,
+          errorElement: <RouteErrorBoundary />,
+        },
+      ],
+      { initialEntries: ["/"] },
+    );
+    render(<RouterProvider router={router} />);
+    expect(await screen.findByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.queryByText(rawMessage)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Failed query:/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Something went wrong. Please try again or contact support if the problem persists.",
+      ),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
Follow-up fixes from the 2026-07-16 end-to-end QA pass. **Stacked on #1055** (base is its branch) so this diff shows only the net-new work; retarget to `dev` after #1055 merges.

## Fixes

**P0 — Chat SMS send silently succeeded but persisted nothing.** Replying in an open thread submitted without a destination number (the hidden `contact_number` field only renders for the new-number composer), so `normalizePhoneNumber` threw into an uncaught 500 *before* any send was attempted — the textbox cleared, giving false confidence. Now the hook always sets `contact_number`, the action returns a clean 400 on a bad/missing number, and the UI surfaces the error via toast without clearing input. Regression test added.

**P1 — RouteErrorBoundary leaked raw errors to users.** The shared boundary (27+ routes) rendered `error.message` verbatim, which surfaced full raw SQL + bound params on a 500. Now routed through `toUserMessage` with a generic fallback, and restyled to design tokens (`Alert`/`Button` variants) instead of hardcoded gray/red classes.

**P1 — Duplicate campaign 500'd on an FK violation.** The duplicate action spread the client's (stale) draft straight into the insert, trusting whatever `script_id` the browser held. Now reads the source campaign's real `script_id` server-side (or nulls it). Combined with the boundary fix, a failure here shows a friendly message, not SQL.

**Dev-only harness hygiene** (no prod/runtime impact): the compose E2E bootstrap now purges the local MinIO bucket before seeding so back-to-back runs are deterministic (the empty-state audio spec was failing on the 2nd run from prior-run leftovers); `.eslintignore` now excludes generated Playwright report dirs. MinIO is the local S3 stand-in only — deployed envs use Railway buckets, unaffected.

Also adds `docs/dev-test-plan-2026-07-16.md`: the tiered roadmap of what to test next (post-merge regression, never-driven local journeys, and deployed-env/real-provider items).

## Verification
- typecheck, lint, node + UI unit suites: green (each fix has a regression test)
- `test:e2e:compose`: **92/92**, run twice back-to-back — both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)