### PR TITLE
fix: onboarding number rental, Numbers settings, and CSV header visibility

### DIFF
--- a/app/components/phone-numbers/ServiceAddressGate.tsx
+++ b/app/components/phone-numbers/ServiceAddressGate.tsx
@@ -20,7 +20,15 @@ type ServiceAddressGateProps = {
   workspaceId: string;
   onboarding: WorkspaceMessagingOnboardingState;
   isReadOnly?: boolean;
+  /** Where save/validate should return; defaults to Numbers settings. */
+  returnTo?: string;
 };
+
+export function isServiceAddressComplete(
+  address: WorkspaceMessagingOnboardingState["emergencyVoice"]["address"],
+): boolean {
+  return addressComplete(address);
+}
 
 /**
  * Capability gate: collect the service / emergency address before renting.
@@ -30,6 +38,7 @@ export function ServiceAddressGate({
   workspaceId,
   onboarding,
   isReadOnly = false,
+  returnTo,
 }: ServiceAddressGateProps) {
   const navigation = useNavigation();
   const address = onboarding.emergencyVoice.address;
@@ -40,6 +49,8 @@ export function ServiceAddressGate({
       : String(navigation.formData?.get("_action") ?? "");
   const isSaving = pendingAction === "save_service_address";
   const isReviewing = pendingAction === "review_emergency_voice";
+  const returnPath =
+    returnTo ?? `/workspaces/${workspaceId}/settings/numbers`;
 
   return (
     <Section variant="flat" data-testid="service-address-gate">
@@ -58,11 +69,7 @@ export function ServiceAddressGate({
         className="grid gap-4 md:grid-cols-2"
       >
         <input type="hidden" name="_action" value="save_service_address" />
-        <input
-          type="hidden"
-          name="returnTo"
-          value={`/workspaces/${workspaceId}/settings/numbers`}
-        />
+        <input type="hidden" name="returnTo" value={returnPath} />
         <FormField
           className="md:col-span-2"
           htmlFor="addressStreet"
@@ -132,6 +139,7 @@ export function ServiceAddressGate({
           className="mt-4"
         >
           <input type="hidden" name="_action" value="review_emergency_voice" />
+          <input type="hidden" name="returnTo" value={returnPath} />
           <p className="mb-2 text-sm text-muted-foreground">
             Address status:{" "}
             <span className="font-medium text-foreground">

--- a/app/hooks/phone/index.ts
+++ b/app/hooks/phone/index.ts
@@ -1,2 +1,3 @@
 export { usePhoneNumbers } from './usePhoneNumbers';
+export { useWorkspaceNumberSettingsMutations } from './useWorkspaceNumberSettingsMutations';
 

--- a/app/hooks/phone/index.ts
+++ b/app/hooks/phone/index.ts
@@ -1,3 +1,9 @@
 export { usePhoneNumbers } from './usePhoneNumbers';
 export { useWorkspaceNumberSettingsMutations } from './useWorkspaceNumberSettingsMutations';
+export {
+  flashSearchParamWarning,
+  flashServiceAddressSavedParam,
+  SERVICE_ADDRESS_SAVED_TOAST,
+  SERVICE_ADDRESS_VALIDATED_TOAST,
+} from './serviceAddressSearchParamFlash';
 

--- a/app/hooks/phone/serviceAddressSearchParamFlash.ts
+++ b/app/hooks/phone/serviceAddressSearchParamFlash.ts
@@ -1,0 +1,22 @@
+import { toast } from "sonner";
+
+/** Toast copy for `?saved=service_address` after saving a regulatory address. */
+export const SERVICE_ADDRESS_SAVED_TOAST =
+  "Service address saved. Validate it before renting a voice-capable number.";
+
+/** Toast copy for `?saved=emergency_voice` after Twilio validates the address. */
+export const SERVICE_ADDRESS_VALIDATED_TOAST = "Service address validated.";
+
+/** Shared `saved` handler for service-address redirects (onboarding + Numbers). */
+export function flashServiceAddressSavedParam(value: string): void {
+  if (value === "service_address") {
+    toast.success(SERVICE_ADDRESS_SAVED_TOAST);
+  } else if (value === "emergency_voice") {
+    toast.success(SERVICE_ADDRESS_VALIDATED_TOAST);
+  }
+}
+
+/** Shared `warning` handler that surfaces the redirect query value as a toast. */
+export function flashSearchParamWarning(value: string): void {
+  toast.warning(value);
+}

--- a/app/hooks/phone/useWorkspaceNumberSettingsMutations.ts
+++ b/app/hooks/phone/useWorkspaceNumberSettingsMutations.ts
@@ -1,0 +1,129 @@
+import { useCallback } from "react";
+import { useFetcher } from "react-router";
+import type { RoutingPresetSubmission } from "@/components/phone-numbers/NumberSummaryList";
+
+function numbersSettingsActionPath(workspaceId: string): string {
+  return `/workspaces/${workspaceId}/settings/numbers`;
+}
+
+export function useWorkspaceNumberSettingsMutations(workspaceId: string) {
+  const fetcher = useFetcher();
+  const actionPath = numbersSettingsActionPath(workspaceId);
+  const isBusy = fetcher.state !== "idle";
+
+  const submit = useCallback(
+    (formData: Record<string, string>) => {
+      fetcher.submit(formData, { method: "POST", action: actionPath });
+    },
+    [fetcher, actionPath],
+  );
+
+  const onIncomingActivityChange = useCallback(
+    (numberId: number, value: string) => {
+      submit({
+        formName: "update-incoming-activity",
+        numberId: String(numberId),
+        incomingActivity: value,
+      });
+    },
+    [submit],
+  );
+
+  const onIncomingVoiceMessageChange = useCallback(
+    (numberId: number, value: string) => {
+      submit({
+        formName: "update-incoming-voice-message",
+        numberId: String(numberId),
+        incomingVoiceMessage: value,
+      });
+    },
+    [submit],
+  );
+
+  const onHandsetChange = useCallback(
+    (numberId: number, enabled: boolean) => {
+      submit({
+        formName: "update-handset",
+        numberId: String(numberId),
+        handsetEnabled: String(enabled),
+      });
+    },
+    [submit],
+  );
+
+  const onInboundRingCountChange = useCallback(
+    (numberId: number, value: string) => {
+      submit({
+        formName: "update-inbound-ring-count",
+        numberId: String(numberId),
+        inboundRingCount: value,
+      });
+    },
+    [submit],
+  );
+
+  const onInboundQueueChange = useCallback(
+    (numberId: number, queueId: string) => {
+      submit({
+        formName: "update-inbound-queue",
+        numberId: String(numberId),
+        inboundQueueId: queueId,
+      });
+    },
+    [submit],
+  );
+
+  const onInboundScriptChange = useCallback(
+    (numberId: number, scriptId: string) => {
+      submit({
+        formName: "update-inbound-script",
+        numberId: String(numberId),
+        inboundScriptId: scriptId,
+      });
+    },
+    [submit],
+  );
+
+  const onCallerIdChange = useCallback(
+    (numberId: number, value: string) => {
+      submit({
+        formName: "update-caller-id",
+        numberId: String(numberId),
+        friendly_name: value,
+      });
+    },
+    [submit],
+  );
+
+  const onNumberRemoval = useCallback(
+    (numberId: number) => {
+      submit({
+        formName: "remove-number",
+        numberId: String(numberId),
+      });
+    },
+    [submit],
+  );
+
+  const onApplyPreset = useCallback(
+    (submission: RoutingPresetSubmission) => {
+      fetcher.submit(submission, { method: "POST", action: actionPath });
+    },
+    [fetcher, actionPath],
+  );
+
+  return {
+    fetcher,
+    actionPath,
+    isBusy,
+    onIncomingActivityChange,
+    onIncomingVoiceMessageChange,
+    onHandsetChange,
+    onInboundRingCountChange,
+    onInboundQueueChange,
+    onInboundScriptChange,
+    onCallerIdChange,
+    onNumberRemoval,
+    onApplyPreset,
+  };
+}

