### PR TITLE
E2E harness: run the job worker + audience upload completion spec

### DIFF
--- a/e2e/fixtures/files/audience-one-contact.csv
+++ b/e2e/fixtures/files/audience-one-contact.csv
@@ -1,0 +1,2 @@
+Name,Phone
+Upload Completion,+15555509905

--- a/e2e/specs/audience-upload-completion.spec.ts
+++ b/e2e/specs/audience-upload-completion.spec.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ownerTest, expect } from "../fixtures/test-base";
+import { E2E_WORKSPACES, workspacePath } from "../fixtures/seed";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// End-to-end job-pipeline coverage: the wizard enqueues an audience_upload
+// job that only the worker process resolves. This spec requires the worker
+// started by the compose harness — without it, the upload sits in
+// "processing" forever (the exact failure mode of #1078, which shipped
+// because nothing exercised job completion).
+ownerTest("AUD-05 upload wizard completes end-to-end via the job worker", async ({ page }) => {
+  const csvPath = path.join(__dirname, "..", "fixtures", "files", "audience-one-contact.csv");
+
+  await page.goto(workspacePath(E2E_WORKSPACES.ready.id, "audiences/new"));
+
+  // Step 1 has a single forward CTA, gated on a non-empty name (#1060).
+  const next = page.getByTestId("audience-next-upload");
+  await expect(next).toBeDisabled();
+  await page.getByLabel("Call list name").fill("E2E Upload Completion");
+  await expect(next).toBeEnabled();
+  await next.click();
+
+  await expect(page.getByTestId("audience-upload-step")).toBeVisible();
+  await page.locator("#contacts").setInputFiles(csvPath);
+  await expect(page.getByText("Map CSV Headers")).toBeVisible();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await page.getByRole("button", { name: "Start Upload" }).click();
+
+  // Submit → job enqueue → worker claim (≤5s poll) → chunk insert → status
+  // flip. 20s leaves headroom over the observed ~6s without masking a hang.
+  await expect(page.getByText("Upload Complete")).toBeVisible({ timeout: 20_000 });
+
+  // The finished list is reachable and carries the name it was given.
+  await page.getByRole("button", { name: "View Call list" }).click();
+  await expect(page.getByRole("heading", { name: "E2E Upload Completion" })).toBeVisible();
+});

--- a/e2e/specs/auth.spec.ts
+++ b/e2e/specs/auth.spec.ts
@@ -46,7 +46,10 @@ test.describe("Auth @smoke", () => {
       }
     });
     await page.goto("/");
