### PR TITLE
fix: audience name display and QC-aligned CSV upload

### DIFF
--- a/app/components/audience/AudienceForm.tsx
+++ b/app/components/audience/AudienceForm.tsx
@@ -1,43 +1,28 @@
 import { Form } from "react-router";
 import { Button } from "@/components/ui/button";
-import { FormEvent, useEffect, useState } from "react";
-import type { Database } from "@/lib/db-types";
+import { FormEvent } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
 interface AudienceFormProps {
-  audienceInfo: Database["public"]["Tables"]["audience"]["Row"] | null;
   handleSaveAudience: (e: FormEvent<HTMLFormElement>) => Promise<void>;
   audience_id: string | undefined;
   workspace_id: string | undefined;
-  /** Keeps the parent page title in sync while the user edits (#1080). */
-  onNameChange?: (name: string) => void;
+  /** Controlled name owned by the page (keeps H1 in sync). */
+  name: string;
+  onNameChange: (name: string) => void;
 }
 
 const AudienceForm = ({
-  audienceInfo,
   handleSaveAudience,
   audience_id,
   workspace_id,
+  name,
   onNameChange,
 }: AudienceFormProps) => {
-  const [, setError] = useState<string | null>(null);
-  const [name, setName] = useState<string>(audienceInfo?.name || "");
-
-  /**
-   * @effect Reset local name when the loader / save response replaces audienceInfo.
-   * @effect-deps audienceInfo?.name from parent
-   * @effect-side-effects setName
-   * @effect-why-not-loader Controlled form state must rehydrate after PATCH / revalidate.
-   */
-  useEffect(() => {
-    setName(audienceInfo?.name || "");
-  }, [audienceInfo?.name]);
-
   const handleSave = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     handleSaveAudience(e);
-    setError(null);
   };
 
   return (
@@ -54,14 +39,7 @@ const AudienceForm = ({
           name="name"
           placeholder="Audience Name"
           value={name}
-          onChange={(e) => {
-            const value = e.target.value;
-            if (value.length > 0) {
-              setError(null);
-            }
-            setName(value);
-            onNameChange?.(value);
-          }}
+          onChange={(e) => onNameChange(e.target.value)}
           className="text-foreground"
         />
         <Button type="submit" disabled={name.trim().length === 0}>

--- a/app/components/audience/AudienceForm.tsx
+++ b/app/components/audience/AudienceForm.tsx
@@ -1,36 +1,55 @@
 import { Form } from "react-router";
 import { Button } from "@/components/ui/button";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import type { Database } from "@/lib/db-types";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
 interface AudienceFormProps {
   audienceInfo: Database["public"]["Tables"]["audience"]["Row"] | null;
   handleSaveAudience: (e: FormEvent<HTMLFormElement>) => Promise<void>;
   audience_id: string | undefined;
   workspace_id: string | undefined;
+  /** Keeps the parent page title in sync while the user edits (#1080). */
+  onNameChange?: (name: string) => void;
 }
 
 const AudienceForm = ({
   audienceInfo,
   handleSaveAudience,
   audience_id,
-  workspace_id
+  workspace_id,
+  onNameChange,
 }: AudienceFormProps) => {
   const [, setError] = useState<string | null>(null);
   const [name, setName] = useState<string>(audienceInfo?.name || "");
+
+  /**
+   * @effect Reset local name when the loader / save response replaces audienceInfo.
+   * @effect-deps audienceInfo?.name from parent
+   * @effect-side-effects setName
+   * @effect-why-not-loader Controlled form state must rehydrate after PATCH / revalidate.
+   */
+  useEffect(() => {
+    setName(audienceInfo?.name || "");
+  }, [audienceInfo?.name]);
+
   const handleSave = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     handleSaveAudience(e);
     setError(null);
   };
+
   return (
     <Form action="/api/audiences" method="PATCH" onSubmit={handleSave} className="py-4">
       <input name="id" hidden value={audience_id} readOnly />
       <input name="workspace" hidden value={workspace_id} readOnly />
-      <Label htmlFor="name" className="text-muted-foreground">Audience Name</Label>
+      <Label htmlFor="name" className="text-foreground">
+        Audience Name
+      </Label>
       <div className="flex gap-2">
         <Input
+          id="name"
           type="text"
           name="name"
           placeholder="Audience Name"
@@ -41,13 +60,16 @@ const AudienceForm = ({
               setError(null);
             }
             setName(value);
+            onNameChange?.(value);
           }}
-          className="text-muted-foreground"
+          className="text-foreground"
         />
-        <Button type="submit" disabled={name.length === 0}>Save</Button>
+        <Button type="submit" disabled={name.trim().length === 0}>
+          Save
+        </Button>
       </div>
     </Form>
-  )
+  );
 };
 
 export { AudienceForm };

--- a/app/components/audience/AudienceTable.tsx
+++ b/app/components/audience/AudienceTable.tsx
@@ -48,6 +48,7 @@ type AudienceTableProps = {
     sortKey: string;
     sortDirection: 'asc' | 'desc';
   };