--- a/app/lib/database/workspace-provisioning.server.ts
+++ b/app/lib/database/workspace-provisioning.server.ts
@@ -1,0 +1,264 @@
+/**
+ * Workspace creation and initial provisioning (Twilio, Stripe, welcome credits).
+ */
+import { eq } from "drizzle-orm";
+import { workspace } from "@/db/schema";
+import { authUser } from "@/db/auth-schema";
+import { welcomeCreditsKey } from "@/lib/billing-keys";
+import { rpcCreateNewWorkspace } from "@/lib/db-rpc.server";
+import { ensureProfileForUser } from "@/lib/ensure-user-profile.server";
+import { env } from "@/lib/env.server";
+import { logger } from "@/lib/logger.server";
+import {
+  buildOnboardingStepsForState,
+  DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE,
+  mergeWorkspaceMessagingOnboardingState,
+} from "@/lib/messaging-onboarding.server";
+import { invalidateWorkspaceTwilioData } from "@/lib/merge-workspace-twilio-data.server";
+import { seedWorkspaceSampleData } from "@/lib/seed/seed-workspace-sample-data.server";
+import { insertTransactionHistoryIdempotent } from "@/lib/transaction-history.server";
+import { ensureWorkspaceTwilioBootstrap } from "@/lib/twilio-bootstrap.server";
+import { addUserToWorkspace } from "@/lib/workspace-membership.server";
+import { adminDb } from "@/server/admin-db";
+import { createStripeContact } from "./stripe.server";
+import {
+  createKeys,
+  createSubaccount,
+  twilioAccountToPersistableJson,
+} from "./workspace.server";
+
+/** Every new workspace starts with free credits so teams can try calling/texting before paying. */
+export const NEW_WORKSPACE_WELCOME_CREDITS = 100;
+
+export async function createNewWorkspace({
+  workspaceName,
+  user_id,
+}: {
+  workspaceName: string;
+  user_id: string;
+}): Promise<{
+  data: string | null;
+  error: string | null;
+  provisioningWarning?: string | null;
+}> {
+  let workspaceId: string | null = null;
+  const provisioningWarnings: string[] = [];
+
+  try {
+    // Domain tables + create_new_workspace RPC key users by uuid. Better Auth now
+    // uses generateId=crypto.randomUUID(), but legacy nanoid auth rows cannot be
+    // mirrored into public.user / cast for the RPC.
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        user_id,
+      )
+    ) {
+      logger.error("createNewWorkspace rejected non-uuid auth user id", {
+        userId: user_id,
+      });
+      return {
+        data: null,
+        error:
+          "This account uses an unsupported user id format. Sign out and sign up again, or contact support.",
+        provisioningWarning: null,
+      };
+    }
+
+    // Safety net for users who signed up before databaseHooks.user.create.after
+    // mirrored auth_user → public.user (required by workspace_users FK).
+    const [authRow] = await adminDb
+      .select({
+        id: authUser.id,
+        email: authUser.email,
+        name: authUser.name,
+      })
+      .from(authUser)
+      .where(eq(authUser.id, user_id))
+      .limit(1);
+    if (authRow) {
+      await ensureProfileForUser(authRow);
+    }
+
+    const insertWorkspaceData = await rpcCreateNewWorkspace(workspaceName, user_id);
+    const createdWorkspaceId = insertWorkspaceData;
+    workspaceId = createdWorkspaceId;
+
+    // Phase C: RPC still seeds legacy workspace_users; also create CHS membership
+    // so getUserRole / requireWorkspaceAccess see the owner (no dual-write of
+    // membership mutations elsewhere — this only fills the CHS gap left by RPC).
+    const { error: ownerMembershipError } = await addUserToWorkspace({
+      workspaceId: createdWorkspaceId,
+      userId: user_id,
+      role: "owner",
+    });
+    if (ownerMembershipError) {
+      logger.error(
+        "CHS owner membership insert failed after workspace create:",
+        ownerMembershipError,
+      );
+      provisioningWarnings.push("Owner membership was not created");
+    }
+
+    let account: Awaited<ReturnType<typeof createSubaccount>> | null = null;
+    try {
+      account = await createSubaccount({
+        workspace_id: createdWorkspaceId,
+      });
+      if (!account) {
+        provisioningWarnings.push("Twilio subaccount was not created");
+      }
+    } catch (subaccountError) {
+      logger.error("Twilio subaccount creation failed after workspace insert:", subaccountError);
+      provisioningWarnings.push("Twilio subaccount creation failed");
+    }
+
+    let newKey: Awaited<ReturnType<typeof createKeys>> | null = null;
+    if (account) {
+      try {
+        newKey = await createKeys({
+          workspace_id: createdWorkspaceId,
+          sid: account.sid,
+          token: account.authToken,
+        });
+        if (!newKey) {
+          provisioningWarnings.push("Twilio API keys were not created");
+        }
+      } catch (keyError) {
+        logger.error("Twilio API key creation failed after workspace insert:", keyError);
+        provisioningWarnings.push("Twilio API key creation failed");
+      }
+    }
+
+    let stripeCustomerId: string | null = null;
+    try {
+      const newStripeCustomer = await createStripeContact({
+        workspace_id: createdWorkspaceId,
+      });
+      stripeCustomerId = newStripeCustomer.id;
+    } catch (stripeError) {
+      logger.error("Stripe customer creation failed after workspace insert:", stripeError);
+      provisioningWarnings.push("Stripe customer creation failed");
+    }
+
+    const seededOnboarding = mergeWorkspaceMessagingOnboardingState(
+      DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE,
+      {
+        subaccountBootstrap: {
+          ...DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE.subaccountBootstrap,
+          callbackBaseUrl: env.BASE_URL(),
+          inboundVoiceUrl: `${env.BASE_URL()}/api/inbound`,
+          inboundSmsUrl: `${env.BASE_URL()}/api/inbound-sms`,
+          statusCallbackUrl: `${env.BASE_URL()}/api/caller-id/status`,
+          status: "provisioning",
+        },
+        status: "provisioning",
+        currentStep: "business_identity",
+        lastUpdatedBy: user_id,
+      },
+    );
+    seededOnboarding.steps = buildOnboardingStepsForState(seededOnboarding);
+
+    const twilioPayload = account
+      ? { ...twilioAccountToPersistableJson(account), onboarding: seededOnboarding }
+      : { onboarding: seededOnboarding };
+
+    const workspaceUpdate: {
+      twilio_data: string;
+      key?: string;
+      token?: string;
+      stripe_id?: string;
+    } = {
+      twilio_data: JSON.stringify(twilioPayload),
+    };
+    if (newKey) {
+      workspaceUpdate.key = newKey.sid;
+      workspaceUpdate.token = newKey.secret;
+    }
+    if (stripeCustomerId) {
+      workspaceUpdate.stripe_id = stripeCustomerId;
+    }
+
+    try {
+      await adminDb
+        .update(workspace)
+        .set(workspaceUpdate)
+        .where(eq(workspace.id, createdWorkspaceId));
+      // workspaceUpdate always carries twilio_data (and, when Twilio keys
+      // were minted above, key/token) — bust the cached credentials/client
+      // for this workspace so subsequent lookups don't serve stale data.
+      invalidateWorkspaceTwilioData(createdWorkspaceId);
+    } catch (insertWorkspaceUsersError) {
+      logger.error(
+        "Workspace metadata update failed after workspace insert:",
+        insertWorkspaceUsersError,
+      );
+      provisioningWarnings.push("Workspace provisioning metadata update failed");
+    }
+
+    if (account && newKey) {
+      try {
+        await ensureWorkspaceTwilioBootstrap({
+          workspaceId: createdWorkspaceId,
+          actorUserId: user_id,
+        });
+      } catch (bootstrapError) {
+        logger.error(
+          "Workspace Twilio bootstrap failed after workspace creation:",
+          bootstrapError,
+        );
+        provisioningWarnings.push("Twilio bootstrap is still running");
+      }
+    }
+
+    try {
+      await insertTransactionHistoryIdempotent({
+        workspaceId: createdWorkspaceId,
+        type: "CREDIT",
+        amount: NEW_WORKSPACE_WELCOME_CREDITS,
+        note: `Welcome bonus: ${NEW_WORKSPACE_WELCOME_CREDITS} free credits to get started`,
+        idempotencyKey: welcomeCreditsKey(createdWorkspaceId),
+      });
+    } catch (welcomeCreditError) {
+      logger.error(
+        "Welcome credit grant failed after workspace creation:",
+        welcomeCreditError,
+      );
+      provisioningWarnings.push("Welcome credits were not granted");
+    }
+
+    try {
+      await seedWorkspaceSampleData(createdWorkspaceId, user_id);
+    } catch (seedError) {
+      logger.error(
+        "Sample data seeding failed after workspace creation:",
+        seedError,
+      );
+      provisioningWarnings.push("Sample data seeding failed");
+    }
+
+    return {
+      data: workspaceId,
+      error: null,
+      provisioningWarning:
+        provisioningWarnings.length > 0 ? provisioningWarnings.join("; ") : null,
+    };
+  } catch (error) {
+    logger.error("Error in createNewWorkspace:", error);
+    if (workspaceId) {
+      return {
+        data: workspaceId,
+        error: null,
+        provisioningWarning:
+          error instanceof Error
+            ? `Workspace created but provisioning failed: ${error.message}`
+            : "Workspace created but provisioning failed",
+      };
+    }
+    return {
+      data: null,
+      error:
+        error instanceof Error ? error.message : "An unexpected error occurred",
+      provisioningWarning: null,
+    };
+  }
+}

--- a/app/lib/database/workspace.server.ts
+++ b/app/lib/database/workspace.server.ts
@@ -23,23 +23,13 @@ import {
 } from "@/lib/merge-workspace-twilio-data.server";
 import { logger } from "../logger.server";
 import {
-  rpcCreateNewWorkspace,
   rpcGetWorkspaceUsers,
   rpcUpdateUserWorkspaceLastAccessTime,
 } from "@/lib/db-rpc.server";
-import { createStripeContact } from "./stripe.server";
 import {
-  buildOnboardingStepsForState,
-  DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE,
   getWorkspaceMessagingOnboardingState,
-  mergeWorkspaceMessagingOnboardingState,
   updateWorkspaceMessagingOnboardingState,
 } from "@/lib/messaging-onboarding.server";
-import { ensureWorkspaceTwilioBootstrap } from "@/lib/twilio-bootstrap.server";
-import { insertTransactionHistoryIdempotent } from "@/lib/transaction-history.server";
-import { welcomeCreditsKey } from "@/lib/billing-keys";
-import { seedWorkspaceSampleData } from "@/lib/seed/seed-workspace-sample-data.server";
-import { ensureProfileForUser } from "@/lib/ensure-user-profile.server";
 import { adminDb } from "@/server/admin-db";
 import { createTenantDb, type TenantDb } from "@/server/tenant-db";
 import { data as routeData } from "react-router";
@@ -53,8 +43,6 @@ import {
   requireWorkspaceAccess,
   workspaceMemberId,
 } from "@/lib/workspace-membership.server";