-    await expect(page).toHaveURL(/\/\/127\.0\.0\.1:3100\/?$/);
+    // Signed out: stays on the marketing root instead of bouncing to
+    // /workspaces. Port-agnostic — the harness may run on a non-default
+    // E2E_PORT.
+    await expect(page).toHaveURL(/\/\/127\.0\.0\.1:\d+\/?$/);
   });
 
   test("AUTH-08 open signup UI when SIGNUP_OPEN is enabled", async ({ page }) => {

--- a/scripts/e2e/ensure-minio-bucket.mjs
+++ b/scripts/e2e/ensure-minio-bucket.mjs
@@ -11,6 +11,11 @@ import {
 const endpoint = process.env.S3_ENDPOINT ?? "http://127.0.0.1:9000";
 const bucket = process.env.S3_BUCKET ?? "callcaster";
 
+// --keep-objects: only ensure the bucket exists, don't purge. Used by server
+// boot paths (start-e2e-server) where wiping seeded fixtures would be wrong;
+// the compose E2E orchestrator keeps the default purge for determinism.
+const keepObjects = process.argv.includes("--keep-objects");
+
 const client = new S3Client({
   endpoint,
   region: process.env.S3_REGION ?? "us-east-1",
@@ -77,7 +82,11 @@ let lastError;
 for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
   try {
     await ensureBucket();
-    await purgeBucket();
+    if (keepObjects) {
+      console.log(`[e2e-minio] keeping existing objects in ${bucket} (--keep-objects)`);
+    } else {
+      await purgeBucket();
+    }
     process.exit(0);
   } catch (error) {
     lastError = error;

--- a/scripts/e2e/run-compose-e2e.mjs
+++ b/scripts/e2e/run-compose-e2e.mjs
@@ -164,6 +164,17 @@ server.on("exit", (code, signal) => {
   }
 });
 
+// Queued jobs (audience_upload, exports, dispatch) only run if a worker is
+// polling. Without one, "processing" states never resolve and specs cannot
+// cover job completion — which is how the upload dead-letter bug shipped.
+console.log("[e2e-compose] starting job worker…");
+const worker = runAsync("bun", ["run", "./worker/index.ts"], serverEnv);
+worker.on("exit", (code, signal) => {
+  if (code != null && code !== 0) {
+    console.error(`[e2e-compose] worker exited early code=${code} signal=${signal ?? ""}`);
+  }
+});
+
 async function waitForReady(url, attempts = 120) {
   for (let i = 0; i < attempts; i += 1) {
     try {
@@ -194,6 +205,15 @@ try {
   console.error(error);
   exitCode = 1;
 } finally {
+  // SIGTERM first for graceful shutdown, but don't trust it — an ignored
+  // signal here orphans bun children that keep ports and stdio pipes open.
   server.kill("SIGTERM");
+  worker.kill("SIGTERM");
+  await new Promise((r) => setTimeout(r, 3000));
+  for (const child of [server, worker]) {
+    if (child.exitCode == null && child.signalCode == null) {
+      child.kill("SIGKILL");
+    }
+  }
   process.exit(exitCode);
 }

--- a/scripts/e2e/start-e2e-server.mjs
+++ b/scripts/e2e/start-e2e-server.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-env node */
 import "dotenv/config";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -56,7 +56,29 @@ async function waitForReady(readyUrl, attempts = 90) {
   throw new Error(`Server not ready at ${readyUrl}/readyz`);
 }
 
+// Best-effort: make sure the S3 bucket exists before anything enqueues an
+// upload — a missing bucket dead-letters audience_upload jobs. Non-fatal so
+// the server still boots for flows that never touch object storage.
+const bucketCheck = spawnSync(
+  "node",
+  ["scripts/e2e/ensure-minio-bucket.mjs", "--keep-objects"],
+  { cwd: rootDir, env, stdio: "inherit" },
+);
+if (bucketCheck.status !== 0) {
+  console.warn(
+    "[e2e-server] WARNING: could not ensure MinIO bucket — uploads will dead-letter until it exists",
+  );
+}
+
 const child = spawn("bun", ["run", "./server/bun.ts"], {
+  cwd: rootDir,
+  env,
+  stdio: "inherit",
+});
+
+// Queued jobs (audience_upload, exports, dispatch) need a polling worker or
+// they sit in "processing" forever — run one alongside the server.
+const workerChild = spawn("bun", ["run", "./worker/index.ts"], {
   cwd: rootDir,
   env,
   stdio: "inherit",
@@ -64,6 +86,7 @@ const child = spawn("bun", ["run", "./server/bun.ts"], {
 
 async function shutdown(code = 0) {
   child.kill("SIGTERM");
+  workerChild.kill("SIGTERM");
   process.exit(code);
 }
 
@@ -79,5 +102,14 @@ try {
 }
 
 child.on("exit", (code) => {
+  workerChild.kill("SIGTERM");
   process.exit(code ?? 0);
+});
+
+workerChild.on("exit", (code, signal) => {
+  if (code != null && code !== 0) {
+    console.error(
+      `[e2e-server] worker exited early code=${code} signal=${signal ?? ""} — queued jobs will not process`,
+    );
+  }
 });


### PR DESCRIPTION
**Stacked on #1085** (base is that branch; will retarget to `dev` when it merges).

Closes the coverage gap that let the #1078 upload dead-letter bug ship: the E2E harness never ran the job worker, so no spec could observe a queued job completing.

- `run-compose-e2e.mjs` and `start-e2e-server.mjs` now spawn `worker/index.ts` alongside the server (same env). Shutdown reaps both, with a SIGKILL fallback after a 3s grace — observed bun children surviving SIGTERM and orphaning ports/pipes.
- `start-e2e-server.mjs` (the preview path) also ensures the MinIO bucket exists at boot via a new `--keep-objects` mode on `ensure-minio-bucket.mjs` (bucket-only, no purge, so seeded fixtures survive; the compose orchestrator keeps its purge for deterministic empty-state specs). A missing bucket also dead-letters upload jobs.
- New **AUD-05** spec: walks the audience upload wizard (name gate → CSV attach → mapping → Start Upload) and asserts "Upload Complete" within 20s, then opens the finished list. Passes in ~7s locally and in a full compose-suite run.
- AUTH-06's sign-out assertion hardcoded port 3100; now port-agnostic so the suite passes on a custom `E2E_PORT`.

Verification: full `run-compose-e2e` pass on `E2E_PORT=3210` — 77/77 with these changes (the only failure in the first run was the AUTH-06 port pin, fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)