+  onAudienceNameChange?: (name: string) => void;
 };
 
 export function AudienceTable({
@@ -56,7 +57,8 @@ export function AudienceTable({
   selected_id: audience_id,
   audience: initialAudience,
   pagination,
-  sorting
+  sorting,
+  onAudienceNameChange,
 }: AudienceTableProps) {
   // Transform the contacts data to extract the nested contact info.
   // Memoized so this map only reruns when the loader actually hands us a new
@@ -136,6 +138,10 @@ export function AudienceTable({
 
     if (response.ok) {
       setAudienceInfo(result);
+      if (result && typeof result === "object" && "name" in result) {
+        const savedName = typeof result.name === "string" ? result.name : "";
+        onAudienceNameChange?.(savedName);
+      }
     } else {
       logger.error("Failed to save audience", result);
     }
@@ -252,6 +258,7 @@ export function AudienceTable({
           handleSaveAudience={handleSaveAudience}
           audience_id={audience_id}
           workspace_id={workspace_id}
+          onNameChange={onAudienceNameChange}
         />
       </div>
       <div className="flex justify-between items-center mb-4">

--- a/app/components/audience/AudienceTable.tsx
+++ b/app/components/audience/AudienceTable.tsx
@@ -24,8 +24,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { Database } from "@/lib/db-types";
-import { Contact } from "@/lib/types";
+import type { ContactListRow } from "@/lib/contacts-loader.types";
 import {
   Select,
   SelectContent,
@@ -35,10 +34,9 @@ import {
 } from "@/components/ui/select";
 
 type AudienceTableProps = {
-  contacts: Array<{ contact: Database['public']['Tables']['contact']['Row'] }> | null;
+  contacts: Array<{ contact: ContactListRow }> | null;
   workspace_id: string | undefined;
   selected_id: string | undefined;
-  audience: Database['public']['Tables']['audience']['Row'] | null;
   pagination: {
     currentPage: number;
     pageSize: number;
@@ -48,17 +46,19 @@ type AudienceTableProps = {
     sortKey: string;
     sortDirection: 'asc' | 'desc';
   };
-  onAudienceNameChange?: (name: string) => void;
+  /** Controlled name owned by the page (H1 sync). */
+  name: string;
+  onNameChange: (name: string) => void;
 };
 
 export function AudienceTable({
   contacts: initialContacts,
   workspace_id,
   selected_id: audience_id,
-  audience: initialAudience,
   pagination,
   sorting,
-  onAudienceNameChange,
+  name,
+  onNameChange,
 }: AudienceTableProps) {
   // Transform the contacts data to extract the nested contact info.
   // Memoized so this map only reruns when the loader actually hands us a new
@@ -67,8 +67,7 @@ export function AudienceTable({
     () => initialContacts?.map(item => item.contact) || [],
     [initialContacts],
   );
-  const [contacts, setContacts] = useState<Contact[]>(transformedContacts);
-  const [audienceInfo, setAudienceInfo] = useState(initialAudience);
+  const [contacts, setContacts] = useState<ContactListRow[]>(transformedContacts);
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchTerm, setSearchTerm] = useState(searchParams.get("q") ?? "");
   const [selectedContacts, setSelectedContacts] = useState<string[]>([]);
@@ -88,12 +87,6 @@ export function AudienceTable({
     // `transformedContacts` is already recomputed for the new `initialContacts`
     // in this same render pass (useMemo above), so reuse it instead of re-mapping.
     setContacts(transformedContacts);
-  }
-
-  const [prevInitialAudience, setPrevInitialAudience] = useState(initialAudience);
-  if (prevInitialAudience !== initialAudience) {
-    setPrevInitialAudience(initialAudience);
-    setAudienceInfo(initialAudience);
   }
 
   const handlePageChange = (newPage: number) => {
@@ -136,13 +129,7 @@ export function AudienceTable({
     });
     const result = await response.json();
 
-    if (response.ok) {
-      setAudienceInfo(result);
-      if (result && typeof result === "object" && "name" in result) {
-        const savedName = typeof result.name === "string" ? result.name : "";
-        onAudienceNameChange?.(savedName);
-      }
-    } else {
+    if (!response.ok) {
       logger.error("Failed to save audience", result);
     }
   };
@@ -254,11 +241,11 @@ export function AudienceTable({
     <div className="w-full space-y-4">
       <div id="audience-settings" className="flex justify-between items-center">
         <AudienceForm
-          audienceInfo={audienceInfo}
           handleSaveAudience={handleSaveAudience}
           audience_id={audience_id}
           workspace_id={workspace_id}
-          onNameChange={onAudienceNameChange}
+          name={name}
+          onNameChange={onNameChange}
         />
       </div>
       <div className="flex justify-between items-center mb-4">

--- a/app/components/audience/AudienceUploader.tsx
+++ b/app/components/audience/AudienceUploader.tsx
@@ -334,7 +334,7 @@ export default function AudienceUploader({
         registerPollFailure();
       }
     },
-    statusPollingEnabled ? 2000 : null // Poll every 2 seconds when enabled
+    statusPollingEnabled ? 5000 : null // QC-style 5s poll fallback while processing (#1078)
   );
 
   const displayFileToUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/components/audience/AudienceUploader.tsx
+++ b/app/components/audience/AudienceUploader.tsx
@@ -18,6 +18,7 @@ import {
   suggestContactImportMapping,
   validateContactImportMapping,
 } from "../../../shared/contact-import-headers";
+import { AUDIENCE_UPLOAD_PROCESSING_POLL_MS } from "../../../shared/audience-upload";
 
 export const VALID_HEADERS = CONTACT_IMPORT_TARGETS.filter(
   (target) => target !== "name",
@@ -334,7 +335,7 @@ export default function AudienceUploader({
         registerPollFailure();
       }
     },
-    statusPollingEnabled ? 5000 : null // QC-style 5s poll fallback while processing (#1078)
+    statusPollingEnabled ? AUDIENCE_UPLOAD_PROCESSING_POLL_MS : null
   );
 
   const displayFileToUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/lib/audience-detail.server.ts
+++ b/app/lib/audience-detail.server.ts
@@ -1,0 +1,213 @@
+import { and, asc, count, desc, eq } from "drizzle-orm";
+import { buildContactSearchWhere } from "@/lib/contacts/search.server";
+import type { ContactListRow } from "@/lib/contacts-loader.types";
+import { logger } from "@/lib/logger.server";
+import { parsePagination, type PaginationMeta } from "@/lib/pagination.server";
+import {
+  audience as audienceTable,
+  audience_upload as audienceUploadTable,
+  contact as contactTable,
+  contact_audience as contactAudienceTable,
+} from "@/db/schema";
+import { db } from "@/server/db";
+import { createTenantDb } from "@/server/tenant-db";
+
+const AUDIENCE_CONTACT_SORT_KEYS = [
+  "id",
+  "firstname",
+  "surname",
+  "phone",
+  "email",
+  "created_at",
+] as const;
+
+type AudienceContactSortKey = (typeof AUDIENCE_CONTACT_SORT_KEYS)[number];
+
+function audienceContactSortColumn(sortKey: string) {
+  if (AUDIENCE_CONTACT_SORT_KEYS.includes(sortKey as AudienceContactSortKey)) {
+    return contactTable[sortKey as AudienceContactSortKey];
+  }
+  return contactTable.id;
+}
+
+type LatestUploadSummary = {
+  id: number;
+  status: string;
+  progress: number;
+  total_contacts: number;
+  processed_contacts: number;
+  error_message?: string | null;
+};
+
+async function loadAudienceContactsPage(args: {
+  workspaceId: string;
+  audienceIdNum: number;
+  searchQuery: string;
+  sortDirection: "asc" | "desc";
+  sortColumn: ReturnType<typeof audienceContactSortColumn>;
+  pageSize: number;
+  offset: number;
+}): Promise<
+  | { ok: true; contacts: Array<{ contact: ContactListRow }>; totalCount: number }
+  | { ok: false; error: string }
+> {
+  const audienceContactFilter = and(
+    eq(contactAudienceTable.audience_id, args.audienceIdNum),
+    eq(contactTable.workspace, args.workspaceId),
+    args.searchQuery ? buildContactSearchWhere(args.searchQuery) : undefined,
+  );
+
+  try {
+    // Select only columns the detail table needs — avoids SELECT * failing when
+    // the review/prod DB lags schema (extra contact columns in Drizzle).
+    const [contactRows, countRows] = await Promise.all([
+      db
+        .select({
+          id: contactTable.id,
+          firstname: contactTable.firstname,
+          surname: contactTable.surname,
+          phone: contactTable.phone,
+          email: contactTable.email,
+          address: contactTable.address,
+          city: contactTable.city,
+          other_data: contactTable.other_data,
+          created_at: contactTable.created_at,
+        })
+        .from(contactAudienceTable)
+        .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
+        .where(audienceContactFilter)
+        .orderBy(
+          args.sortDirection === "asc" ? asc(args.sortColumn) : desc(args.sortColumn),
+        )
+        .limit(args.pageSize)
+        .offset(args.offset),
+      db
+        .select({ value: count() })
+        .from(contactAudienceTable)
+        .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
+        .where(audienceContactFilter),
+    ]);
+
+    return {
+      ok: true,
+      contacts: contactRows.map((row) => ({ contact: row })),
+      totalCount: countRows[0]?.value ?? 0,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Failed to load contacts",
+    };
+  }
+}
+
+async function loadLatestAudienceUpload(
+  workspaceId: string,
+  audienceIdNum: number,
+): Promise<LatestUploadSummary | null> {
+  const tdb = createTenantDb(workspaceId);
+  try {
+    const upload = await tdb.audience_upload.findFirst({
+      where: eq(audienceUploadTable.audience_id, audienceIdNum),
+      orderBy: (row, { desc: descFn }) => [descFn(row.created_at)],
+    });
+    if (!upload) return null;
+    return {
+      id: upload.id,
+      status: upload.status ?? "unknown",
+      progress:
+        upload.processed_contacts && upload.total_contacts
+          ? Math.round((upload.processed_contacts / upload.total_contacts) * 100)
+          : 0,
+      total_contacts: upload.total_contacts ?? 0,
+      processed_contacts: upload.processed_contacts ?? 0,
+      error_message: upload.error_message,
+    };
+  } catch (error) {
+    logger.warn("getAudienceDetailApi latest upload lookup failed", {
+      workspaceId,
+      audienceId: audienceIdNum,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+export async function getAudienceDetailApi(
+  workspaceId: string,
+  audienceId: string,
+  searchParams: URLSearchParams,
+) {
+  const { page, pageSize, offset } = parsePagination(searchParams, {
+    defaultPageSize: 50,
+  });
+  const sortKey = searchParams.get("sort_key") || "id";
+  const sortDirection = searchParams.get("sort_direction") === "desc" ? "desc" : "asc";
+  const searchQuery = (searchParams.get("q") ?? "").trim().replaceAll(",", " ");
+  const audienceIdNum = Number(audienceId);
+  const sortColumn = audienceContactSortColumn(sortKey);
+  const tdb = createTenantDb(workspaceId);
+
+  let audience: typeof audienceTable.$inferSelect;
+  try {
+    const found = await tdb.audience.findFirst({
+      where: eq(audienceTable.id, audienceIdNum),
+    });
+    if (!found) {
+      return { ok: false as const, error: "Audience not found", status: 404 };
+    }
+    audience = found;
+  } catch (error) {
+    return {
+      ok: false as const,
+      error: error instanceof Error ? error.message : "Failed to load audience",
+      status: 500,
+    };
+  }
+
+  // Contacts / upload metadata are best-effort after the audience row loads.
+  // A contact join failure must not wipe the audience name (#1080).
+  const [contactsResult, latestUpload] = await Promise.all([
+    loadAudienceContactsPage({
+      workspaceId,
+      audienceIdNum,
+      searchQuery,
+      sortDirection,
+      sortColumn,
+      pageSize,
+      offset,
+    }),
+    loadLatestAudienceUpload(workspaceId, audienceIdNum),
+  ]);
+
+  let contacts: Array<{ contact: ContactListRow }> = [];
+  let totalCount = 0;
+  let contactsError: string | null = null;
+
+  if (contactsResult.ok) {
+    contacts = contactsResult.contacts;
+    totalCount = contactsResult.totalCount;
+  } else {
+    contactsError = contactsResult.error;
+    logger.error("getAudienceDetailApi contacts query failed", {
+      workspaceId,
+      audienceId,
+      error: contactsError,
+    });
+  }
+
+  return {
+    ok: true as const,
+    audience,
+    contacts,
+    pagination: {
+      page,
+      page_size: pageSize,
+      total_count: totalCount,
+    } satisfies PaginationMeta,
+    sorting: { sort_key: sortKey, sort_direction: sortDirection },
+    search_query: searchQuery || null,
+    latest_upload: latestUpload,
+    contacts_error: contactsError,
+  };
+}

--- a/app/lib/audience-upload-db.server.ts
+++ b/app/lib/audience-upload-db.server.ts
@@ -42,8 +42,9 @@ export async function createAudienceForUpload(
   name: string,
 ): Promise<AudienceRow | null> {
   const tdb = createTenantDb(workspaceId);
+  const trimmed = name.trim();
   const [row] = await tdb.audience.insert({
-    name,
+    name: trimmed.length > 0 ? trimmed : null,
     created_at: new Date().toISOString(),
     is_conditional: false,
     status: "pending",

--- a/app/lib/audience-upload-process.server.ts
+++ b/app/lib/audience-upload-process.server.ts
@@ -16,8 +16,8 @@ import { createTenantDb } from "@/server/tenant-db";
 import { parsePhoneNumber } from "@/lib/phone";
 import {
   AUDIENCE_UPLOAD_CHUNK_SIZE,
-  AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS,
   audienceUploadChunkDelayMs,
+  audienceUploadShouldWriteStatus,
 } from "../../shared/audience-upload";
 import {
   splitContactFullName,
@@ -231,7 +231,6 @@ export const processAudienceUpload = async (
 
     // Process contacts in chunks
     const CHUNK_SIZE = AUDIENCE_UPLOAD_CHUNK_SIZE;
-    const isMultiChunkUpload = parsedContacts.length > CHUNK_SIZE;
     let lastProgressAt = 0;
     let processedCount = 0;
     let importedCount = 0;
@@ -355,18 +354,28 @@ export const processAudienceUpload = async (
         );
       }
 
-      // Update progress
+      // Update progress — durable row every chunk; sidecar throttled (#1078).
       processedCount += chunk.length;
 
-      const isLastChunk = i + CHUNK_SIZE >= parsedContacts.length;
-      const shouldNotifyProgress =
-        isMultiChunkUpload &&
-        (isLastChunk ||
-          Date.now() - lastProgressAt >= AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS);
+      await tdb.audience_upload.update({
+        set: {
+          processed_contacts: processedCount,
+          status: "processing",
+        },
+        where: eq(audienceUploadTable.id, uploadId),
+      });
 
-      // Multi-chunk imports throttle mid-flight status writes; single-chunk
-      // uploads rely on finalization writes below (#1078).
-      if (shouldNotifyProgress) {
+      const isLastChunk = i + CHUNK_SIZE >= parsedContacts.length;
+      const now = Date.now();
+      if (
+        audienceUploadShouldWriteStatus({
+          total: parsedContacts.length,
+          chunkSize: CHUNK_SIZE,
+          isLastChunk,
+          lastProgressAt,
+          now,
+        })
+      ) {
         const progress = Math.round((processedCount / parsedContacts.length) * 100);
 
         await writeAudienceUploadStatus(workspaceId, uploadId, {
@@ -376,15 +385,7 @@ export const processAudienceUpload = async (
           skipped_invalid_contacts: skippedInvalidCount,
         });
 
-        await tdb.audience_upload.update({
-          set: {
-            processed_contacts: processedCount,
-            status: "processing",
-          },
-          where: eq(audienceUploadTable.id, uploadId),
-        });
-
-        lastProgressAt = Date.now();
+        lastProgressAt = now;
       }
 
       const chunkDelayMs = audienceUploadChunkDelayMs(parsedContacts.length);
@@ -408,6 +409,7 @@ export const processAudienceUpload = async (
     await tdb.audience_upload.update({
       set: {
         status: "completed",
+        processed_contacts: processedCount,
         processed_at: new Date().toISOString(),
       },
       where: eq(audienceUploadTable.id, uploadId),

--- a/app/lib/audience-upload-process.server.ts
+++ b/app/lib/audience-upload-process.server.ts
@@ -15,6 +15,11 @@ import { db } from "@/server/db";
 import { createTenantDb } from "@/server/tenant-db";
 import { parsePhoneNumber } from "@/lib/phone";
 import {
+  AUDIENCE_UPLOAD_CHUNK_SIZE,
+  AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS,
+  audienceUploadChunkDelayMs,
+} from "../../shared/audience-upload";
+import {
   splitContactFullName,
   validateContactImportMapping,
 } from "../../shared/contact-import-headers";
@@ -225,7 +230,9 @@ export const processAudienceUpload = async (
     });
 
     // Process contacts in chunks
-    const CHUNK_SIZE = 100;
+    const CHUNK_SIZE = AUDIENCE_UPLOAD_CHUNK_SIZE;
+    const isMultiChunkUpload = parsedContacts.length > CHUNK_SIZE;
+    let lastProgressAt = 0;
     let processedCount = 0;
     let importedCount = 0;
     let skippedInvalidCount = 0;
@@ -350,26 +357,40 @@ export const processAudienceUpload = async (
 
       // Update progress
       processedCount += chunk.length;
-      const progress = Math.round((processedCount / parsedContacts.length) * 100);
 
-      await writeAudienceUploadStatus(workspaceId, uploadId, {
-        ...statusData,
-        progress,
-        stage: `Processing contacts (${processedCount}/${parsedContacts.length}; ${skippedInvalidCount} skipped)`,
-        skipped_invalid_contacts: skippedInvalidCount,
-      });
+      const isLastChunk = i + CHUNK_SIZE >= parsedContacts.length;
+      const shouldNotifyProgress =
+        isMultiChunkUpload &&
+        (isLastChunk ||
+          Date.now() - lastProgressAt >= AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS);
 
-      // Update upload record
-      await tdb.audience_upload.update({
-        set: {
-          processed_contacts: processedCount,
-          status: "processing",
-        },
-        where: eq(audienceUploadTable.id, uploadId),
-      });
+      // Multi-chunk imports throttle mid-flight status writes; single-chunk
+      // uploads rely on finalization writes below (#1078).
+      if (shouldNotifyProgress) {
+        const progress = Math.round((processedCount / parsedContacts.length) * 100);
 
-      // Small delay to prevent overwhelming the database
-      await new Promise(resolve => setTimeout(resolve, 100));
+        await writeAudienceUploadStatus(workspaceId, uploadId, {
+          ...statusData,
+          progress,
+          stage: `Processing contacts (${processedCount}/${parsedContacts.length}; ${skippedInvalidCount} skipped)`,
+          skipped_invalid_contacts: skippedInvalidCount,
+        });
+
+        await tdb.audience_upload.update({
+          set: {
+            processed_contacts: processedCount,
+            status: "processing",
+          },
+          where: eq(audienceUploadTable.id, uploadId),
+        });
+
+        lastProgressAt = Date.now();
+      }
+
+      const chunkDelayMs = audienceUploadChunkDelayMs(parsedContacts.length);
+      if (chunkDelayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, chunkDelayMs));
+      }
     }
 
     // Update audience status. audience_status enum is

--- a/app/lib/platform-data.server.ts
+++ b/app/lib/platform-data.server.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, inArray } from "drizzle-orm";
+import { and, count, desc, eq, inArray } from "drizzle-orm";
 import {
   requireJsonAuth,
   verifyApiKeyOrSession,
@@ -71,23 +71,7 @@ import { db } from "@/server/db";
 import { createTenantDb } from "@/server/tenant-db";
 import { downloadObject } from "@/lib/object-storage.server";
 
-const AUDIENCE_CONTACT_SORT_KEYS = [
-  "id",
-  "firstname",
-  "surname",
-  "phone",
-  "email",
-  "created_at",
-] as const;
-
-type AudienceContactSortKey = (typeof AUDIENCE_CONTACT_SORT_KEYS)[number];
-
-function audienceContactSortColumn(sortKey: string) {
-  if (AUDIENCE_CONTACT_SORT_KEYS.includes(sortKey as AudienceContactSortKey)) {
-    return contactTable[sortKey as AudienceContactSortKey];
-  }
-  return contactTable.id;
-}
+export { getAudienceDetailApi } from "./audience-detail.server";
 
 export type DataPlaneApiKeyAuth = {
   keyId: string;
@@ -869,142 +853,6 @@ export async function listWorkspaceAudiencesApi(
       status: 500,
     };
   }
-}
-
-export async function getAudienceDetailApi(
-  workspaceId: string,
-  audienceId: string,
-  searchParams: URLSearchParams,
-) {
-  const { page, pageSize, offset } = parsePagination(searchParams, {
-    defaultPageSize: 50,
-  });
-  const sortKey = searchParams.get("sort_key") || "id";
-  const sortDirection = searchParams.get("sort_direction") === "desc" ? "desc" : "asc";
-  const searchQuery = (searchParams.get("q") ?? "").trim().replaceAll(",", " ");
-  const audienceIdNum = Number(audienceId);
-  const sortColumn = audienceContactSortColumn(sortKey);
-  const tdb = createTenantDb(workspaceId);
-
-  let audience: typeof audienceTable.$inferSelect;
-  try {
-    const found = await tdb.audience.findFirst({
-      where: eq(audienceTable.id, audienceIdNum),
-    });
-    if (!found) {
-      return { ok: false as const, error: "Audience not found", status: 404 };
-    }
-    audience = found;
-  } catch (error) {
-    return {
-      ok: false as const,
-      error: error instanceof Error ? error.message : "Failed to load audience",
-      status: 500,
-    };
-  }
-
-  // Contacts / upload metadata are best-effort after the audience row loads.
-  // A contact join failure must not wipe the audience name (#1080).
-  let contacts: Array<{ contact: Record<string, unknown> }> = [];
-  let totalCount = 0;
-  let contactsError: string | null = null;
-  let latestUpload:
-    | {
-        id: number;
-        status: string;
-        progress: number;
-        total_contacts: number;
-        processed_contacts: number;
-        error_message?: string | null;
-      }
-    | null = null;
-
-  const audienceContactFilter = and(
-    eq(contactAudienceTable.audience_id, audienceIdNum),
-    eq(contactTable.workspace, workspaceId),
-    searchQuery ? buildContactSearchWhere(searchQuery) : undefined,
-  );
-
-  try {
-    // Select only columns the detail table needs — avoids SELECT * failing when
-    // the review/prod DB lags schema (extra contact columns in Drizzle).
-    const [contactRows, countRows] = await Promise.all([
-      db
-        .select({
-          id: contactTable.id,
-          firstname: contactTable.firstname,
-          surname: contactTable.surname,
-          phone: contactTable.phone,
-          email: contactTable.email,
-          address: contactTable.address,
-          city: contactTable.city,
-          other_data: contactTable.other_data,
-          created_at: contactTable.created_at,
-        })
-        .from(contactAudienceTable)
-        .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
-        .where(audienceContactFilter)
-        .orderBy(sortDirection === "asc" ? asc(sortColumn) : desc(sortColumn))
-        .limit(pageSize)
-        .offset(offset),
-      db
-        .select({ value: count() })
-        .from(contactAudienceTable)
-        .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
-        .where(audienceContactFilter),
-    ]);
-    contacts = contactRows.map((row) => ({ contact: row }));
-    totalCount = countRows[0]?.value ?? 0;
-  } catch (error) {
-    contactsError =
-      error instanceof Error ? error.message : "Failed to load contacts";
-    logger.error("getAudienceDetailApi contacts query failed", {
-      workspaceId,
-      audienceId,
-      error: contactsError,
-    });
-  }
-
-  try {
-    const upload = await tdb.audience_upload.findFirst({
-      where: eq(audienceUploadTable.audience_id, audienceIdNum),
-      orderBy: (row, { desc: descFn }) => [descFn(row.created_at)],
-    });
-    if (upload) {
-      latestUpload = {
-        id: upload.id,
-        status: upload.status ?? "unknown",
-        progress:
-          upload.processed_contacts && upload.total_contacts
-            ? Math.round((upload.processed_contacts / upload.total_contacts) * 100)
-            : 0,
-        total_contacts: upload.total_contacts ?? 0,
-        processed_contacts: upload.processed_contacts ?? 0,
-        error_message: upload.error_message,
-      };
-    }
-  } catch (error) {
-    logger.warn("getAudienceDetailApi latest upload lookup failed", {
-      workspaceId,
-      audienceId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  return {
-    ok: true as const,
-    audience,
-    contacts,
-    pagination: {
-      page,
-      page_size: pageSize,
-      total_count: totalCount,
-    } satisfies PaginationMeta,
-    sorting: { sort_key: sortKey, sort_direction: sortDirection },
-    search_query: searchQuery || null,
-    latest_upload: latestUpload,
-    contacts_error: contactsError,
-  };
 }
 
 export async function listWorkspaceScriptsApi(

--- a/app/lib/platform-data.server.ts
+++ b/app/lib/platform-data.server.ts
@@ -886,23 +886,61 @@ export async function getAudienceDetailApi(
   const sortColumn = audienceContactSortColumn(sortKey);
   const tdb = createTenantDb(workspaceId);
 
+  let audience: typeof audienceTable.$inferSelect;
   try {
-    const audience = await tdb.audience.findFirst({
+    const found = await tdb.audience.findFirst({
       where: eq(audienceTable.id, audienceIdNum),
     });
-    if (!audience) {
+    if (!found) {
       return { ok: false as const, error: "Audience not found", status: 404 };
     }
+    audience = found;
+  } catch (error) {
+    return {
+      ok: false as const,
+      error: error instanceof Error ? error.message : "Failed to load audience",
+      status: 500,
+    };
+  }
 
-    const audienceContactFilter = and(
-      eq(contactAudienceTable.audience_id, audienceIdNum),
-      eq(contactTable.workspace, workspaceId),
-      searchQuery ? buildContactSearchWhere(searchQuery) : undefined,
-    );
+  // Contacts / upload metadata are best-effort after the audience row loads.
+  // A contact join failure must not wipe the audience name (#1080).
+  let contacts: Array<{ contact: Record<string, unknown> }> = [];
+  let totalCount = 0;
+  let contactsError: string | null = null;
+  let latestUpload:
+    | {
+        id: number;
+        status: string;
+        progress: number;
+        total_contacts: number;
+        processed_contacts: number;
+        error_message?: string | null;
+      }
+    | null = null;
 
-    const [contactRows, countRows, latestUpload] = await Promise.all([
+  const audienceContactFilter = and(
+    eq(contactAudienceTable.audience_id, audienceIdNum),
+    eq(contactTable.workspace, workspaceId),
+    searchQuery ? buildContactSearchWhere(searchQuery) : undefined,
+  );
+
+  try {
+    // Select only columns the detail table needs — avoids SELECT * failing when
+    // the review/prod DB lags schema (extra contact columns in Drizzle).
+    const [contactRows, countRows] = await Promise.all([
       db
-        .select({ contact: contactTable })
+        .select({
+          id: contactTable.id,
+          firstname: contactTable.firstname,
+          surname: contactTable.surname,
+          phone: contactTable.phone,
+          email: contactTable.email,
+          address: contactTable.address,
+          city: contactTable.city,
+          other_data: contactTable.other_data,
+          created_at: contactTable.created_at,
+        })
         .from(contactAudienceTable)
         .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
         .where(audienceContactFilter)
@@ -914,46 +952,59 @@ export async function getAudienceDetailApi(
         .from(contactAudienceTable)
         .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
         .where(audienceContactFilter),
-      tdb.audience_upload.findFirst({
-        where: eq(audienceUploadTable.audience_id, audienceIdNum),
-        orderBy: (upload, { desc: descFn }) => [descFn(upload.created_at)],
-      }),
     ]);
-
-    return {
-      ok: true as const,
-      audience,
-      contacts: contactRows.map((row) => ({ contact: row.contact })),
-      pagination: {
-        page,
-        page_size: pageSize,
-        total_count: countRows[0]?.value ?? 0,
-      } satisfies PaginationMeta,
-      sorting: { sort_key: sortKey, sort_direction: sortDirection },
-      search_query: searchQuery || null,
-      latest_upload: latestUpload
-        ? {
-            id: latestUpload.id,
-            status: latestUpload.status ?? "unknown",
-            progress:
-              latestUpload.processed_contacts && latestUpload.total_contacts
-                ? Math.round(
-                    (latestUpload.processed_contacts / latestUpload.total_contacts) * 100,
-                  )
-                : 0,
-            total_contacts: latestUpload.total_contacts ?? 0,
-            processed_contacts: latestUpload.processed_contacts ?? 0,
-            error_message: latestUpload.error_message,
-          }
-        : null,
-    };
+    contacts = contactRows.map((row) => ({ contact: row }));
+    totalCount = countRows[0]?.value ?? 0;
   } catch (error) {
-    return {
-      ok: false as const,
-      error: error instanceof Error ? error.message : "Failed to load audience",
-      status: 500,
-    };
+    contactsError =
+      error instanceof Error ? error.message : "Failed to load contacts";
+    logger.error("getAudienceDetailApi contacts query failed", {
+      workspaceId,
+      audienceId,
+      error: contactsError,
+    });
   }
+
+  try {
+    const upload = await tdb.audience_upload.findFirst({
+      where: eq(audienceUploadTable.audience_id, audienceIdNum),
+      orderBy: (row, { desc: descFn }) => [descFn(row.created_at)],
+    });
+    if (upload) {
+      latestUpload = {
+        id: upload.id,
+        status: upload.status ?? "unknown",
+        progress:
+          upload.processed_contacts && upload.total_contacts
+            ? Math.round((upload.processed_contacts / upload.total_contacts) * 100)
+            : 0,
+        total_contacts: upload.total_contacts ?? 0,
+        processed_contacts: upload.processed_contacts ?? 0,
+        error_message: upload.error_message,
+      };
+    }
+  } catch (error) {
+    logger.warn("getAudienceDetailApi latest upload lookup failed", {
+      workspaceId,
+      audienceId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return {
+    ok: true as const,
+    audience,
+    contacts,
+    pagination: {
+      page,
+      page_size: pageSize,
+      total_count: totalCount,
+    } satisfies PaginationMeta,
+    sorting: { sort_key: sortKey, sort_direction: sortDirection },
+    search_query: searchQuery || null,
+    latest_upload: latestUpload,
+    contacts_error: contactsError,
+  };
 }
 
 export async function listWorkspaceScriptsApi(

--- a/app/routes/api+/audience-upload.action.server.ts
+++ b/app/routes/api+/audience-upload.action.server.ts
@@ -3,7 +3,6 @@ import { logger } from "@/lib/logger.server";
 import { parseCSV } from '@/lib/csv';
 import {
   normalizeVoterListSource,
-  processAudienceUpload,
   type VoterListSource,
 } from "@/lib/audience-upload-process.server";
 import { resolveDualAuthSession } from "@/lib/api-auth.server";
@@ -18,6 +17,7 @@ import {
 import { requireWorkspaceAccess } from "@/lib/database/workspace.server";
 import { AppError } from "@/lib/errors.server";
 import { defineAction } from "@/lib/handler.server";
+import { enqueueJob } from "@/lib/worker/enqueue-job.server";
 import type { ActionFunctionArgs } from "react-router";
 import type { Database } from "@/lib/db-types";
 import {
@@ -57,7 +57,7 @@ type AudienceUploadDeps = Partial<{
     headers: Headers;
     user: { id: string } | null;
   }>;
-  processAudienceUpload: typeof processAudienceUpload;
+  enqueueJob: typeof enqueueJob;
   requireWorkspaceAccess: (args: {
     user: { id: string };
     workspaceId: string;
@@ -73,7 +73,7 @@ export const action = defineAction({
 
   const d = {
     verifyAuth: deps?.verifyAuth ?? resolveDualAuthSession,
-    processAudienceUpload: deps?.processAudienceUpload ?? processAudienceUpload,
+    enqueueJob: deps?.enqueueJob ?? enqueueJob,
     requireWorkspaceAccess: deps?.requireWorkspaceAccess ?? requireWorkspaceAccess,
   };
   const { headers, user } = await d.verifyAuth(request);
@@ -226,19 +226,21 @@ export const action = defineAction({
 
     const uploadId = uploadData.id;
 
-    // Start background processing
-    d.processAudienceUpload(
-      uploadId,
-      finalAudienceId,
+    await d.enqueueJob({
+      type: "audience_upload",
       workspaceId,
-      user.id,
-      fileBase64,
-      parsedHeaderMapping,
-      splitNameColumn || null,
-      { parseCSV },
-      voterListSource,
-    ).catch(error => {
-      logger.error("Background processing error:", error);
+      userId: user.id,
+      params: {
+        uploadId,
+        audienceId: finalAudienceId,
+        workspaceId,
+        userId: user.id,
+        fileContent: fileBase64,
+        headerMapping: parsedHeaderMapping,
+        splitNameColumn: splitNameColumn || null,
+        voterListSource,
+      },
+      dedupe: { kind: "idempotency", key: `audience_upload:${uploadId}` },
     });
 
     // Return the audience ID and upload ID immediately

--- a/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
@@ -1,7 +1,7 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   getAudienceDetailApi,
-} from "@/lib/platform-data.server";
+} from "@/lib/audience-detail.server";
 import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
@@ -35,6 +35,7 @@ export const loader = defineLoader({
         pagination: result.pagination,
         sorting: result.sorting,
         latest_upload: result.latest_upload,
+        contacts_error: result.contacts_error,
       },
       200,
     );

--- a/app/routes/workspaces+/$id/audiences/$audience_id.loader.server.ts
+++ b/app/routes/workspaces+/$id/audiences/$audience_id.loader.server.ts
@@ -1,5 +1,5 @@
 import { data as routeData } from "react-router";
-import { getAudienceDetailApi } from "@/lib/platform-data.server";
+import { getAudienceDetailApi } from "@/lib/audience-detail.server";
 import { workspaceLoaderAuth } from "@/lib/workspace-route.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { AudienceDetailLoaderData } from "./$audience_id.types";
@@ -25,6 +25,7 @@ export const loader = defineLoader({
           audience: null,
           audience_id,
           error: "Audience ID is required",
+          contactsError: null,
           pagination: {
             currentPage: page,
             pageSize,
@@ -61,6 +62,7 @@ export const loader = defineLoader({
           audience: null,
           audience_id,
           error: detailResult.error,
+          contactsError: null,
           pagination: {
             currentPage: page,
             pageSize,
@@ -78,7 +80,7 @@ export const loader = defineLoader({
 
     return routeData<AudienceDetailLoaderData>(
       {
-        contacts: detailResult.contacts as AudienceDetailLoaderData["contacts"],
+        contacts: detailResult.contacts,
         workspace_id,
         audience: detailResult.audience,
         audience_id,

--- a/app/routes/workspaces+/$id/audiences/$audience_id.loader.server.ts
+++ b/app/routes/workspaces+/$id/audiences/$audience_id.loader.server.ts
@@ -78,11 +78,12 @@ export const loader = defineLoader({
 
     return routeData<AudienceDetailLoaderData>(
       {
-        contacts: detailResult.contacts,
+        contacts: detailResult.contacts as AudienceDetailLoaderData["contacts"],
         workspace_id,
         audience: detailResult.audience,
         audience_id,
         error: null,
+        contactsError: detailResult.contacts_error,
         pagination: {
           currentPage: detailResult.pagination.page,
           pageSize: detailResult.pagination.page_size,

--- a/app/routes/workspaces+/$id/audiences/$audience_id.route.tsx
+++ b/app/routes/workspaces+/$id/audiences/$audience_id.route.tsx
@@ -2,7 +2,7 @@ export { loader } from "./$audience_id.loader.server";
 
 import { Form, useLoaderData, useNavigate, useOutletContext, useRevalidator } from "react-router";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { AudienceTable } from "@/components/audience/AudienceTable";
 import AudienceUploadHistory from "@/components/audience/AudienceUploadHistory";
 import AudienceUploader from "@/components/audience/AudienceUploader";
@@ -13,6 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { useInterval } from "@/hooks/utils/useInterval";
 import { logger } from "@/lib/logger.client";
+import { AUDIENCE_UPLOAD_PROCESSING_POLL_MS } from "../../../../../shared/audience-upload";
 
 import type { AudienceDetailLoaderData } from "./$audience_id.types";
 
@@ -32,17 +33,12 @@ export default function AudienceView() {
   useOutletContext<{ }>();
   const [activeTab, setActiveTab] = useState("contacts");
   const revalidator = useRevalidator();
-  const [displayName, setDisplayName] = useState(audience?.name ?? "");
-
-  /**
-   * @effect Keep the page title in sync when the loader revalidates with a new audience row.
-   * @effect-deps audience?.name from the detail loader
-   * @effect-side-effects setDisplayName
-   * @effect-why-not-loader Title also tracks in-progress form edits via onAudienceNameChange.
-   */
-  useEffect(() => {
-    setDisplayName(audience?.name ?? "");
-  }, [audience?.name]);
+  const [name, setName] = useState(audience?.name ?? "");
+  const [prevAudienceName, setPrevAudienceName] = useState(audience?.name ?? "");
+  if (prevAudienceName !== (audience?.name ?? "")) {
+    setPrevAudienceName(audience?.name ?? "");
+    setName(audience?.name ?? "");
+  }
 
   // Track current upload status
   const [currentUploadId, setCurrentUploadId] = useState<number | null>(
@@ -69,7 +65,7 @@ export default function AudienceView() {
         setCurrentUploadId(null);
       }
     },
-    currentUploadId ? 5000 : null
+    currentUploadId ? AUDIENCE_UPLOAD_PROCESSING_POLL_MS : null
   );
 
   const handleUploadComplete = (_uploadId: string) => {
@@ -79,8 +75,7 @@ export default function AudienceView() {
   };
 
   const title =
-    displayName.trim() ||
-    audience?.name?.trim() ||
+    name.trim() ||
     (audience_id ? `Unnamed Audience ${audience_id}` : "Unnamed Audience");
 
   return (
@@ -137,15 +132,13 @@ export default function AudienceView() {
 
         <TabsContent value="contacts">
           <AudienceTable
-            {...{
-              contacts,
-              workspace_id,
-              selected_id: audience_id,
-              audience,
-              pagination,
-              sorting,
-              onAudienceNameChange: setDisplayName,
-            }}
+            contacts={contacts}
+            workspace_id={workspace_id}
+            selected_id={audience_id}
+            pagination={pagination}
+            sorting={sorting}
+            name={name}
+            onNameChange={setName}
           />
         </TabsContent>
 
@@ -161,8 +154,8 @@ export default function AudienceView() {
 
         <TabsContent value="history">
           <AudienceUploadHistory
-            audienceId={audience_id}
-            workspaceId={workspace_id}
+            audienceId={Number(audience_id)}
+            workspaceId={workspace_id ?? ""}
           />
         </TabsContent>
       </Tabs>

--- a/app/routes/workspaces+/$id/audiences/$audience_id.route.tsx
+++ b/app/routes/workspaces+/$id/audiences/$audience_id.route.tsx
@@ -1,28 +1,48 @@
 export { loader } from "./$audience_id.loader.server";
 
-import { data as routeData, LoaderFunctionArgs, Form, useLoaderData, useNavigate, useOutletContext, useRevalidator } from "react-router";
+import { Form, useLoaderData, useNavigate, useOutletContext, useRevalidator } from "react-router";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AudienceTable } from "@/components/audience/AudienceTable";
 import AudienceUploadHistory from "@/components/audience/AudienceUploadHistory";
 import AudienceUploader from "@/components/audience/AudienceUploader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Heading } from "@/components/ui/typography";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import type { Database } from "@/lib/db-types";
 import { useInterval } from "@/hooks/utils/useInterval";
 import { logger } from "@/lib/logger.client";
 
 import type { AudienceDetailLoaderData } from "./$audience_id.types";
 
 export default function AudienceView() {
-  const { contacts, audience, error, workspace_id, audience_id, pagination, sorting, latestUpload } =
-    useLoaderData<AudienceDetailLoaderData>();
+  const {
+    contacts,
+    audience,
+    error,
+    contactsError,
+    workspace_id,
+    audience_id,
+    pagination,
+    sorting,
+    latestUpload,
+  } = useLoaderData<AudienceDetailLoaderData>();
   const navigate = useNavigate();
   useOutletContext<{ }>();
   const [activeTab, setActiveTab] = useState("contacts");
   const revalidator = useRevalidator();
+  const [displayName, setDisplayName] = useState(audience?.name ?? "");
+
+  /**
+   * @effect Keep the page title in sync when the loader revalidates with a new audience row.
+   * @effect-deps audience?.name from the detail loader
+   * @effect-side-effects setDisplayName
+   * @effect-why-not-loader Title also tracks in-progress form edits via onAudienceNameChange.
+   */
+  useEffect(() => {
+    setDisplayName(audience?.name ?? "");
+  }, [audience?.name]);
 
   // Track current upload status
   const [currentUploadId, setCurrentUploadId] = useState<number | null>(
@@ -44,12 +64,12 @@ export default function AudienceView() {
           setCurrentUploadId(null);
           revalidator.revalidate();
         }
-      } catch (error) {
-        logger.error("Error polling status:", error);
+      } catch (pollError) {
+        logger.error("Error polling status:", pollError);
         setCurrentUploadId(null);
       }
     },
-    currentUploadId ? 2000 : null
+    currentUploadId ? 5000 : null
   );
 
   const handleUploadComplete = (_uploadId: string) => {
@@ -58,11 +78,16 @@ export default function AudienceView() {
     setActiveTab("contacts");
   };
 
+  const title =
+    displayName.trim() ||
+    audience?.name?.trim() ||
+    (audience_id ? `Unnamed Audience ${audience_id}` : "Unnamed Audience");
+
   return (
     <main className="flex h-full flex-col gap-4 text-foreground">
       <div className="flex items-center justify-between gap-4">
         <Heading as="h1" level={2} branded={false}>
-          {audience?.name || `Unnamed Audience ${audience_id}`}
+          {title}
         </Heading>
         <div className="flex gap-1">
           <Form
@@ -82,6 +107,19 @@ export default function AudienceView() {
           </Form>
         </div>
       </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+      {contactsError ? (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Contacts could not be loaded. The call list name and settings below are still available.
+          </AlertDescription>
+        </Alert>
+      ) : null}
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
         <TabsList>
@@ -105,14 +143,15 @@ export default function AudienceView() {
               selected_id: audience_id,
               audience,
               pagination,
-              sorting
+              sorting,
+              onAudienceNameChange: setDisplayName,
             }}
           />
         </TabsContent>
 
         <TabsContent value="upload" className="space-y-4">
           <Heading as="h2" level={3} branded={false}>
-            Upload Contacts to {audience?.name}
+            Upload Contacts to {title}
           </Heading>
           <AudienceUploader
             existingAudienceId={audience_id}
@@ -120,13 +159,10 @@ export default function AudienceView() {
           />
         </TabsContent>
 
-        <TabsContent value="history" className="space-y-4">
-          <Heading as="h2" level={3} branded={false}>
-            Upload History
-          </Heading>
+        <TabsContent value="history">
           <AudienceUploadHistory
-            audienceId={Number(audience_id)}
-            workspaceId={workspace_id ?? ""}
+            audienceId={audience_id}
+            workspaceId={workspace_id}
           />
         </TabsContent>
       </Tabs>

--- a/app/routes/workspaces+/$id/audiences/$audience_id.types.ts
+++ b/app/routes/workspaces+/$id/audiences/$audience_id.types.ts
@@ -6,6 +6,8 @@ export type AudienceDetailLoaderData = {
   audience: Database["public"]["Tables"]["audience"]["Row"] | null;
   audience_id: string | undefined;
   error: string | null;
+  /** Present when the audience row loaded but the contacts join failed (#1080). */
+  contactsError?: string | null;
   pagination: {
     currentPage: number;
     pageSize: number;

--- a/app/routes/workspaces+/$id/audiences/$audience_id.types.ts
+++ b/app/routes/workspaces+/$id/audiences/$audience_id.types.ts
@@ -1,13 +1,14 @@
 import type { Database } from "@/lib/db-types";
+import type { ContactListRow } from "@/lib/contacts-loader.types";
 
 export type AudienceDetailLoaderData = {
-  contacts: Array<{ contact: Database["public"]["Tables"]["contact"]["Row"] }> | null;
+  contacts: Array<{ contact: ContactListRow }> | null;
   workspace_id: string | undefined;
   audience: Database["public"]["Tables"]["audience"]["Row"] | null;
   audience_id: string | undefined;
   error: string | null;
   /** Present when the audience row loaded but the contacts join failed (#1080). */
-  contactsError?: string | null;
+  contactsError: string | null;
   pagination: {
     currentPage: number;
     pageSize: number;

--- a/docs/remediation/sai-issues-2026-07-21.md
+++ b/docs/remediation/sai-issues-2026-07-21.md
@@ -1,0 +1,82 @@
+# Sai QA issues — 2026-07-21
+
+**Author:** sai-sy  
+**Filed against:** Railway review (`callcaster-review-visual-asset-review`)  
+**Working branch context:** `dev` + local WIP for #1080/#1078 (QC-aligned audience upload)  
+**Walkthrough date:** 2026-07-21  
+**Status:** #1083 leftovers closed; #1080/#1078 implemented locally (pending PR); #1076/#1077 deferred
+
+---
+
+## Goal
+
+Work through Sai’s issues from 2026-07-21: confirm what #1083 already fixed, then ship #1080/#1078 by aligning audience upload with quick-canvass import processor patterns.
+
+---
+
+## Issue ledger
+
+| Issue | Title | State | Status |
+|------:|-------|-------|--------|
+| [#1082](https://github.com/chester-hill-solutions/callcaster/issues/1082) | Onboarding blocks renting | CLOSED | Fixed in #1083 |
+| [#1081](https://github.com/chester-hill-solutions/callcaster/issues/1081) | Number rental UI overlapping | CLOSED | Hardened in #1083 |
+| [#1080](https://github.com/chester-hill-solutions/callcaster/issues/1080) | Unnamed audience when named | OPEN → close with PR | **Implemented** (loader preserve + H1 sync) |
+| [#1079](https://github.com/chester-hill-solutions/callcaster/issues/1079) | CSV header invisible light mode | CLOSED | Fixed in #1083 |
+| [#1078](https://github.com/chester-hill-solutions/callcaster/issues/1078) | 1-contact upload forever | OPEN → close with PR | **Implemented** (QC job + batch + poll) |
+| [#1077](https://github.com/chester-hill-solutions/callcaster/issues/1077) | Better upload UI | OPEN | Deferred |
+| [#1076](https://github.com/chester-hill-solutions/callcaster/issues/1076) | Program Details Page is Hell | OPEN | Deferred |
+| [#1074](https://github.com/chester-hill-solutions/callcaster/issues/1074) / [#1075](https://github.com/chester-hill-solutions/callcaster/issues/1075) | Service address wizard | CLOSED | Fixed in #1083 |
+
+---
+
+## Already shipped (#1083)
+
+PR: https://github.com/chester-hill-solutions/callcaster/pull/1083 — `b1f0c00a` on `dev`.
+
+---
+
+## #1080 / #1078 implementation (this pass)
+
+### #1080
+
+- `getAudienceDetailApi` always returns audience after row load; contacts failures set `contacts_error` only.
+- Narrow contact SELECT; H1 `displayName` syncs with form `onNameChange`.
+- Test: [`test/get-audience-detail-api.test.ts`](../../test/get-audience-detail-api.test.ts).
+
+### #1078 (QC-aligned)
+
+| Concern | CallCaster now | QC reference |
+|---------|----------------|--------------|
+| Batch size | `AUDIENCE_UPLOAD_CHUNK_SIZE = 40` | `BATCH = 40` |
+| Progress throttle | `AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS = 2500` | `IMPORT_PROGRESS_NOTIFY_MS = 2500` |
+| Small-upload delay | `audienceUploadChunkDelayMs(n) === 0` for `n ≤ 40` | No setTimeout in import loop |
+| Execution | Local `enqueueJob({ type: "audience_upload", ... })` | `process-contact-import` job |
+| Client poll | 5000ms | `PROCESSING_POLL_MS = 5000` |
+| Job package | Local poller + [`jobqueue.adapter.server.ts`](../../app/lib/adapters/jobqueue.adapter.server.ts) — **not** published `@chester-hill-solutions/jobqueue` yet | QC jobs package |
+
+**QC reference files:**  
+`quick-canvass/app/server/run-client-import.server.ts`, `contact-import-job.server.ts`, `use-import-processing-revalidate-poll.ts`
+
+**CallCaster files:**  
+`audience-upload-process.server.ts`, `audience-upload.action.server.ts`, `audienceUploadHandler`, `AudienceUploader.tsx`, `shared/audience-upload.ts`
+
+**Local runtime:** `nvm use 22` + `npm run dev` **and** `npm run worker` (no HTTP worker wake; poller picks up jobs).
+
+---
+
+## Deferred
+
+| Issue | Notes |
+|------:|-------|
+| [#1076](https://github.com/chester-hill-solutions/callcaster/issues/1076) | Goal-scoped Program details copy/defaults |
+| [#1077](https://github.com/chester-hill-solutions/callcaster/issues/1077) | Shared dropzone UI after perf path lands |
+
+---
+
+## Done when
+
+- [x] Fixed issues from #1083 closed on GitHub
+- [x] #1080 code + unit test (close issue with PR)
+- [x] #1078 code + unit tests (close issue with PR)
+- [x] #1076 / #1077 deferred comments
+- [ ] PR opened / merged

--- a/shared/audience-upload.ts
+++ b/shared/audience-upload.ts
@@ -8,6 +8,29 @@ export interface AudienceUploadRequestBody {
   splitNameColumn: string | null;
 }
 
+/** Per-chunk yield used for large imports so the DB is not hammered. */
+export const AUDIENCE_UPLOAD_CHUNK_DELAY_MS = 100;
+
+/** Minimum interval between mid-flight progress status writes during import. */
+export const AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS = 2500;
+
+/** Default contact batch size for audience CSV import. */
+export const AUDIENCE_UPLOAD_CHUNK_SIZE = 40;
+
+/** Row-level concurrency for future per-row work; bulk insertMany remains the default. */
+export const AUDIENCE_UPLOAD_ROW_CONCURRENCY = 6;
+
+/**
+ * Small uploads (single chunk) skip the artificial delay — a 1-row CSV
+ * otherwise always waited at least 100ms after insert + dual status writes.
+ */
+export function audienceUploadChunkDelayMs(
+  totalContacts: number,
+  chunkSize: number = AUDIENCE_UPLOAD_CHUNK_SIZE,
+): number {
+  return totalContacts <= chunkSize ? 0 : AUDIENCE_UPLOAD_CHUNK_DELAY_MS;
+}
+
 export interface AudienceUploadContact {
   workspace: string;
   created_by: string;

--- a/shared/audience-upload.ts
+++ b/shared/audience-upload.ts
@@ -17,8 +17,8 @@ export const AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS = 2500;
 /** Default contact batch size for audience CSV import. */
 export const AUDIENCE_UPLOAD_CHUNK_SIZE = 40;
 
-/** Row-level concurrency for future per-row work; bulk insertMany remains the default. */
-export const AUDIENCE_UPLOAD_ROW_CONCURRENCY = 6;
+/** Client/status poll interval while an upload is processing (QC-aligned). */
+export const AUDIENCE_UPLOAD_PROCESSING_POLL_MS = 5000;
 
 /**
  * Small uploads (single chunk) skip the artificial delay — a 1-row CSV
@@ -29,6 +29,27 @@ export function audienceUploadChunkDelayMs(
   chunkSize: number = AUDIENCE_UPLOAD_CHUNK_SIZE,
 ): number {
   return totalContacts <= chunkSize ? 0 : AUDIENCE_UPLOAD_CHUNK_DELAY_MS;
+}
+
+/**
+ * Throttle mid-flight status-sidecar writes for multi-chunk imports.
+ * Single-chunk uploads skip mid-flight sidecar writes (finalization covers them).
+ * Durable `processed_contacts` row updates are always written by the caller.
+ */
+export function audienceUploadShouldWriteStatus(args: {
+  total: number;
+  chunkSize?: number;
+  isLastChunk: boolean;
+  lastProgressAt: number;
+  now?: number;
+}): boolean {
+  const chunkSize = args.chunkSize ?? AUDIENCE_UPLOAD_CHUNK_SIZE;
+  if (args.total <= chunkSize) return false;
+  const now = args.now ?? Date.now();
+  return (
+    args.isLastChunk ||
+    now - args.lastProgressAt >= AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS
+  );
 }
 
 export interface AudienceUploadContact {

--- a/test/audience-upload-chunk-delay.test.ts
+++ b/test/audience-upload-chunk-delay.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import {
+  AUDIENCE_UPLOAD_CHUNK_DELAY_MS,
+  AUDIENCE_UPLOAD_CHUNK_SIZE,
+  audienceUploadChunkDelayMs,
+} from "../shared/audience-upload";
+
+describe("audienceUploadChunkDelayMs", () => {
+  test("CHUNK_SIZE is 40 for QC alignment", () => {
+    expect(AUDIENCE_UPLOAD_CHUNK_SIZE).toBe(40);
+  });
+
+  test("skips artificial delay for single-chunk uploads (#1078)", () => {
+    expect(audienceUploadChunkDelayMs(1)).toBe(0);
+    expect(audienceUploadChunkDelayMs(40)).toBe(0);
+    expect(audienceUploadChunkDelayMs(AUDIENCE_UPLOAD_CHUNK_SIZE)).toBe(0);
+  });
+
+  test("keeps yield delay for multi-chunk uploads", () => {
+    expect(audienceUploadChunkDelayMs(41)).toBe(AUDIENCE_UPLOAD_CHUNK_DELAY_MS);
+    expect(audienceUploadChunkDelayMs(AUDIENCE_UPLOAD_CHUNK_SIZE + 1)).toBe(
+      AUDIENCE_UPLOAD_CHUNK_DELAY_MS,
+    );
+    expect(audienceUploadChunkDelayMs(500)).toBe(AUDIENCE_UPLOAD_CHUNK_DELAY_MS);
+  });
+});

--- a/test/audience-upload-chunk-delay.test.ts
+++ b/test/audience-upload-chunk-delay.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "vitest";
 import {
   AUDIENCE_UPLOAD_CHUNK_DELAY_MS,
   AUDIENCE_UPLOAD_CHUNK_SIZE,
+  AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS,
   audienceUploadChunkDelayMs,
+  audienceUploadShouldWriteStatus,
 } from "../shared/audience-upload";
 
 describe("audienceUploadChunkDelayMs", () => {
@@ -22,5 +24,53 @@ describe("audienceUploadChunkDelayMs", () => {
       AUDIENCE_UPLOAD_CHUNK_DELAY_MS,
     );
     expect(audienceUploadChunkDelayMs(500)).toBe(AUDIENCE_UPLOAD_CHUNK_DELAY_MS);
+  });
+});
+
+describe("audienceUploadShouldWriteStatus", () => {
+  test("skips mid-flight sidecar writes for single-chunk uploads", () => {
+    expect(
+      audienceUploadShouldWriteStatus({
+        total: 1,
+        isLastChunk: true,
+        lastProgressAt: 0,
+        now: 10_000,
+      }),
+    ).toBe(false);
+    expect(
+      audienceUploadShouldWriteStatus({
+        total: 40,
+        isLastChunk: true,
+        lastProgressAt: 0,
+        now: 10_000,
+      }),
+    ).toBe(false);
+  });
+
+  test("writes on last chunk or after notify interval for multi-chunk", () => {
+    expect(
+      audienceUploadShouldWriteStatus({
+        total: 41,
+        isLastChunk: true,
+        lastProgressAt: 0,
+        now: 100,
+      }),
+    ).toBe(true);
+    expect(
+      audienceUploadShouldWriteStatus({
+        total: 80,
+        isLastChunk: false,
+        lastProgressAt: 0,
+        now: AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS,
+      }),
+    ).toBe(true);
+    expect(
+      audienceUploadShouldWriteStatus({
+        total: 80,
+        isLastChunk: false,
+        lastProgressAt: 1000,
+        now: 1000 + AUDIENCE_UPLOAD_PROGRESS_NOTIFY_MS - 1,
+      }),
+    ).toBe(false);
   });
 });

--- a/test/audience-upload.route.test.ts
+++ b/test/audience-upload.route.test.ts
@@ -40,6 +40,10 @@ const requireWorkspaceAccessMock = vi.hoisted(() => ({
   requireWorkspaceAccess: vi.fn(async () => undefined),
 }));
 
+const enqueueJobMock = vi.hoisted(() =>
+  vi.fn(async () => ({ enqueued: true, jobId: 1 })),
+);
+
 const processDbMocks = vi.hoisted(() => ({
   insertValues: vi.fn(async () => undefined),
 }));
@@ -59,6 +63,9 @@ vi.mock("@/lib/object-storage.server", () => ({
 vi.mock("@/lib/database/workspace.server", () => ({
   requireWorkspaceAccess: (...args: any[]) =>
     requireWorkspaceAccessMock.requireWorkspaceAccess(...args),
+}));
+vi.mock("@/lib/worker/enqueue-job.server", () => ({
+  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 vi.mock("@/lib/logger.server", () => ({ logger }));
@@ -97,6 +104,8 @@ describe("app/routes/api+/audience-upload/route.tsx", () => {
     processTdbMocks.audience_upload.update.mockReset();
     processTdbMocks.audience.update.mockReset();
     processDbMocks.insertValues.mockReset();
+    enqueueJobMock.mockReset();
+    enqueueJobMock.mockResolvedValue({ enqueued: true, jobId: 1 });
     objectStorageMocks.uploads.length = 0;
     objectStorageMocks.uploadObject.mockReset();
     objectStorageMocks.uploadObject.mockImplementation(
@@ -182,10 +191,10 @@ describe("app/routes/api+/audience-upload/route.tsx", () => {
     expect(res400c.status).toBe(400);
   }, 30000);
 
-  test("action: audienceId path validates audience, creates upload record, and starts background processing", async () => {
+  test("action: audienceId path validates audience, creates upload record, and enqueues processing job", async () => {
     const mod = await import("../app/routes/api+/audience-upload");
 
-    const processAudienceUpload = vi.fn(async () => {});
+    const enqueueJob = vi.fn(async () => ({ enqueued: true, jobId: 1 }));
     const verifyAuth = vi.fn(async () => ({
       null: {} as any,
       headers: new Headers(),
@@ -201,14 +210,28 @@ describe("app/routes/api+/audience-upload/route.tsx", () => {
 
     const res = await asRouteResponse(mod.action({
       request: makeReq(fd),
-      deps: { verifyAuth, processAudienceUpload },
+      deps: { verifyAuth, enqueueJob },
     } as any));
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toMatchObject({ success: true, audience_id: 1, upload_id: 99 });
     expect(body.message).toContain("Processing in background");
-    expect(processAudienceUpload).toHaveBeenCalled();
+    expect(enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "audience_upload",
+        workspaceId: "w1",
+        userId: "u1",
+        dedupe: { kind: "idempotency", key: "audience_upload:99" },
+        params: expect.objectContaining({
+          uploadId: 99,
+          audienceId: 1,
+          workspaceId: "w1",
+          userId: "u1",
+          splitNameColumn: "Name",
+        }),
+      }),
+    );
   }, 30000);
 
   test("action: audienceId path returns 404 when audience missing", async () => {
@@ -292,13 +315,11 @@ describe("app/routes/api+/audience-upload/route.tsx", () => {
     expect(r3.status).toBe(400);
   }, 30000);
 
-  test("action: create-audience success message and background .catch logging", async () => {
+  test("action: create-audience success message enqueues upload job", async () => {
     vi.resetModules();
     const mod = await import("../app/routes/api+/audience-upload");
 
-    const processAudienceUpload = vi.fn(async () => {
-      throw new Error("bg");
-    });
+    const enqueueJob = vi.fn(async () => ({ enqueued: true, jobId: 1 }));
     const verifyAuth = vi.fn(async () => ({
       null: {} as any,
       headers: new Headers(),
@@ -313,16 +334,18 @@ describe("app/routes/api+/audience-upload/route.tsx", () => {
     // omit split_name_column to hit its null branch
     const res = await asRouteResponse(mod.action({
       request: makeReq(fd),
-      deps: { verifyAuth, processAudienceUpload },
+      deps: { verifyAuth, enqueueJob },
     } as any));
     const body = await res.json();
     expect(body.message).toContain("Audience created");
-
-    // let the background rejection propagate to the attached .catch
-    await Promise.resolve();
-    expect(logger.error).toHaveBeenCalledWith(
-      "Background processing error:",
-      expect.any(Error),
+    expect(enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "audience_upload",
+        params: expect.objectContaining({
+          uploadId: 99,
+          splitNameColumn: null,
+        }),
+      }),
     );
   }, 30000);
 

--- a/test/get-audience-detail-api.test.ts
+++ b/test/get-audience-detail-api.test.ts
@@ -87,7 +87,7 @@ describe("getAudienceDetailApi", () => {
     );
 
     const { getAudienceDetailApi } = await import(
-      "../app/lib/platform-data.server"
+      "../app/lib/audience-detail.server"
     );
     const result = await getAudienceDetailApi(
       "ws-1",
@@ -106,7 +106,7 @@ describe("getAudienceDetailApi", () => {
     tdbMocks.audience.findFirst.mockResolvedValue(null);
 
     const { getAudienceDetailApi } = await import(
-      "../app/lib/platform-data.server"
+      "../app/lib/audience-detail.server"
     );
     const result = await getAudienceDetailApi(
       "ws-1",

--- a/test/get-audience-detail-api.test.ts
+++ b/test/get-audience-detail-api.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgres://test:test@localhost:5432/test";
+
+const tdbMocks = vi.hoisted(() => ({
+  audience: {
+    findFirst: vi.fn(),
+  },
+  audience_upload: {
+    findFirst: vi.fn(),
+  },
+}));
+
+const dbMocks = vi.hoisted(() => {
+  const selectChain = {
+    from: vi.fn(),
+    innerJoin: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    limit: vi.fn(),
+    offset: vi.fn(),
+  };
+  // Make every builder step return the chain so either contacts or count path works.
+  for (const key of Object.keys(selectChain) as Array<keyof typeof selectChain>) {
+    selectChain[key].mockReturnValue(selectChain);
+  }
+  selectChain.offset.mockResolvedValue([]);
+  // count query ends at .where() without limit/offset
+  selectChain.where.mockImplementation(() => selectChain);
+  return {
+    select: vi.fn(() => selectChain),
+    selectChain,
+  };
+});
+
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: vi.fn(() => tdbMocks),
+}));
+
+vi.mock("@/server/db", () => ({
+  db: {
+    select: (...args: unknown[]) => dbMocks.select(...args),
+  },
+}));
+
+vi.mock("@/lib/logger.server", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe("getAudienceDetailApi", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(dbMocks.selectChain) as Array<
+      keyof typeof dbMocks.selectChain
+    >) {
+      dbMocks.selectChain[key].mockReturnValue(dbMocks.selectChain);
+    }
+    dbMocks.selectChain.offset.mockResolvedValue([]);
+    dbMocks.selectChain.where.mockImplementation(() => dbMocks.selectChain);
+  });
+
+  test("returns audience with contacts_error when contacts query fails (#1080)", async () => {
+    tdbMocks.audience.findFirst.mockResolvedValue({
+      id: 4,
+      name: "Launch test call list",
+      workspace: "ws-1",
+      is_conditional: false,
+      created_at: "2026-07-20T00:00:00Z",
+      status: "completed",
+      total_contacts: null,
+      processed_contacts: null,
+      processed_at: null,
+      error_message: null,
+    });
+    tdbMocks.audience_upload.findFirst.mockResolvedValue(null);
+
+    // First select (contacts) throws; second (count) would also throw if reached —
+    // Promise.all fails on first rejection.
+    dbMocks.selectChain.offset.mockRejectedValueOnce(
+      new Error("Failed query: contact join"),
+    );
+
+    const { getAudienceDetailApi } = await import(
+      "../app/lib/platform-data.server"
+    );
+    const result = await getAudienceDetailApi(
+      "ws-1",
+      "4",
+      new URLSearchParams(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.audience.name).toBe("Launch test call list");
+    expect(result.contacts).toEqual([]);
+    expect(result.contacts_error).toMatch(/Failed query: contact join/);
+  });
+
+  test("returns 404 when audience is missing", async () => {
+    tdbMocks.audience.findFirst.mockResolvedValue(null);
+
+    const { getAudienceDetailApi } = await import(
+      "../app/lib/platform-data.server"
+    );
+    const result = await getAudienceDetailApi(
+      "ws-1",
+      "999",
+      new URLSearchParams(),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Audience not found",
+      status: 404,
+    });
+  });
+});

--- a/test/ui/audience-form.test.tsx
+++ b/test/ui/audience-form.test.tsx
@@ -11,17 +11,19 @@ describe("app/components/audience/AudienceForm.tsx", () => {
     vi.resetModules();
   });
 
-  test("renders with initial name and disables save when empty; submits via handleSaveAudience", async () => {
+  test("renders controlled name, disables save when empty, and submits via handleSaveAudience", async () => {
     const { AudienceForm } = await import("@/components/audience/AudienceForm");
     const handleSaveAudience = vi.fn(async () => {});
+    const onNameChange = vi.fn();
 
-    const { unmount } = render(
+    const { rerender } = render(
       <AudienceForm
-        audienceInfo={null}
+        name=""
+        onNameChange={onNameChange}
         handleSaveAudience={handleSaveAudience}
         audience_id="a1"
         workspace_id="w1"
-      />
+      />,
     );
 
     const nameInput = screen.getByPlaceholderText("Audience Name") as HTMLInputElement;
@@ -29,26 +31,33 @@ describe("app/components/audience/AudienceForm.tsx", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
 
     fireEvent.change(nameInput, { target: { value: "My Audience" } });
+    expect(onNameChange).toHaveBeenCalledWith("My Audience");
+
+    rerender(
+      <AudienceForm
+        name="My Audience"
+        onNameChange={onNameChange}
+        handleSaveAudience={handleSaveAudience}
+        audience_id="a1"
+        workspace_id="w1"
+      />,
+    );
     expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
-    // cover value.length === 0 branch (does not clear error)
-    fireEvent.change(nameInput, { target: { value: "" } });
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
-    fireEvent.change(nameInput, { target: { value: "My Audience" } });
 
     fireEvent.submit(nameInput.closest("form") as HTMLFormElement);
     expect(handleSaveAudience).toHaveBeenCalled();
 
-    // initial value from audienceInfo (fresh mount; component doesn't sync state on prop change)
-    unmount();
-    render(
+    rerender(
       <AudienceForm
-        audienceInfo={{ name: "Existing" } as any}
+        name="Existing"
+        onNameChange={onNameChange}
         handleSaveAudience={handleSaveAudience}
         audience_id="a1"
         workspace_id="w1"
-      />
+      />,
     );
-    expect((screen.getByPlaceholderText("Audience Name") as HTMLInputElement).value).toBe("Existing");
+    expect((screen.getByPlaceholderText("Audience Name") as HTMLInputElement).value).toBe(
+      "Existing",
+    );
   });
 });
-

--- a/test/ui/audience-table.test.tsx
+++ b/test/ui/audience-table.test.tsx
@@ -28,9 +28,9 @@ vi.mock("@/hooks/utils/useOptimisticMutation", () => ({
 }));
 
 vi.mock("@/components/audience/AudienceForm", () => ({
-  AudienceForm: ({ audienceInfo, handleSaveAudience }: any) => (
+  AudienceForm: ({ name, handleSaveAudience }: any) => (
     <form onSubmit={handleSaveAudience}>
-      <div data-testid="audience-name">{audienceInfo?.name ?? ""}</div>
+      <div data-testid="audience-name">{name ?? ""}</div>
       <input name="name" defaultValue="New Name" />
       <button type="submit">Save Audience</button>
     </form>
@@ -150,7 +150,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={null}
         workspace_id="w1"
         selected_id={undefined}
-        audience={null}
+        name=""
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 0 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -174,7 +175,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         ]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 2 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -210,7 +212,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         ]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 2 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -234,7 +237,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1, { firstname: "First" }) }]}
         workspace_id="w1"
         selected_id={undefined}
-        audience={null}
+        name=""
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -251,7 +255,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1, { firstname: "First" }) }]}
         workspace_id="w1"
         selected_id={undefined}
-        audience={null}
+        name=""
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -272,7 +277,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1) }, { contact: makeContact(2) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 2 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -298,7 +304,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1, { firstname: "First" }) }, { contact: makeContact(2, { firstname: "Second" }) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 2 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -327,7 +334,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "surname", sortDirection: "desc" }}
       />,
@@ -348,7 +356,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -369,7 +378,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 2, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -394,7 +404,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 2, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "id", sortDirection: "desc" }}
       />,
@@ -412,7 +423,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
       contacts: [{ contact: makeContact(1) }],
       workspace_id: "w1",
       selected_id: "a1",
-      audience: { id: "a1", name: "Audience A" } as any,
+      name: "Audience A",
+      onNameChange: () => {},
       pagination: { currentPage: 1, pageSize: 10, totalCount: 1 },
     };
 
@@ -456,7 +468,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 2, pageSize: 10, totalCount: 30 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -491,7 +504,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1, { firstname: "Bob" }) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "surname", sortDirection: "desc" }}
       />,
@@ -531,7 +545,8 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[{ contact: makeContact(1) }]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 1 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
@@ -544,7 +559,7 @@ describe("app/components/audience/AudienceTable.tsx", () => {
     createElementSpy.mockRestore();
   });
 
-  test("save audience updates state on ok, logs on failure", async () => {
+  test("save audience PATCHes on ok and logs on failure", async () => {
     const { AudienceTable } = await import("@/components/audience/AudienceTable");
 
     const fetchMock = vi
@@ -564,14 +579,17 @@ describe("app/components/audience/AudienceTable.tsx", () => {
         contacts={[]}
         workspace_id="w1"
         selected_id="a1"
-        audience={{ id: "a1", name: "Audience A" } as any}
+        name="Audience A"
+        onNameChange={() => {}}
         pagination={{ currentPage: 1, pageSize: 10, totalCount: 0 }}
         sorting={{ sortKey: "id", sortDirection: "asc" }}
       />,
     );
 
     fireEvent.submit(screen.getByRole("button", { name: "Save Audience" }).closest("form") as HTMLFormElement);
-    expect(await screen.findByText("Saved")).toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    // Name is owned by the page; table no longer mirrors PATCH JSON into local state.
+    expect(screen.getByTestId("audience-name")).toHaveTextContent("Audience A");
 
     fireEvent.submit(screen.getByRole("button", { name: "Save Audience" }).closest("form") as HTMLFormElement);
     await waitFor(() =>

--- a/test/ui/audience-uploader.test.tsx
+++ b/test/ui/audience-uploader.test.tsx
@@ -333,7 +333,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     });
 
     await waitFor(() => {
-      expect(mocks.interval.ms).toBe(2000);
+      expect(mocks.interval.ms).toBe(5000);
     });
     await act(async () => {
       await mocks.interval.cb?.();
@@ -391,7 +391,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    expect(mocks.interval.ms).toBe(2000);
+    expect(mocks.interval.ms).toBe(5000);
 
     await act(async () => {
       await mocks.interval.cb?.();
@@ -480,7 +480,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
         },
       } as any;
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
     await act(async () => {
       await mocks.interval.cb?.();
     });
@@ -773,7 +773,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
 
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
   });
 
   test("upload POST throws non-Error -> shows generic unexpected error", async () => {
@@ -857,7 +857,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
 
     await act(async () => {
       await mocks.interval.cb?.();
@@ -921,7 +921,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
 
     await act(async () => {
       await mocks.interval.cb?.();
@@ -980,7 +980,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
 
     await act(async () => {
       await mocks.interval.cb?.();
@@ -1041,7 +1041,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
 
     await act(async () => {
       await mocks.interval.cb?.();
@@ -1104,7 +1104,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
 
     expect(screen.getByText("0 / 1 contacts")).toBeInTheDocument();
 
@@ -1167,7 +1167,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
 
     for (let i = 0; i < 6; i++) {
       await act(async () => {
@@ -1185,7 +1185,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     ).toBeNull();
     expect(screen.getByText("Processing...")).toBeInTheDocument();
     // Polling stays enabled for transient refresh failures.
-    expect(mocks.interval.ms).toBe(2000);
+    expect(mocks.interval.ms).toBe(5000);
   });
 
   test("non-JSON status response is treated as a transient poll failure", async () => {
@@ -1237,7 +1237,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Start Upload" }));
     });
-    await waitFor(() => expect(mocks.interval.ms).toBe(2000));
+    await waitFor(() => expect(mocks.interval.ms).toBe(5000));
 
     await act(async () => {
       await mocks.interval.cb?.();
@@ -1246,7 +1246,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     expect(
       screen.getByText("Live progress is delayed. Retrying automatically..."),
     ).toBeInTheDocument();
-    expect(mocks.interval.ms).toBe(2000);
+    expect(mocks.interval.ms).toBe(5000);
     expect(screen.queryByText("Error")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #1080, closes #1078.

## Summary
- **#1080** — `getAudienceDetailApi` keeps the audience row when the contacts join fails (`contacts_error`); detail H1 tracks the name form.
- **#1078** — Align audience CSV upload with quick-canvass processor patterns: `CHUNK_SIZE=40`, progress throttle 2500ms, no artificial delay for small uploads, `enqueueJob({ type: "audience_upload" })` via the local worker (not published `@chester-hill-solutions/jobqueue` yet), 5s client poll.
- Ledger: `docs/remediation/sai-issues-2026-07-21.md`

## Test plan
- [x] `vitest` `test/audience-upload-chunk-delay.test.ts`, `test/audience-upload.route.test.ts`, `test/get-audience-detail-api.test.ts` (19 tests)
- [ ] Local: Node 22 — `npm run dev` + `npm run worker`; upload a 1-row CSV
- [ ] Review: named call list H1 matches list name when contacts previously failed