-import { authUser } from "@/db/auth-schema";
-
 export {
   addUserToWorkspace,
   getUserRole,
@@ -164,7 +152,7 @@ export async function createSubaccount({
 }
 
 /** Twilio `AccountInstance` is not JSON-serializable (circular `_version`); tests may return plain objects without `toJSON`. */
-function twilioAccountToPersistableJson(account: unknown): Record<string, unknown> {
+export function twilioAccountToPersistableJson(account: unknown): Record<string, unknown> {
   if (
     typeof account === "object" &&
     account !== null &&
@@ -197,242 +185,6 @@ function twilioAccountToPersistableJson(account: unknown): Record<string, unknow
     }
   }
   return out;
-}
-
-/** Every new workspace starts with free credits so teams can try calling/texting before paying. */
-export const NEW_WORKSPACE_WELCOME_CREDITS = 100;
-
-export async function createNewWorkspace({
-  workspaceName,
-  user_id,
-}: {
-  workspaceName: string;
-  user_id: string;
-}): Promise<{
-  data: string | null;
-  error: string | null;
-  provisioningWarning?: string | null;
-}> {
-  let workspaceId: string | null = null;
-  const provisioningWarnings: string[] = [];
-
-  try {
-    // Domain tables + create_new_workspace RPC key users by uuid. Better Auth now
-    // uses generateId=crypto.randomUUID(), but legacy nanoid auth rows cannot be
-    // mirrored into public.user / cast for the RPC.
-    if (
-      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-        user_id,
-      )
-    ) {
-      logger.error("createNewWorkspace rejected non-uuid auth user id", {
-        userId: user_id,
-      });
-      return {
-        data: null,
-        error:
-          "This account uses an unsupported user id format. Sign out and sign up again, or contact support.",
-        provisioningWarning: null,
-      };
-    }
-
-    // Safety net for users who signed up before databaseHooks.user.create.after
-    // mirrored auth_user → public.user (required by workspace_users FK).
-    const [authRow] = await adminDb
-      .select({
-        id: authUser.id,
-        email: authUser.email,
-        name: authUser.name,
-      })
-      .from(authUser)
-      .where(eq(authUser.id, user_id))
-      .limit(1);
-    if (authRow) {
-      await ensureProfileForUser(authRow);
-    }
-
-    const insertWorkspaceData = await rpcCreateNewWorkspace(workspaceName, user_id);
-    const createdWorkspaceId = insertWorkspaceData;
-    workspaceId = createdWorkspaceId;
-
-    // Phase C: RPC still seeds legacy workspace_users; also create CHS membership
-    // so getUserRole / requireWorkspaceAccess see the owner (no dual-write of
-    // membership mutations elsewhere — this only fills the CHS gap left by RPC).
-    const { error: ownerMembershipError } = await addUserToWorkspace({
-      workspaceId: createdWorkspaceId,
-      userId: user_id,
-      role: "owner",
-    });
-    if (ownerMembershipError) {
-      logger.error(
-        "CHS owner membership insert failed after workspace create:",
-        ownerMembershipError,
-      );
-      provisioningWarnings.push("Owner membership was not created");
-    }
-
-    let account: Awaited<ReturnType<typeof createSubaccount>> | null = null;
-    try {
-      account = await createSubaccount({
-        workspace_id: createdWorkspaceId,
-      });
-      if (!account) {
-        provisioningWarnings.push("Twilio subaccount was not created");
-      }
-    } catch (subaccountError) {
-      logger.error("Twilio subaccount creation failed after workspace insert:", subaccountError);
-      provisioningWarnings.push("Twilio subaccount creation failed");
-    }
-
-    let newKey: Awaited<ReturnType<typeof createKeys>> | null = null;
-    if (account) {
-      try {
-        newKey = await createKeys({
-          workspace_id: createdWorkspaceId,
-          sid: account.sid,
-          token: account.authToken,
-        });
-        if (!newKey) {
-          provisioningWarnings.push("Twilio API keys were not created");
-        }
-      } catch (keyError) {
-        logger.error("Twilio API key creation failed after workspace insert:", keyError);
-        provisioningWarnings.push("Twilio API key creation failed");
-      }
-    }
-
-    let stripeCustomerId: string | null = null;
-    try {
-      const newStripeCustomer = await createStripeContact({
-        workspace_id: createdWorkspaceId,
-      });
-      stripeCustomerId = newStripeCustomer.id;
-    } catch (stripeError) {
-      logger.error("Stripe customer creation failed after workspace insert:", stripeError);
-      provisioningWarnings.push("Stripe customer creation failed");
-    }
-
-    const seededOnboarding = mergeWorkspaceMessagingOnboardingState(
-      DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE,
-      {
-        subaccountBootstrap: {
-          ...DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE.subaccountBootstrap,
-          callbackBaseUrl: env.BASE_URL(),
-          inboundVoiceUrl: `${env.BASE_URL()}/api/inbound`,
-          inboundSmsUrl: `${env.BASE_URL()}/api/inbound-sms`,
-          statusCallbackUrl: `${env.BASE_URL()}/api/caller-id/status`,
-          status: "provisioning",
-        },
-        status: "provisioning",
-        currentStep: "business_identity",
-        lastUpdatedBy: user_id,
-      },
-    );
-    seededOnboarding.steps = buildOnboardingStepsForState(seededOnboarding);
-
-    const twilioPayload = account
-      ? { ...twilioAccountToPersistableJson(account), onboarding: seededOnboarding }
-      : { onboarding: seededOnboarding };
-
-    const workspaceUpdate: {
-      twilio_data: string;
-      key?: string;
-      token?: string;
-      stripe_id?: string;
-    } = {
-      twilio_data: JSON.stringify(twilioPayload),
-    };
-    if (newKey) {
-      workspaceUpdate.key = newKey.sid;
-      workspaceUpdate.token = newKey.secret;
-    }
-    if (stripeCustomerId) {
-      workspaceUpdate.stripe_id = stripeCustomerId;
-    }
-
-    try {
-      await adminDb
-        .update(workspace)
-        .set(workspaceUpdate)
-        .where(eq(workspace.id, createdWorkspaceId));
-      // workspaceUpdate always carries twilio_data (and, when Twilio keys
-      // were minted above, key/token) — bust the cached credentials/client
-      // for this workspace so subsequent lookups don't serve stale data.
-      invalidateWorkspaceTwilioData(createdWorkspaceId);
-    } catch (insertWorkspaceUsersError) {
-      logger.error(
-        "Workspace metadata update failed after workspace insert:",
-        insertWorkspaceUsersError,
-      );
-      provisioningWarnings.push("Workspace provisioning metadata update failed");
-    }
-
-    if (account && newKey) {
-      try {
-        await ensureWorkspaceTwilioBootstrap({
-          workspaceId: createdWorkspaceId,
-          actorUserId: user_id,
-        });
-      } catch (bootstrapError) {
-        logger.error(
-          "Workspace Twilio bootstrap failed after workspace creation:",
-          bootstrapError,
-        );
-        provisioningWarnings.push("Twilio bootstrap is still running");
-      }
-    }
-
-    try {
-      await insertTransactionHistoryIdempotent({
-        workspaceId: createdWorkspaceId,
-        type: "CREDIT",
-        amount: NEW_WORKSPACE_WELCOME_CREDITS,
-        note: `Welcome bonus: ${NEW_WORKSPACE_WELCOME_CREDITS} free credits to get started`,
-        idempotencyKey: welcomeCreditsKey(createdWorkspaceId),
-      });
-    } catch (welcomeCreditError) {
-      logger.error(
-        "Welcome credit grant failed after workspace creation:",
-        welcomeCreditError,
-      );
-      provisioningWarnings.push("Welcome credits were not granted");
-    }
-
-    try {
-      await seedWorkspaceSampleData(createdWorkspaceId, user_id);
-    } catch (seedError) {
-      logger.error(
-        "Sample data seeding failed after workspace creation:",
-        seedError,
-      );
-      provisioningWarnings.push("Sample data seeding failed");
-    }
-
-    return {
-      data: workspaceId,
-      error: null,
-      provisioningWarning:
-        provisioningWarnings.length > 0 ? provisioningWarnings.join("; ") : null,
-    };
-  } catch (error) {
-    logger.error("Error in createNewWorkspace:", error);
-    if (workspaceId) {
-      return {
-        data: workspaceId,
-        error: null,
-        provisioningWarning:
-          error instanceof Error
-            ? `Workspace created but provisioning failed: ${error.message}`
-            : "Workspace created but provisioning failed",
-      };
-    }
-    return {
-      data: null,
-      error:
-        error instanceof Error ? error.message : "An unexpected error occurred",
-      provisioningWarning: null,
-    };
-  }
 }
 
 export async function getWorkspaceInfo({

--- a/app/lib/onboarding/emergency-voice.server.ts
+++ b/app/lib/onboarding/emergency-voice.server.ts
@@ -8,14 +8,16 @@ import { isObject } from "@/lib/type-safety-utils";
 import { hasVoiceCapability } from "@/lib/onboarding/voice-capabilities";
 import type { Database } from "@/lib/db-types";
 import type Twilio from "twilio";
-import type { OnboardingActionData } from "@/lib/onboarding-actions.server";
-import { data as routeData } from "react-router";
 import { persistWorkspaceOnboardingState } from "@/lib/onboarding/onboarding-persist.server";
+
+export type ReviewWorkspaceEmergencyVoiceResult =
+  | { ok: true; success?: string }
+  | { ok: false; error: string; status?: number };
 
 export async function reviewWorkspaceEmergencyVoice(args: {
   workspaceId: string;
   actorUserId: string | null;
-}) {
+}): Promise<ReviewWorkspaceEmergencyVoiceResult> {
   const { workspaceId, actorUserId } = args;
 
   const [current, workspacePhoneNumbers] = await Promise.all([
@@ -39,10 +41,11 @@ export async function reviewWorkspaceEmergencyVoice(args: {
     !address.postalCode.trim() ||
     !customerName
   ) {
-    return routeData<OnboardingActionData>(
-      { error: "Save a complete emergency service address before running voice review." },
-      { status: 400 },
-    );
+    return {
+      ok: false,
+      error: "Save a complete emergency service address before running voice review.",
+      status: 400,
+    };
   }
 
   try {
@@ -164,19 +167,21 @@ export async function reviewWorkspaceEmergencyVoice(args: {
     });
 
     if (eligiblePhoneNumbers.length === 0) {
-      return routeData<OnboardingActionData>({
+      return {
+        ok: true,
         success:
           "Emergency address validated. Add or refresh a rented voice number to finish voice readiness.",
-      });
+      };
     }
 
     const ineligibleCount = ineligibleCallerIds.length;
-    return routeData<OnboardingActionData>({
+    return {
+      ok: true,
       success:
         ineligibleCount > 0
           ? `Emergency voice reviewed. ${eligiblePhoneNumbers.length} number(s) are ready and ${ineligibleCount} still need review.`
           : `Emergency voice reviewed. ${eligiblePhoneNumbers.length} number(s) are emergency-ready.`,
-    });
+    };
   } catch (error) {
     await persistWorkspaceOnboardingState({
       workspaceId,
@@ -198,12 +203,11 @@ export async function reviewWorkspaceEmergencyVoice(args: {
       },
     });
 
-    return routeData<OnboardingActionData>(
-      {
-        error:
-          error instanceof Error ? error.message : "Emergency address validation failed.",
-      },
-      { status: 500 },
-    );
+    return {
+      ok: false,
+      error:
+        error instanceof Error ? error.message : "Emergency address validation failed.",
+      status: 500,
+    };
   }
 }

--- a/app/lib/platform-auth.server.ts
+++ b/app/lib/platform-auth.server.ts
@@ -5,9 +5,9 @@ import { mergeBetterAuthSetCookieHeaders } from "@/lib/better-auth-headers.serve
 import { isTwoFactorRedirectResponse } from "@/lib/two-factor.server";
 import {
   acceptWorkspaceInvitations,
-  createNewWorkspace,
   getInvitesByUserId,
 } from "@/lib/database/workspace.server";
+import { createNewWorkspace } from "@/lib/database/workspace-provisioning.server";
 import {
   getUserById,
   listUserWorkspaceMembershipsForProfile,

--- a/app/lib/platform-onboarding-handlers.server.ts
+++ b/app/lib/platform-onboarding-handlers.server.ts
@@ -428,10 +428,36 @@ async function handleSaveServiceAddress(
 async function handleReviewEmergencyVoice(
   ctx: OnboardingActionContext,
 ): Promise<OnboardingHandlerResult> {
-  const result = await reviewWorkspaceEmergencyVoice({workspaceId: ctx.workspaceId,
+  const formData = resolveOnboardingInput(ctx.input);
+  const result = await reviewWorkspaceEmergencyVoice({
+    workspaceId: ctx.workspaceId,
     actorUserId: ctx.actorUserId,
   });
-  return adaptRouteDataResult(result);
+  const adapted = adaptRouteDataResult(result);
+  if (adapted.kind !== "payload") {
+    return adapted;
+  }
+
+  const returnTo = String(
+    formData.get("returnTo") ?? formData.get("return_to") ?? "",
+  );
+  if (returnTo.startsWith(`/workspaces/${ctx.workspaceId}`)) {
+    if (adapted.data.error) {
+      return {
+        kind: "redirect_path",
+        path: returnTo,
+        searchParams: { warning: adapted.data.error },
+      };
+    }
+    return redirectToReturnToOrPayload(
+      formData,
+      ctx.workspaceId,
+      "emergency_voice",
+      adapted.data.success ?? "Service address validated.",
+    );
+  }
+
+  return adapted;
 }
 
 async function handleProvisionA2p(ctx: OnboardingActionContext): Promise<OnboardingHandlerResult> {

--- a/app/lib/platform-onboarding-handlers.server.ts
+++ b/app/lib/platform-onboarding-handlers.server.ts
@@ -36,7 +36,6 @@ import { updateWorkspaceName } from "@/lib/platform-workspace.server";
 import { enqueueWorkspaceComplianceJob } from "@/lib/worker/handlers.server";
 import { attachWorkspaceRcsSenderToPool } from "@/lib/twilio-sender-pool.server";
 import {
-  adaptRouteDataResult,
   redirectToReturnToOrPayload,
   resolveOnboardingInput,
   resolveOperatingCountryFromForm,
@@ -433,31 +432,23 @@ async function handleReviewEmergencyVoice(
     workspaceId: ctx.workspaceId,
     actorUserId: ctx.actorUserId,
   });
-  const adapted = adaptRouteDataResult(result);
-  if (adapted.kind !== "payload") {
-    return adapted;
-  }
 
-  const returnTo = String(
-    formData.get("returnTo") ?? formData.get("return_to") ?? "",
-  );
-  if (returnTo.startsWith(`/workspaces/${ctx.workspaceId}`)) {
-    if (adapted.data.error) {
-      return {
-        kind: "redirect_path",
-        path: returnTo,
-        searchParams: { warning: adapted.data.error },
-      };
-    }
+  if (!result.ok) {
     return redirectToReturnToOrPayload(
       formData,
       ctx.workspaceId,
       "emergency_voice",
-      adapted.data.success ?? "Service address validated.",
+      "",
+      { error: result.error, status: result.status },
     );
   }
 
-  return adapted;
+  return redirectToReturnToOrPayload(
+    formData,
+    ctx.workspaceId,
+    "emergency_voice",
+    result.success ?? "Service address validated.",
+  );
 }
 
 async function handleProvisionA2p(ctx: OnboardingActionContext): Promise<OnboardingHandlerResult> {

--- a/app/lib/platform-onboarding-helpers.server.ts
+++ b/app/lib/platform-onboarding-helpers.server.ts
@@ -1,22 +1,29 @@
 import {
   getWorkspacePhoneNumbers,
 } from "@/lib/database/workspace.server";
+import { getWorkspaceRecentOutboundMessageCount } from "@/lib/database/workspace-twilio-portal-snapshot.server";
 import type { Tables } from "@/lib/db-types";
 import {
   applyOnboardingStepsWithWorkspaceNumbers,
   applyWorkspaceOnboardingChannelPolicy,
+  deriveWorkspaceMessagingReadiness,
   getWorkspaceMessagingOnboardingState,
 } from "@/lib/messaging-onboarding.server";
 import type { OnboardingActionData } from "@/lib/onboarding-actions.server";
 import {
+  getWorkspaceRcsBlockingIssues,
   hydrateWorkspaceRcsOnboardingState,
+  isRcsOnboardingEnabled,
 } from "@/lib/rcs-onboarding.server";
+import { buildA2pBlockingIssues } from "@/lib/twilio-a2p.server";
 import type {
   WorkspaceMessagingOnboardingState,
   WorkspaceMessagingReadiness,
   WorkspaceOperatingCountry,
 } from "@/lib/types";
 import { WORKSPACE_OPERATING_COUNTRY_VALUES } from "@/lib/types";
+import { getWorkspaceCredits } from "@/lib/workspace-members-db.server";
+import { createTenantDb } from "@/server/tenant-db";
 
 export type OnboardingHandlerResult =
   | {
@@ -50,6 +57,19 @@ export type WorkspaceOnboardingDetail = {
   rcs_blocking_issues: string[];
   phone_numbers: Tables<"workspace_number">[] | null;
   credits_balance: number;
+};
+
+export type WorkspaceOnboardingView = {
+  onboarding: WorkspaceMessagingOnboardingState;
+  phoneNumbers: Tables<"workspace_number">[] | null;
+  creditsBalance: number;
+  readiness: WorkspaceMessagingReadiness;
+  rcsBlockingIssues: string[];
+  a2pBlockingIssues: string[];
+  audienceCount: number;
+  campaignCount: number;
+  scriptCount: number;
+  recentOutboundCount: number;
 };
 
 function jsonInputToFormData(body: Record<string, unknown>): FormData {
@@ -101,42 +121,42 @@ export function resolveOperatingCountryFromForm(
     : fallback;
 }
 
-/** Prefer an in-workspace returnTo path; otherwise return a success payload. */
+/** Prefer an in-workspace returnTo path; otherwise return a success or error payload. */
 export function redirectToReturnToOrPayload(
   formData: FormData,
   workspaceId: string,
   savedKey: string,
   successMessage: string,
+  options?: { error?: string; status?: number },
 ): OnboardingHandlerResult {
   const returnTo = String(
     formData.get("returnTo") ?? formData.get("return_to") ?? "",
   );
   if (returnTo.startsWith(`/workspaces/${workspaceId}`)) {
+    if (options?.error) {
+      return {
+        kind: "redirect_path",
+        path: returnTo,
+        searchParams: { warning: options.error },
+      };
+    }
     return {
       kind: "redirect_path",
       path: returnTo,
       searchParams: { saved: savedKey },
     };
   }
+  if (options?.error) {
+    return {
+      kind: "payload",
+      data: { error: options.error },
+      status: options.status,
+    };
+  }
   return {
     kind: "payload",
     data: { success: successMessage },
   };
-}
-
-export function adaptRouteDataResult(result: unknown): OnboardingHandlerResult {
-  if (result && typeof result === "object" && "data" in result) {
-    const wrapped = result as {
-      data: OnboardingActionData;
-      init?: number | { status?: number } | null;
-    };
-    const status =
-      typeof wrapped.init === "number"
-        ? wrapped.init
-        : wrapped.init?.status ?? 200;
-    return { kind: "payload", data: wrapped.data, status };
-  }
-  return { kind: "payload", data: {}, status: 200 };
 }
 
 export async function hydrateWorkspaceOnboarding(workspaceId: string) {
@@ -151,4 +171,67 @@ export async function hydrateWorkspaceOnboarding(workspaceId: string) {
   );
 
   return { phoneNumbers: phoneNumbers ?? null, onboarding: hydratedOnboarding };
+}
+
+export async function loadWorkspaceOnboardingView(
+  workspaceId: string,
+): Promise<WorkspaceOnboardingView> {
+  const tdb = createTenantDb(workspaceId);
+
+  const [
+    { data: phoneNumbers },
+    onboarding,
+    creditsBalance,
+    recentOutboundCount,
+    audienceCount,
+    campaignCount,
+    scriptCount,
+  ] = await Promise.all([
+    getWorkspacePhoneNumbers({ workspaceId }),
+    getWorkspaceMessagingOnboardingState({ workspaceId }),
+    getWorkspaceCredits(workspaceId),
+    getWorkspaceRecentOutboundMessageCount({ workspaceId }),
+    tdb.audience.count(),
+    tdb.campaign.count(),
+    tdb.script.count(),
+  ]);
+
+  const hydratedOnboarding = applyOnboardingStepsWithWorkspaceNumbers(
+    hydrateWorkspaceRcsOnboardingState(applyWorkspaceOnboardingChannelPolicy(onboarding)),
+    phoneNumbers ?? [],
+    {
+      audienceCount,
+      scriptCount,
+      campaignCount,
+      creditsBalance: creditsBalance ?? 0,
+    },
+  );
+
+  const rcsBlockingIssues =
+    isRcsOnboardingEnabled() && hydratedOnboarding.selectedChannels.includes("rcs")
+      ? getWorkspaceRcsBlockingIssues(hydratedOnboarding)
+      : [];
+
+  const readiness = deriveWorkspaceMessagingReadiness({
+    onboarding: hydratedOnboarding,
+    workspaceNumbers: (phoneNumbers ?? []).map((number) => ({
+      type: number?.type ?? null,
+      phone_number: number?.phone_number ?? null,
+      capabilities: number?.capabilities ?? null,
+    })),
+    recentOutboundCount,
+  });
+
+  return {
+    onboarding: hydratedOnboarding,
+    phoneNumbers: phoneNumbers ?? null,
+    creditsBalance: creditsBalance ?? 0,
+    readiness,
+    rcsBlockingIssues,
+    a2pBlockingIssues: buildA2pBlockingIssues(hydratedOnboarding),
+    audienceCount,
+    campaignCount,
+    scriptCount,
+    recentOutboundCount,
+  };
 }

--- a/app/lib/platform-onboarding.server.ts
+++ b/app/lib/platform-onboarding.server.ts
@@ -3,7 +3,6 @@ import {
   requireWorkspaceAccess,
 } from "@/lib/database/workspace.server";
 import {
-  deriveWorkspaceMessagingReadiness,
   isWizardOnboardingStepId,
 } from "@/lib/messaging-onboarding.server";
 import {
@@ -12,16 +11,10 @@ import {
   type OnboardingActionData,
 } from "@/lib/onboarding-actions.server";
 import { persistWorkspaceOnboardingState } from "@/lib/onboarding/onboarding-persist.server";
-import { getWorkspaceCredits } from "@/lib/workspace-members-db.server";
-import {
-  getWorkspaceRcsBlockingIssues,
-  isRcsOnboardingEnabled,
-  stripDisabledRcsChannel,
-} from "@/lib/rcs-onboarding.server";
-import { buildA2pBlockingIssues } from "@/lib/twilio-a2p.server";
+import { stripDisabledRcsChannel } from "@/lib/rcs-onboarding.server";
 import type { WorkspaceMessagingOnboardingState } from "@/lib/types";
 import {
-  hydrateWorkspaceOnboarding,
+  loadWorkspaceOnboardingView,
   type OnboardingActionContext,
   type OnboardingHandlerResult,
   type WorkspaceOnboardingDetail,
@@ -74,35 +67,17 @@ export async function getWorkspaceOnboardingDetail(
     workspaceId,
   });
 
-  const [{ onboarding, phoneNumbers }, credits] = await Promise.all([
-    hydrateWorkspaceOnboarding(workspaceId),
-    getWorkspaceCredits(workspaceId),
-  ]);
-
-  const rcsBlockingIssues =
-    isRcsOnboardingEnabled() && onboarding.selectedChannels.includes("rcs")
-      ? getWorkspaceRcsBlockingIssues(onboarding)
-      : [];
-
-  const readiness = deriveWorkspaceMessagingReadiness({
-    onboarding,
-    workspaceNumbers: (phoneNumbers ?? []).map((number) => ({
-      type: number?.type ?? null,
-      phone_number: number?.phone_number ?? null,
-      capabilities: number?.capabilities ?? null,
-    })),
-    recentOutboundCount: 0,
-  });
+  const view = await loadWorkspaceOnboardingView(workspaceId);
 
   return {
     ok: true,
     detail: {
-      onboarding,
-      readiness,
-      a2p_blocking_issues: buildA2pBlockingIssues(onboarding),
-      rcs_blocking_issues: rcsBlockingIssues,
-      phone_numbers: phoneNumbers,
-      credits_balance: credits ?? 0,
+      onboarding: view.onboarding,
+      readiness: view.readiness,
+      a2p_blocking_issues: view.a2pBlockingIssues,
+      rcs_blocking_issues: view.rcsBlockingIssues,
+      phone_numbers: view.phoneNumbers,
+      credits_balance: view.creditsBalance,
     },
   };
 }

--- a/app/lib/platform-workspace-numbers.server.ts
+++ b/app/lib/platform-workspace-numbers.server.ts
@@ -152,7 +152,7 @@ export async function purchaseWorkspaceNumber(
       return {
         ok: false as const,
         error:
-          "Add a service address in Numbers settings before renting a phone number.",
+          "Add a service address before renting a phone number.",
         status: 400,
       };
     }

--- a/app/routes/workspaces+/$id/audiences/$audience_id.route.tsx
+++ b/app/routes/workspaces+/$id/audiences/$audience_id.route.tsx
@@ -59,7 +59,7 @@ export default function AudienceView() {
   };
 
   return (
-    <main className="flex h-full flex-col gap-4 text-white">
+    <main className="flex h-full flex-col gap-4 text-foreground">
       <div className="flex items-center justify-between gap-4">
         <Heading as="h1" level={2} branded={false}>
           {audience?.name || `Unnamed Audience ${audience_id}`}

--- a/app/routes/workspaces+/$id/onboarding.action.server.ts
+++ b/app/routes/workspaces+/$id/onboarding.action.server.ts
@@ -35,8 +35,12 @@ function redirectToWorkspacePath(
   if (!searchParams || Object.keys(searchParams).length === 0) {
     throw redirect(path, { headers });
   }
-  const params = new URLSearchParams(searchParams);
-  throw redirect(`${path}?${params.toString()}`, { headers });
+  // Merge flash params into any query already present on `path` (e.g. ?step=).
+  const url = new URL(path, "http://local.invalid");
+  for (const [key, value] of Object.entries(searchParams)) {
+    url.searchParams.set(key, value);
+  }
+  throw redirect(`${url.pathname}${url.search}`, { headers });
 }
 
 async function runUiOnboardingAction(

--- a/app/routes/workspaces+/$id/onboarding.action.server.ts
+++ b/app/routes/workspaces+/$id/onboarding.action.server.ts
@@ -1,8 +1,4 @@
 import { workspaceRouteAuth } from "@/lib/workspace-route.server";
-import {
-  getUserRole,
-  requireWorkspaceAccess,
-} from "@/lib/database/workspace.server";
 import { data as routeData, redirect } from "react-router";
 import {
   isOnboardingActionName,
@@ -93,20 +89,6 @@ export const action = defineAction({
     const wsId = params.id;
     if (!wsId) {
       return routeData<OnboardingActionData>({ error: "Workspace ID is required." }, { status: 400 });
-    }
-
-    await requireWorkspaceAccess({
-      user,
-      workspaceId: wsId,
-    });
-
-    const role = (await getUserRole({ user, workspaceId: wsId }))?.role;
-
-    if (role !== "owner" && role !== "admin") {
-      return routeData<OnboardingActionData>(
-        { error: "Only workspace admins can change onboarding state." },
-        { status: 403 },
-      );
     }
 
     const formData = await request.formData();

--- a/app/routes/workspaces+/$id/onboarding.loader.server.ts
+++ b/app/routes/workspaces+/$id/onboarding.loader.server.ts
@@ -1,26 +1,15 @@
 import { workspaceRouteAuth } from "@/lib/workspace-route.server";
 import {
-  applyOnboardingStepsWithWorkspaceNumbers,
-  applyWorkspaceOnboardingChannelPolicy,
-  deriveWorkspaceMessagingReadiness,
-  getWorkspaceMessagingOnboardingState,
   isWizardOnboardingStepId,
   resolvePersistedWizardStep,
 } from "@/lib/messaging-onboarding.server";
 import {
   getWorkspaceInfo,
-  getWorkspacePhoneNumbers,
   getWorkspaceUsers,
   requireWorkspaceAccess,
 } from "@/lib/database/workspace.server";
-import {
-  getWorkspaceRcsBlockingIssues,
-  hydrateWorkspaceRcsOnboardingState,
-  isRcsOnboardingEnabled,
-} from "@/lib/rcs-onboarding.server";
+import { loadWorkspaceOnboardingView } from "@/lib/platform-onboarding-helpers.server";
 import { data as routeData, redirect } from "react-router";
-import { getWorkspaceCredits } from "@/lib/workspace-members-db.server";
-import { getWorkspaceRecentOutboundMessageCount } from "@/lib/database/workspace-twilio-portal-snapshot.server";
 import { listObjects } from "@/lib/object-storage.server";
 import { createTenantDb } from "@/server/tenant-db";
 import { defineLoader } from "@/lib/handler.server";
@@ -63,23 +52,15 @@ export const loader = defineLoader({
 
     const tdb = createTenantDb(workspaceId);
     const [
+      onboardingView,
       { data: workspaceInfo },
-      { data: phoneNumbers },
-      onboarding,
-      creditsBalance,
-      recentOutboundCount,
       { data: workspaceUsersData },
       mediaNames,
       inboundQueues,
       scripts,
-      audienceCount,
-      campaignCount,
     ] = await Promise.all([
+      loadWorkspaceOnboardingView(workspaceId),
       getWorkspaceInfo({ workspaceId }),
-      getWorkspacePhoneNumbers({ workspaceId }),
-      getWorkspaceMessagingOnboardingState({ workspaceId }),
-      getWorkspaceCredits(workspaceId),
-      getWorkspaceRecentOutboundMessageCount({ workspaceId }),
       getWorkspaceUsers({ workspaceId }),
       listObjects("workspaceAudio", workspaceId),
       tdb.inbound_queue.findMany({
@@ -90,33 +71,16 @@ export const loader = defineLoader({
         columns: { id: true, name: true },
         orderBy: (script, { asc: ascFn }) => [ascFn(script.name)],
       }),
-      tdb.audience.count(),
-      tdb.campaign.count(),
     ]);
-    const hydratedOnboarding = applyOnboardingStepsWithWorkspaceNumbers(
-      hydrateWorkspaceRcsOnboardingState(applyWorkspaceOnboardingChannelPolicy(onboarding)),
-      phoneNumbers ?? [],
-      {
-        audienceCount,
-        scriptCount: scripts.length,
-        campaignCount,
-        creditsBalance: creditsBalance ?? 0,
-      },
-    );
-    const rcsBlockingIssues =
-      isRcsOnboardingEnabled() && hydratedOnboarding.selectedChannels.includes("rcs")
-        ? getWorkspaceRcsBlockingIssues(hydratedOnboarding)
-        : [];
-
-    const readiness = deriveWorkspaceMessagingReadiness({
+    const {
       onboarding: hydratedOnboarding,
-      workspaceNumbers: (phoneNumbers ?? []).map((number) => ({
-        type: number?.type ?? null,
-        phone_number: number?.phone_number ?? null,
-        capabilities: number?.capabilities ?? null,
-      })),
-      recentOutboundCount,
-    });
+      readiness,
+      phoneNumbers,
+      creditsBalance,
+      rcsBlockingIssues,
+      audienceCount,
+      campaignCount,
+    } = onboardingView;
     const stepParam = url.searchParams.get("step");
     const serverStep = resolvePersistedWizardStep(hydratedOnboarding.currentStep);
 
@@ -139,7 +103,7 @@ export const loader = defineLoader({
         onboarding: hydratedOnboarding,
         readiness,
         phoneNumbers,
-        creditsBalance: creditsBalance ?? 0,
+        creditsBalance,
         rcsBlockingIssues,
         workspaceUsers: workspaceUsersData ?? [],
         mediaNames,

--- a/app/routes/workspaces+/$id/onboarding.route.tsx
+++ b/app/routes/workspaces+/$id/onboarding.route.tsx
@@ -3,6 +3,10 @@ export { action } from "./onboarding.action.server";
 
 import { useActionData, useLoaderData, useNavigation } from "react-router";
 import { toast } from "sonner";
+import {
+  flashSearchParamWarning,
+  flashServiceAddressSavedParam,
+} from "@/hooks/phone";
 import { useActionFeedback } from "@/hooks/utils/useActionFeedback";
 import { useSearchParamFlash } from "@/hooks/utils/useSearchParamFlash";
 import type { OnboardingActionData } from "./onboarding.action.server";
@@ -40,18 +44,8 @@ export default function WorkspaceMessagingOnboardingRoute() {
         toast.success("Messaging Service is ready.");
       }
     },
-    saved: (value) => {
-      if (value === "service_address") {
-        toast.success(
-          "Service address saved. Validate it before renting a voice-capable number.",
-        );
-      } else if (value === "emergency_voice") {
-        toast.success("Service address validated.");
-      }
-    },
-    warning: (value) => {
-      toast.warning(value);
-    },
+    saved: flashServiceAddressSavedParam,
+    warning: flashSearchParamWarning,
   });
 
   useActionFeedback(actionData, {

--- a/app/routes/workspaces+/$id/onboarding.route.tsx
+++ b/app/routes/workspaces+/$id/onboarding.route.tsx
@@ -40,6 +40,15 @@ export default function WorkspaceMessagingOnboardingRoute() {
         toast.success("Messaging Service is ready.");
       }
     },
+    saved: (value) => {
+      if (value === "service_address") {
+        toast.success(
+          "Service address saved. Validate it before renting a voice-capable number.",
+        );
+      } else if (value === "emergency_voice") {
+        toast.success("Service address validated.");
+      }
+    },
     warning: (value) => {
       toast.warning(value);
     },

--- a/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
@@ -1,11 +1,9 @@
 import { Link, useFetcher, useRevalidator } from "react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { NumberPurchase } from "@/components/phone-numbers/NumberPurchase";
 import type { NumbersSearchFetcherData } from "@/components/phone-numbers/NumberPurchase";
-import {
-  NumberSummaryList,
-  type RoutingPresetSubmission,
-} from "@/components/phone-numbers/NumberSummaryList";
+import { NumberSummaryList } from "@/components/phone-numbers/NumberSummaryList";
+import { useWorkspaceNumberSettingsMutations } from "@/hooks/phone";
 import {
   CallerIdVerificationDialog,
   type CallerIdValidationRequest,
@@ -50,13 +48,6 @@ type OnboardingFirstNumberStepProps = Pick<
   validationRequest?: CallerIdValidationRequest | null;
 };
 
-// Reuse the same patch-number action handlers the numbers settings page uses
-// (app/routes/workspaces+/$id/settings/numbers.action.server.ts) instead of
-// building a second inbound-routing/handset write path (Phase G, Q44-46/59).
-function numbersSettingsActionPath(workspaceId: string): string {
-  return `/workspaces/${workspaceId}/settings/numbers`;
-}
-
 function presetOrderForGoal(
   goal: WorkspaceOnboardingGoal | null,
 ): readonly InboundRoutingPresetId[] {
@@ -90,8 +81,19 @@ export function OnboardingFirstNumberStep({
   validationRequest,
 }: OnboardingFirstNumberStepProps) {
   const purchaseFetcher = useFetcher<NumbersSearchFetcherData>();
-  const routingFetcher = useFetcher();
   const revalidator = useRevalidator();
+  const {
+    isBusy: isRoutingBusy,
+    onIncomingActivityChange,
+    onIncomingVoiceMessageChange,
+    onHandsetChange,
+    onInboundRingCountChange,
+    onInboundQueueChange,
+    onInboundScriptChange,
+    onCallerIdChange,
+    onNumberRemoval,
+    onApplyPreset,
+  } = useWorkspaceNumberSettingsMutations(workspaceId);
   const [verificationDialogOpen, setVerificationDialogOpen] = useState(
     () => Boolean(validationRequest),
   );
@@ -117,100 +119,11 @@ export function OnboardingFirstNumberStep({
   const verifiedCallerIdCount = countVerifiedCallerIdNumbers(numbers);
   const hasFirstNumber = workspaceHasFirstNumber(numbers);
   const messagingReady = Boolean(onboarding.messagingService.serviceSid);
-  const isRoutingBusy = routingFetcher.state !== "idle";
-  const actionPath = numbersSettingsActionPath(workspaceId);
   const isVerifying = pending.isVerifyingCallerId;
 
-  const handlePurchaseComplete = useCallback(() => {
+  const handlePurchaseComplete = () => {
     revalidator.revalidate();
-  }, [revalidator]);
-
-  const handleIncomingActivityChange = useCallback(
-    (numberId: number, value: string) => {
-      routingFetcher.submit(
-        { formName: "update-incoming-activity", numberId: String(numberId), incomingActivity: value },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleIncomingVoiceMessageChange = useCallback(
-    (numberId: number, value: string) => {
-      routingFetcher.submit(
-        { formName: "update-incoming-voice-message", numberId: String(numberId), incomingVoiceMessage: value },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleHandsetChange = useCallback(
-    (numberId: number, enabled: boolean) => {
-      routingFetcher.submit(
-        { formName: "update-handset", numberId: String(numberId), handsetEnabled: String(enabled) },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleInboundRingCountChange = useCallback(
-    (numberId: number, value: string) => {
-      routingFetcher.submit(
-        { formName: "update-inbound-ring-count", numberId: String(numberId), inboundRingCount: value },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleInboundQueueChange = useCallback(
-    (numberId: number, queueId: string) => {
-      routingFetcher.submit(
-        { formName: "update-inbound-queue", numberId: String(numberId), inboundQueueId: queueId },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleInboundScriptChange = useCallback(
-    (numberId: number, scriptId: string) => {
-      routingFetcher.submit(
-        { formName: "update-inbound-script", numberId: String(numberId), inboundScriptId: scriptId },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleCallerIdChange = useCallback(
-    (numberId: number, value: string) => {
-      routingFetcher.submit(
-        { formName: "update-caller-id", numberId: String(numberId), friendly_name: value },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleNumberRemoval = useCallback(
-    (numberId: number) => {
-      routingFetcher.submit(
-        { formName: "remove-number", numberId: String(numberId) },
-        { method: "POST", action: actionPath },
-      );
-    },
-    [routingFetcher, actionPath],
-  );
-
-  const handleApplyPreset = useCallback(
-    (submission: RoutingPresetSubmission) => {
-      routingFetcher.submit(submission, { method: "POST", action: actionPath });
-    },
-    [routingFetcher, actionPath],
-  );
+  };
 
   const smsGoal = goalNeedsSmsCompliance(onboarding.selectedGoal);
   const callerIdNumbers = numbers.filter((number) => number?.type === "caller_id");
@@ -390,15 +303,15 @@ export function OnboardingFirstNumberStep({
                 queues={inboundQueues}
                 scripts={scripts}
                 verifiedCallerIds={numbers}
-                onIncomingActivityChange={handleIncomingActivityChange}
-                onIncomingVoiceMessageChange={handleIncomingVoiceMessageChange}
-                onCallerIdChange={handleCallerIdChange}
-                onHandsetChange={handleHandsetChange}
-                onInboundRingCountChange={handleInboundRingCountChange}
-                onInboundQueueChange={handleInboundQueueChange}
-                onInboundScriptChange={handleInboundScriptChange}
-                onNumberRemoval={handleNumberRemoval}
-                onApplyPreset={handleApplyPreset}
+                onIncomingActivityChange={onIncomingActivityChange}
+                onIncomingVoiceMessageChange={onIncomingVoiceMessageChange}
+                onCallerIdChange={onCallerIdChange}
+                onHandsetChange={onHandsetChange}
+                onInboundRingCountChange={onInboundRingCountChange}
+                onInboundQueueChange={onInboundQueueChange}
+                onInboundScriptChange={onInboundScriptChange}
+                onNumberRemoval={onNumberRemoval}
+                onApplyPreset={onApplyPreset}
                 presetOrder={presetOrderForGoal(onboarding.selectedGoal)}
                 isBusy={isRoutingBusy}
               />

--- a/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
@@ -11,6 +11,10 @@ import {
   type CallerIdValidationRequest,
 } from "@/components/phone-numbers/CallerIdVerificationDialog";
 import { CallerIdVerificationForm } from "@/components/phone-numbers/CallerIdVerificationForm";
+import {
+  isServiceAddressComplete,
+  ServiceAddressGate,
+} from "@/components/phone-numbers/ServiceAddressGate";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Section, SectionHeader } from "@/components/shared/Section";
 import {
@@ -210,6 +214,10 @@ export function OnboardingFirstNumberStep({
 
   const smsGoal = goalNeedsSmsCompliance(onboarding.selectedGoal);
   const callerIdNumbers = numbers.filter((number) => number?.type === "caller_id");
+  const hasServiceAddress = isServiceAddressComplete(
+    onboarding.emergencyVoice.address,
+  );
+  const firstNumberReturnTo = `/workspaces/${workspaceId}/onboarding?step=first_number`;
 
   if (!messagingReady) {
     return (
@@ -245,6 +253,12 @@ export function OnboardingFirstNumberStep({
           description="Rent a number for inbound and outbound traffic, or verify a number you already own for outbound calling and texting."
         />
         <div className="space-y-6">
+          <ServiceAddressGate
+            workspaceId={workspaceId}
+            onboarding={onboarding}
+            isReadOnly={isReadOnly}
+            returnTo={firstNumberReturnTo}
+          />
           {smsGoal ? (
             <TooltipProvider>
               <div className="rounded-md bg-muted/40 p-3 text-sm text-muted-foreground">
@@ -281,8 +295,8 @@ export function OnboardingFirstNumberStep({
             </Alert>
           ) : null}
 
-          <div className="grid gap-6 lg:grid-cols-2">
-            <fieldset className="space-y-4 rounded-md bg-muted/40 p-3">
+          <div className="grid min-w-0 grid-cols-1 gap-6 xl:grid-cols-2">
+            <fieldset className="min-w-0 space-y-4 overflow-hidden rounded-md bg-muted/40 p-3">
               <legend className="text-sm font-medium">Rent a Canadian number</legend>
               <p className="text-sm text-muted-foreground">
                 Best for inbound SMS, inbound calls, and full two-way messaging.
@@ -292,6 +306,12 @@ export function OnboardingFirstNumberStep({
                   Only workspace owners and admins can rent numbers. Ask an admin to complete this
                   step.
                 </p>
+              ) : !hasServiceAddress ? (
+                <Alert>
+                  <AlertDescription>
+                    Save a service address above before searching for numbers to rent.
+                  </AlertDescription>
+                </Alert>
               ) : (
                 <NumberPurchase
                   fetcher={purchaseFetcher}
@@ -303,7 +323,7 @@ export function OnboardingFirstNumberStep({
               )}
             </fieldset>
 
-            <fieldset className="space-y-4 rounded-md bg-muted/40 p-3">
+            <fieldset className="min-w-0 space-y-4 overflow-hidden rounded-md bg-muted/40 p-3">
               <legend className="text-sm font-medium">Verify your own number</legend>
               <p className="text-sm text-muted-foreground">
                 Outbound SMS and calls only. Rent a number for inbound traffic.
@@ -321,12 +341,12 @@ export function OnboardingFirstNumberStep({
                     return (
                       <li
                         key={number.id ?? number.phone_number}
-                        className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
+                        className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
                       >
-                        <span className="font-mono">
+                        <span className="truncate font-mono">
                           {number.phone_number ?? "Unknown number"}
                         </span>
-                        <span className="text-xs text-muted-foreground">
+                        <span className="shrink-0 text-xs text-muted-foreground">
                           {isVerifiedCallerIdNumber(number)
                             ? "Verified"
                             : pendingStatus

--- a/app/routes/workspaces+/$id/settings/numbers.route.tsx
+++ b/app/routes/workspaces+/$id/settings/numbers.route.tsx
@@ -7,7 +7,11 @@ import { Link, useActionData, useFetcher, useLoaderData, useOutletContext } from
 import { useRef, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
-import { useActionFeedback, useFetcherOnIdle } from "@/hooks/utils";
+import {
+  useActionFeedback,
+  useFetcherOnIdle,
+  useSearchParamFlash,
+} from "@/hooks/utils";
 import { Section, SectionHeader } from "@/components/shared/Section";
 import { Button } from "@/components/ui/button";
 import { PageShell } from "@/components/ui/page-shell";
@@ -164,6 +168,21 @@ const WorkspaceSettings = () => {
     getSuccess: (data) => Boolean(data?.validationRequest),
     onSuccess: () => setDialog(true),
     successMessage: undefined,
+  });
+
+  useSearchParamFlash({
+    saved: (value) => {
+      if (value === "service_address") {
+        toast.success(
+          "Service address saved. Validate it before renting a voice-capable number.",
+        );
+      } else if (value === "emergency_voice") {
+        toast.success("Service address validated.");
+      }
+    },
+    warning: (value) => {
+      toast.warning(value);
+    },
   });
 
   const handleIncomingActivityChange = (numberId: number, value: string) => {

--- a/app/routes/workspaces+/$id/settings/numbers.route.tsx
+++ b/app/routes/workspaces+/$id/settings/numbers.route.tsx
@@ -12,6 +12,7 @@ import {
   useFetcherOnIdle,
   useSearchParamFlash,
 } from "@/hooks/utils";
+import { useWorkspaceNumberSettingsMutations } from "@/hooks/phone";
 import { Section, SectionHeader } from "@/components/shared/Section";
 import { Button } from "@/components/ui/button";
 import { PageShell } from "@/components/ui/page-shell";
@@ -28,7 +29,6 @@ import {
 import { useWorkspaceRealtime } from "@/hooks/realtime/useWorkspaceRealtime";
 import {
   NumberSummaryList,
-  type RoutingPresetSubmission,
 } from "@/components/phone-numbers/NumberSummaryList";
 import { NumberCallerId } from "@/components/phone-numbers/NumberCallerId";
 import { NumberPurchase } from "@/components/phone-numbers/NumberPurchase";
@@ -68,15 +68,6 @@ type CallerIDResponse = {
   error?: string;
 };
 
-interface FormData {
-  formName: string;
-  numberId?: string;
-  incomingActivity?: string;
-  incomingVoiceMessage?: string;
-  callerId?: string;
-  [key: string]: unknown;
-}
-
 type LoaderData = {
   phoneNumbers: WorkspaceNumbers;
   workspaceId: string;
@@ -110,7 +101,19 @@ const WorkspaceSettings = () => {
     !!actionData?.validationRequest,
   );
   const fetcher = useFetcher<NumbersSearchFetcherData>();
-  const updateFetcher = useFetcher();
+  const {
+    fetcher: updateFetcher,
+    isBusy,
+    onIncomingActivityChange,
+    onIncomingVoiceMessageChange,
+    onCallerIdChange,
+    onHandsetChange,
+    onInboundRingCountChange,
+    onInboundQueueChange,
+    onInboundScriptChange,
+    onApplyPreset,
+    onNumberRemoval,
+  } = useWorkspaceNumberSettingsMutations(workspaceId);
   const [numberPendingRemoval, setNumberPendingRemoval] = useState<
     number | null
   >(null);
@@ -185,100 +188,13 @@ const WorkspaceSettings = () => {
     },
   });
 
-  const handleIncomingActivityChange = (numberId: number, value: string) => {
-    updateFetcher.submit(
-      {
-        formName: "update-incoming-activity",
-        numberId: String(numberId),
-        incomingActivity: value,
-      },
-      { method: "POST" },
-    );
-  };
-
-  const handleIncomingVoiceMessageChange = (
-    numberId: number,
-    value: string,
-  ) => {
-    updateFetcher.submit(
-      {
-        formName: "update-incoming-voice-message",
-        numberId: String(numberId),
-        incomingVoiceMessage: value,
-      },
-      { method: "POST" },
-    );
-  };
-
-  const handleCallerIdChange = (numberId: number, value: string) => {
-    updateFetcher.submit(
-      {
-        formName: "update-caller-id",
-        numberId: String(numberId),
-        friendly_name: value,
-      },
-      { method: "POST" },
-    );
-  };
-
-  const handleHandsetChange = (numberId: number, enabled: boolean) => {
-    updateFetcher.submit(
-      {
-        formName: "update-handset",
-        numberId: String(numberId),
-        handsetEnabled: String(enabled),
-      },
-      { method: "POST" },
-    );
-  };
-
-  const handleInboundRingCountChange = (numberId: number, value: string) => {
-    updateFetcher.submit(
-      {
-        formName: "update-inbound-ring-count",
-        numberId: String(numberId),
-        inboundRingCount: value,
-      },
-      { method: "POST" },
-    );
-  };
-
-  const handleInboundQueueChange = (numberId: number, queueId: string) => {
-    updateFetcher.submit(
-      {
-        formName: "update-inbound-queue",
-        numberId: String(numberId),
-        inboundQueueId: queueId,
-      },
-      { method: "POST" },
-    );
-  };
-
-  const handleInboundScriptChange = (numberId: number, scriptId: string) => {
-    updateFetcher.submit(
-      {
-        formName: "update-inbound-script",
-        numberId: String(numberId),
-        inboundScriptId: scriptId,
-      },
-      { method: "POST" },
-    );
-  };
-
   const handleNumberRemoval = (numberId: number) => {
     setNumberPendingRemoval(numberId);
   };
 
-  const handleApplyPreset = (submission: RoutingPresetSubmission) => {
-    updateFetcher.submit(submission, { method: "POST" });
-  };
-
   const confirmNumberRemoval = () => {
     if (numberPendingRemoval == null) return;
-    updateFetcher.submit(
-      { formName: "remove-number", numberId: String(numberPendingRemoval) },
-      { method: "POST" },
-    );
+    onNumberRemoval(numberPendingRemoval);
     setNumberPendingRemoval(null);
   };
 
@@ -314,7 +230,7 @@ const WorkspaceSettings = () => {
             <Button
               variant="destructive"
               onClick={confirmNumberRemoval}
-              disabled={updateFetcher.state !== "idle"}
+              disabled={isBusy}
             >
               Release number
             </Button>
@@ -327,7 +243,7 @@ const WorkspaceSettings = () => {
         actions={
           <Button
             asChild
-            disabled={updateFetcher.state !== "idle"}
+            disabled={isBusy}
             variant="outline"
             size="sm"
           >
@@ -352,16 +268,16 @@ const WorkspaceSettings = () => {
               mediaNames={mediaNames}
               queues={queues}
               scripts={scripts}
-              onIncomingActivityChange={handleIncomingActivityChange}
-              onIncomingVoiceMessageChange={handleIncomingVoiceMessageChange}
-              onCallerIdChange={handleCallerIdChange}
-              onHandsetChange={handleHandsetChange}
-              onInboundRingCountChange={handleInboundRingCountChange}
-              onInboundQueueChange={handleInboundQueueChange}
-              onInboundScriptChange={handleInboundScriptChange}
+              onIncomingActivityChange={onIncomingActivityChange}
+              onIncomingVoiceMessageChange={onIncomingVoiceMessageChange}
+              onCallerIdChange={onCallerIdChange}
+              onHandsetChange={onHandsetChange}
+              onInboundRingCountChange={onInboundRingCountChange}
+              onInboundQueueChange={onInboundQueueChange}
+              onInboundScriptChange={onInboundScriptChange}
               onNumberRemoval={handleNumberRemoval}
-              onApplyPreset={handleApplyPreset}
-              isBusy={updateFetcher.state !== "idle"}
+              onApplyPreset={onApplyPreset}
+              isBusy={isBusy}
             />
           </Section>
           <div className="min-w-0 space-y-6">

--- a/app/routes/workspaces+/$id/settings/numbers.route.tsx
+++ b/app/routes/workspaces+/$id/settings/numbers.route.tsx
@@ -12,7 +12,11 @@ import {
   useFetcherOnIdle,
   useSearchParamFlash,
 } from "@/hooks/utils";
-import { useWorkspaceNumberSettingsMutations } from "@/hooks/phone";
+import {
+  flashSearchParamWarning,
+  flashServiceAddressSavedParam,
+  useWorkspaceNumberSettingsMutations,
+} from "@/hooks/phone";
 import { Section, SectionHeader } from "@/components/shared/Section";
 import { Button } from "@/components/ui/button";
 import { PageShell } from "@/components/ui/page-shell";
@@ -174,18 +178,8 @@ const WorkspaceSettings = () => {
   });
 
   useSearchParamFlash({
-    saved: (value) => {
-      if (value === "service_address") {
-        toast.success(
-          "Service address saved. Validate it before renting a voice-capable number.",
-        );
-      } else if (value === "emergency_voice") {
-        toast.success("Service address validated.");
-      }
-    },
-    warning: (value) => {
-      toast.warning(value);
-    },
+    saved: flashServiceAddressSavedParam,
+    warning: flashSearchParamWarning,
   });
 
   const handleNumberRemoval = (numberId: number) => {

--- a/app/routes/workspaces+/index.action.server.ts
+++ b/app/routes/workspaces+/index.action.server.ts
@@ -1,4 +1,4 @@
-import { createNewWorkspace } from "@/lib/database/workspace.server";
+import { createNewWorkspace } from "@/lib/database/workspace-provisioning.server";
 import { logger } from "@/lib/logger.server";
 import { data as routeData, redirect } from "react-router";
 import { getSession } from "@/lib/auth.server";

--- a/test/db-workspace.server.test.ts
+++ b/test/db-workspace.server.test.ts
@@ -367,7 +367,7 @@ describe("app/lib/database/workspace.server.ts", () => {
   test("createNewWorkspace: happy path and failure cases", async () => {
     const { logger } = await import("../app/lib/logger.server");
     const stripe = await import("../app/lib/database/stripe.server");
-    const mod = await import("../app/lib/database/workspace.server");
+    const mod = await import("../app/lib/database/workspace-provisioning.server");
 
     rpcMocks.rpcCreateNewWorkspace.mockResolvedValue("w_new");
 

--- a/test/onboarding-business-profile-validation.test.ts
+++ b/test/onboarding-business-profile-validation.test.ts
@@ -74,6 +74,18 @@ vi.mock("@/lib/caller-id-verification.server", () => ({
   startWorkspaceCallerIdVerification: vi.fn(),
 }));
 
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: () => ({
+    audience: { count: vi.fn().mockResolvedValue(0) },
+    campaign: { count: vi.fn().mockResolvedValue(0) },
+    script: { count: vi.fn().mockResolvedValue(0) },
+  }),
+}));
+
+vi.mock("@/lib/database/workspace-twilio-portal-snapshot.server", () => ({
+  getWorkspaceRecentOutboundMessageCount: vi.fn().mockResolvedValue(0),
+}));
+
 import {
   mapOnboardingHandlerResult,
   runOnboardingAction,

--- a/test/onboarding-review-emergency-voice-return-to.test.ts
+++ b/test/onboarding-review-emergency-voice-return-to.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * Validate-address from Numbers settings posts to the onboarding action.
+ * Without a returnTo redirect, React Router leaves the user on the wizard.
+ */
+
+const mocks = vi.hoisted(() => ({
+  getUserRole: vi.fn(),
+  requireWorkspaceAccess: vi.fn(),
+  getWorkspacePhoneNumbers: vi.fn(),
+  getWorkspaceMessagingOnboardingState: vi.fn(),
+  persistWorkspaceOnboardingState: vi.fn(),
+  getWorkspaceCredits: vi.fn(),
+  reviewWorkspaceEmergencyVoice: vi.fn(),
+}));
+
+vi.mock("@/lib/database/workspace.server", () => ({
+  getUserRole: (...args: unknown[]) => mocks.getUserRole(...args),
+  requireWorkspaceAccess: (...args: unknown[]) => mocks.requireWorkspaceAccess(...args),
+  getWorkspacePhoneNumbers: (...args: unknown[]) => mocks.getWorkspacePhoneNumbers(...args),
+}));
+
+vi.mock("@/lib/messaging-onboarding.server", () => ({
+  getWorkspaceMessagingOnboardingState: (...args: unknown[]) =>
+    mocks.getWorkspaceMessagingOnboardingState(...args),
+  applyOnboardingStepsWithWorkspaceNumbers: (state: unknown) => state,
+  applyWorkspaceOnboardingChannelPolicy: (state: unknown) => state,
+  deriveWorkspaceMessagingReadiness: () => ({ ready: false, blockingIssues: [] }),
+  isWizardOnboardingStepId: (value: string) =>
+    [
+      "business_identity",
+      "path_selection",
+      "audience",
+      "first_number",
+      "script",
+      "campaign_info",
+      "credits",
+      "launch_checks",
+    ].includes(value),
+}));
+
+vi.mock("@/lib/onboarding/onboarding-persist.server", () => ({
+  persistWorkspaceOnboardingState: (...args: unknown[]) =>
+    mocks.persistWorkspaceOnboardingState(...args),
+}));
+
+vi.mock("@/lib/onboarding/emergency-voice.server", () => ({
+  reviewWorkspaceEmergencyVoice: (...args: unknown[]) =>
+    mocks.reviewWorkspaceEmergencyVoice(...args),
+}));
+
+vi.mock("@/lib/worker/handlers.server", () => ({
+  enqueueWorkspaceComplianceJob: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace-members-db.server", () => ({
+  getWorkspaceCredits: (...args: unknown[]) => mocks.getWorkspaceCredits(...args),
+}));
+
+vi.mock("@/lib/platform-workspace.server", () => ({
+  updateWorkspaceName: vi.fn(),
+}));
+
+vi.mock("@/lib/rcs-onboarding.server", () => ({
+  TWILIO_RCS_PROVIDER: "twilio",
+  getWorkspaceRcsBlockingIssues: () => [],
+  hydrateWorkspaceRcsOnboardingState: (state: unknown) => state,
+  isRcsOnboardingEnabled: () => false,
+  stripDisabledRcsChannel: (channels: unknown) => channels,
+  updateWorkspaceRcsOnboarding: vi.fn(),
+}));
+
+vi.mock("@/lib/twilio-bootstrap.server", () => ({
+  ensureWorkspaceTwilioBootstrap: vi.fn(),
+}));
+
+vi.mock("@/lib/twilio-a2p.server", () => ({
+  buildA2pBlockingIssues: () => [],
+  provisionWorkspaceA2P: vi.fn(),
+}));
+
+vi.mock("@/lib/twilio-sender-pool.server", () => ({
+  attachWorkspaceRcsSenderToPool: vi.fn(),
+}));
+
+vi.mock("@/lib/caller-id-verification.server", () => ({
+  startWorkspaceCallerIdVerification: vi.fn(),
+}));
+
+import {
+  mapOnboardingHandlerResult,
+  runOnboardingAction,
+} from "../app/lib/platform-onboarding.server";
+
+const WORKSPACE_ID = "workspace-1";
+const USER_ID = "user-1";
+
+function onboardingState() {
+  return {
+    status: "collecting_business",
+    currentStep: "first_number",
+    operatingCountry: "CA",
+    selectedChannels: [] as string[],
+    selectedGoal: null,
+    businessProfile: {
+      legalBusinessName: "Acme",
+      businessType: "",
+      websiteUrl: "",
+      privacyPolicyUrl: "",
+      termsOfServiceUrl: "",
+      supportEmail: "",
+      supportPhone: "",
+      useCaseSummary: "",
+      optInWorkflow: "",
+      optInKeywords: "",
+      optOutKeywords: "",
+      helpKeywords: "",
+      sampleMessages: [] as string[],
+      doingBusinessAs: "",
+      businessRegistrationNumber: "",
+      ageGatedContent: false,
+      ein: "",
+      industry: "",
+      authorizedRepName: "",
+      authorizedRepEmail: "",
+      authorizedRepPhone: "",
+      authorizedRepTitle: "",
+    },
+    emergencyVoice: {
+      enabled: false,
+      status: "collecting_business",
+      emergencyEligiblePhoneNumbers: [] as string[],
+      ineligibleCallerIds: [] as string[],
+      lastReviewedAt: null,
+      address: {
+        customerName: "Acme",
+        street: "123 Main St",
+        city: "Toronto",
+        region: "ON",
+        postalCode: "M5V 2T6",
+        countryCode: "CA",
+        addressSid: null,
+        status: "pending_validation",
+        validationError: null,
+        lastValidatedAt: null,
+      },
+    },
+    messagingService: { serviceSid: "MG123", desiredSendMode: "messaging_service" },
+    a2p10dlc: { status: "not_started" },
+    rcs: { status: "not_started", regions: [] as string[] },
+    reviewState: { blockingIssues: [] as string[], lastError: null },
+    steps: [],
+  };
+}
+
+describe("review_emergency_voice returnTo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireWorkspaceAccess.mockResolvedValue(undefined);
+    mocks.getUserRole.mockResolvedValue({ role: "owner" });
+    mocks.getWorkspacePhoneNumbers.mockResolvedValue({ data: [] });
+    mocks.getWorkspaceMessagingOnboardingState.mockResolvedValue(onboardingState());
+    mocks.persistWorkspaceOnboardingState.mockResolvedValue(undefined);
+    mocks.getWorkspaceCredits.mockResolvedValue(0);
+    mocks.reviewWorkspaceEmergencyVoice.mockResolvedValue({
+      data: {
+        success:
+          "Emergency address validated. Add or refresh a rented voice number to finish voice readiness.",
+      },
+    });
+  });
+
+  test("redirects back to Numbers settings when returnTo is present", async () => {
+    const formData = new FormData();
+    formData.set("_action", "review_emergency_voice");
+    formData.set("returnTo", `/workspaces/${WORKSPACE_ID}/settings/numbers`);
+
+    const outcome = await runOnboardingAction(
+      USER_ID,
+      WORKSPACE_ID,
+      "review_emergency_voice",
+      formData,
+    );
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    const mapped = mapOnboardingHandlerResult(outcome.result, outcome.detail, "ui");
+    expect(mapped).toEqual({
+      kind: "ui_redirect_path",
+      path: `/workspaces/${WORKSPACE_ID}/settings/numbers`,
+      searchParams: { saved: "emergency_voice" },
+    });
+  });
+
+  test("returns a success payload when returnTo is absent", async () => {
+    const formData = new FormData();
+    formData.set("_action", "review_emergency_voice");
+
+    const outcome = await runOnboardingAction(
+      USER_ID,
+      WORKSPACE_ID,
+      "review_emergency_voice",
+      formData,
+    );
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.kind).toBe("payload");
+    if (outcome.result.kind !== "payload") return;
+    expect(outcome.result.data.success).toMatch(/validated/i);
+  });
+
+  test("redirects validation errors back to returnTo instead of the wizard", async () => {
+    mocks.reviewWorkspaceEmergencyVoice.mockResolvedValue({
+      data: { error: "Save a complete emergency service address before running voice review." },
+      init: { status: 400 },
+    });
+
+    const formData = new FormData();
+    formData.set("_action", "review_emergency_voice");
+    formData.set("returnTo", `/workspaces/${WORKSPACE_ID}/settings/numbers`);
+
+    const outcome = await runOnboardingAction(
+      USER_ID,
+      WORKSPACE_ID,
+      "review_emergency_voice",
+      formData,
+    );
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    const mapped = mapOnboardingHandlerResult(outcome.result, outcome.detail, "ui");
+    expect(mapped).toEqual({
+      kind: "ui_redirect_path",
+      path: `/workspaces/${WORKSPACE_ID}/settings/numbers`,
+      searchParams: {
+        warning:
+          "Save a complete emergency service address before running voice review.",
+      },
+    });
+  });
+});

--- a/test/onboarding-review-emergency-voice-return-to.test.ts
+++ b/test/onboarding-review-emergency-voice-return-to.test.ts
@@ -88,6 +88,18 @@ vi.mock("@/lib/caller-id-verification.server", () => ({
   startWorkspaceCallerIdVerification: vi.fn(),
 }));
 
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: () => ({
+    audience: { count: vi.fn().mockResolvedValue(0) },
+    campaign: { count: vi.fn().mockResolvedValue(0) },
+    script: { count: vi.fn().mockResolvedValue(0) },
+  }),
+}));
+
+vi.mock("@/lib/database/workspace-twilio-portal-snapshot.server", () => ({
+  getWorkspaceRecentOutboundMessageCount: vi.fn().mockResolvedValue(0),
+}));
+
 import {
   mapOnboardingHandlerResult,
   runOnboardingAction,
@@ -164,10 +176,9 @@ describe("review_emergency_voice returnTo", () => {
     mocks.persistWorkspaceOnboardingState.mockResolvedValue(undefined);
     mocks.getWorkspaceCredits.mockResolvedValue(0);
     mocks.reviewWorkspaceEmergencyVoice.mockResolvedValue({
-      data: {
-        success:
-          "Emergency address validated. Add or refresh a rented voice number to finish voice readiness.",
-      },
+      ok: true,
+      success:
+        "Emergency address validated. Add or refresh a rented voice number to finish voice readiness.",
     });
   });
 
@@ -214,8 +225,9 @@ describe("review_emergency_voice returnTo", () => {
 
   test("redirects validation errors back to returnTo instead of the wizard", async () => {
     mocks.reviewWorkspaceEmergencyVoice.mockResolvedValue({
-      data: { error: "Save a complete emergency service address before running voice review." },
-      init: { status: 400 },
+      ok: false,
+      error: "Save a complete emergency service address before running voice review.",
+      status: 400,
     });
 
     const formData = new FormData();

--- a/test/onboarding-save-channels-bootstrap-failure.test.ts
+++ b/test/onboarding-save-channels-bootstrap-failure.test.ts
@@ -84,6 +84,18 @@ vi.mock("@/lib/caller-id-verification.server", () => ({
   startWorkspaceCallerIdVerification: vi.fn(),
 }));
 
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: () => ({
+    audience: { count: vi.fn().mockResolvedValue(0) },
+    campaign: { count: vi.fn().mockResolvedValue(0) },
+    script: { count: vi.fn().mockResolvedValue(0) },
+  }),
+}));
+
+vi.mock("@/lib/database/workspace-twilio-portal-snapshot.server", () => ({
+  getWorkspaceRecentOutboundMessageCount: vi.fn().mockResolvedValue(0),
+}));
+
 import {
   mapOnboardingHandlerResult,
   runOnboardingAction,

--- a/test/onboarding-save-workspace-name.test.ts
+++ b/test/onboarding-save-workspace-name.test.ts
@@ -88,6 +88,18 @@ vi.mock("@/lib/caller-id-verification.server", () => ({
   startWorkspaceCallerIdVerification: vi.fn(),
 }));
 
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: () => ({
+    audience: { count: vi.fn().mockResolvedValue(0) },
+    campaign: { count: vi.fn().mockResolvedValue(0) },
+    script: { count: vi.fn().mockResolvedValue(0) },
+  }),
+}));
+
+vi.mock("@/lib/database/workspace-twilio-portal-snapshot.server", () => ({
+  getWorkspaceRecentOutboundMessageCount: vi.fn().mockResolvedValue(0),
+}));
+
 import {
   mapOnboardingHandlerResult,
   runOnboardingAction,

--- a/test/platform-auth.test.ts
+++ b/test/platform-auth.test.ts
@@ -36,8 +36,11 @@ vi.mock("@/lib/workspace-members-db.server", () => ({
 
 vi.mock("@/lib/database/workspace.server", () => ({
   acceptWorkspaceInvitations: vi.fn(async () => ({ errors: [] })),
-  createNewWorkspace: vi.fn(async () => ({ data: "w1", error: null })),
   getInvitesByUserId: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/database/workspace-provisioning.server", () => ({
+  createNewWorkspace: vi.fn(async () => ({ data: "w1", error: null })),
 }));
 
 describe("platform-auth.server.ts", () => {

--- a/test/seed-workspace-sample-data.server.test.ts
+++ b/test/seed-workspace-sample-data.server.test.ts
@@ -91,7 +91,7 @@ describe("app/lib/seed/seed-workspace-sample-data.server.ts", () => {
   });
 });
 
-describe("app/lib/database/workspace.server.ts createNewWorkspace + sample data seeding", () => {
+describe("app/lib/database/workspace-provisioning.server.ts createNewWorkspace + sample data seeding", () => {
   // createNewWorkspace rejects non-uuid auth user ids (legacy nanoid rows cannot be
   // mirrored into public.user / cast for the create_new_workspace RPC), so this
   // fixture must be a real uuid like Better Auth's generateId=crypto.randomUUID().
@@ -191,7 +191,7 @@ describe("app/lib/database/workspace.server.ts createNewWorkspace + sample data 
       new Error("insert failed"),
     );
 
-    const mod = await import("../app/lib/database/workspace.server");
+    const mod = await import("../app/lib/database/workspace-provisioning.server");
     const result = await mod.createNewWorkspace({
       workspaceName: "W",
       user_id: AUTH_USER_ID,
@@ -212,7 +212,7 @@ describe("app/lib/database/workspace.server.ts createNewWorkspace + sample data 
       campaign: { id: 2 },
     });
 
-    const mod = await import("../app/lib/database/workspace.server");
+    const mod = await import("../app/lib/database/workspace-provisioning.server");
     const result = await mod.createNewWorkspace({
       workspaceName: "W",
       user_id: AUTH_USER_ID,

--- a/test/workspaces-index.route.test.ts
+++ b/test/workspaces-index.route.test.ts
@@ -13,7 +13,7 @@ vi.mock("@/lib/auth.server", () => ({
   verifyAuth: mocks.verifyAuth,
 }));
 
-vi.mock("@/lib/database/workspace.server", () => ({
+vi.mock("@/lib/database/workspace-provisioning.server", () => ({
   createNewWorkspace: mocks.createNewWorkspace,
 }));
 


### PR DESCRIPTION
Closes #1082, closes #1074, closes #1075, closes #1079. Also hardens #1081 layout.

## Summary
Unblocks Sai’s AFK onboarding/numbers bugs and cleans up the shared phone-settings + workspace-provisioning paths those flows depend on:

1. **Onboarding number rental dead-end** — Phone number wizard step renders `ServiceAddressGate` inline and gates rental search until an address is saved.
2. **Validate address dumps into wizard** — Validate form includes `returnTo`; `review_emergency_voice` redirects back (success or warning) instead of leaving the user on onboarding.
3. **CSV header invisible in light mode** — Audience detail page no longer forces `text-white`.
4. **Rent/verify overlap** — Stack until `xl`, with `min-w-0` / overflow guards on the two panels.
5. **Shared number settings mutations** — New `useWorkspaceNumberSettingsMutations` hook consolidates incoming activity / voice message / routing submissions for onboarding and Settings → Numbers.
6. **Workspace provisioning extract** — Moves create/provision helpers into `workspace-provisioning.server.ts` so onboarding bootstrap stays focused and testable.

## Test plan
- [x] `vitest` `test/onboarding-review-emergency-voice-return-to.test.ts` (returnTo success + error redirect)
- [x] Related onboarding / platform-auth / workspace tests updated for provisioning import path
- [ ] Manual: new workspace → onboarding Phone number step → save address → rent number
- [ ] Manual: Settings → Numbers → Validate address stays on Numbers and shows status/toast
- [ ] Manual: Settings → Numbers → change incoming activity / voice message / routing via shared mutations
- [ ] Manual: Call lists → edit → Upload → CSV Header column readable in light mode