### PR TITLE
Harden NANP phone parsing: reject garbage, salvage spreadsheet notation (#1057)

### DIFF
--- a/app/lib/phone.ts
+++ b/app/lib/phone.ts
@@ -17,36 +17,71 @@ export const phoneRegex =
   /^(\+\d{1,2}\s?)?(\(\d{3}\)|\d{3})[\s.-]?\d{3}[\s.-]?\d{4}$/;
 
 /**
+ * NANP structure: +1 NXX XXX-XXXX where the area code N is 2-9 — so
+ * "+10555550100" is not a dialable number even though it is 11 digits.
+ * The exchange code technically has the same N constraint, but enforcing it
+ * would reject the ubiquitous 555-123-4567 style of legacy/test data and
+ * silently null contacts on import, so only the area code is checked.
+ */
+const NANP_E164_PATTERN = /^\+1[2-9]\d{9}$/;
+
+/**
+ * Expand spreadsheet scientific notation ("1.5556667777E+10") back into its
+ * digit string. Returns null unless every digit of the original number
+ * survives in the mantissa — a rounded export like "1.55567E+10" would
+ * otherwise fabricate a plausible-looking wrong number ending in zeros.
+ */
+function expandScientificNotation(raw: string): string | null {
+  const match = /^(\d)(?:\.(\d+))?[eE]\+?(\d{1,2})$/.exec(raw.trim());
+  if (!match) return null;
+  const mantissaDigits = `${match[1]}${match[2] ?? ""}`;
+  const exponent = Number(match[3]);
+  if (mantissaDigits.length !== exponent + 1) return null;
+  return mantissaDigits;
+}
+
+/**
+ * Shared normalization core: strip punctuation, expand spreadsheet
+ * scientific notation, add the +1 country code to bare ten-digit numbers,
+ * and require a structurally valid NANP number. Returns null on anything
+ * that is not a dialable North American number (international input is
+ * intentionally rejected — dialing/billing is NANP-only today).
+ */
+function toE164Nanp(input: string): string | null {
+  const scientific = expandScientificNotation(input);
+  let cleaned = (scientific ?? input).replace(/[^0-9+]/g, "");
+
+  if (cleaned.indexOf("+") > 0) {
+    cleaned = cleaned.replace(/\+/g, "");
+  }
+  const digits = cleaned.replace(/^\+/, "");
+
+  const withCountry =
+    digits.length === 10 ? `1${digits}` : digits;
+  if (withCountry.length !== 11 || !withCountry.startsWith("1")) {
+    return null;
+  }
+
+  const e164 = `+${withCountry}`;
+  return NANP_E164_PATTERN.test(e164) ? e164 : null;
+}
+
+/**
  * Normalize a phone number to E.164 format (+1XXXXXXXXXX).
  * @param input - Raw phone number input
  * @returns Normalized phone number in E.164 format
- * @throws {Error} when input is empty or the resulting length is invalid
+ * @throws {Error} when input is empty, the wrong length, or not a valid NANP number
  */
 export function normalizePhoneNumber(input: string): string {
   if (!input || typeof input !== "string") {
     throw new Error("Phone number input must be a non-empty string");
   }
 
-  let cleaned = input.replace(/[^0-9+]/g, "");
-
-  if (cleaned.indexOf("+") > 0) {
-    cleaned = cleaned.replace(/\+/g, "");
-  }
-
-  if (!cleaned.startsWith("+")) {
-    cleaned = `+${cleaned}`;
-  }
-
-  const expectedLength = 12;
-  if (cleaned.length < expectedLength) {
-    cleaned = `+1${cleaned.replace("+", "")}`;
-  }
-
-  if (cleaned.length !== expectedLength) {
+  const normalized = toE164Nanp(input);
+  if (normalized == null) {
     throw new Error("Invalid phone number length");
   }
-
-  return cleaned;
+  return normalized;
 }
 
 /**
@@ -54,30 +89,10 @@ export function normalizePhoneNumber(input: string): string {
  * when the value cannot be normalized. Used by lenient/CSV parse paths.
  */
 export function parsePhoneNumber(input: string | null): string | null {
-  if (input) {
-    let cleaned = input.replace(/[^0-9+]/g, "");
-
-    if (cleaned.indexOf("+") > 0) {
-      cleaned = cleaned.replace(/\+/g, "");
-    }
-    if (!cleaned.startsWith("+")) {
-      cleaned = "+" + cleaned;
-    }
-
-    const validLength = 11;
-    const minLength = 11;
-
-    if (cleaned.length < minLength + 1) {
-      cleaned = "+1" + cleaned.replace("+", "");
-    }
-
-    if (cleaned.length !== validLength + 1) {
-      return null;
-    }
-    return cleaned;
-  } else {
+  if (!input) {
     return "";
   }
+  return toE164Nanp(input);
 }
 
 /**

--- a/test/phone.test.ts
+++ b/test/phone.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { isValidPhoneNumber, normalizePhoneNumber, phoneRegex } from "@/lib/phone";
+import {
+  isValidPhoneNumber,
+  normalizePhoneNumber,
+  parsePhoneNumber,
+  phoneRegex,
+} from "@/lib/phone";
 
 describe("app/lib/phone", () => {
   test("phoneRegex matches common NA formats", () => {
@@ -33,6 +38,66 @@ describe("app/lib/phone", () => {
     expect(isValidPhoneNumber("")).toBe(false);
     expect(isValidPhoneNumber("bad")).toBe(false);
     expect(isValidPhoneNumber("(555) 555-0100")).toBe(true);
+  });
+
+  // Format checklist from #1057 — every common NA entry style normalizes to
+  // the same E.164 number.
+  test.each([
+    "5556667777",
+    "15556667777",
+    "+15556667777",
+    "555 666 7777",
+    "1 555 666 7777",
+    "+1 555 666 7777",
+    "(555) 666-7777",
+    "+1 (555) 666-7777",
+    "555-666-7777",
+    "+1 555-666-7777",
+  ])("parsePhoneNumber(%s) → +15556667777", (input) => {
+    expect(parsePhoneNumber(input)).toBe("+15556667777");
+    expect(normalizePhoneNumber(input)).toBe("+15556667777");
+  });
+
+  test("parsePhoneNumber returns '' for null and null for garbage", () => {
+    expect(parsePhoneNumber(null)).toBe("");
+    expect(parsePhoneNumber("not a number")).toBeNull();
+    expect(parsePhoneNumber("555-01")).toBeNull();
+  });
+
+  test("rejects 11-digit numbers that are not NANP country code 1 (#1057)", () => {
+    // Previously accepted as "+25556667777" — not a dialable number.
+    expect(parsePhoneNumber("25556667777")).toBeNull();
+    expect(() => normalizePhoneNumber("25556667777")).toThrow();
+  });
+
+  test("rejects invalid NANP area codes (#1057)", () => {
+    // Area codes never start with 0 or 1.
+    expect(parsePhoneNumber("0555550100")).toBeNull();
+    expect(parsePhoneNumber("+10555550100")).toBeNull();
+    // Exchange-code strictness is deliberately NOT enforced — 555-123-4567
+    // style legacy/test data must keep importing.
+    expect(parsePhoneNumber("5551234567")).toBe("+15551234567");
+  });
+
+  test("still rejects international numbers", () => {
+    expect(parsePhoneNumber("+44 20 7946 0018")).toBeNull();
+    expect(() => normalizePhoneNumber("+44 20 7946 0018")).toThrow(
+      "Invalid phone number length",
+    );
+  });
+
+  test("expands full-precision spreadsheet scientific notation (#1057)", () => {
+    // Excel renders 15556667777 as 1.5556667777E+10 when a CSV round-trips.
+    expect(parsePhoneNumber("1.5556667777E+10")).toBe("+15556667777");
+    expect(parsePhoneNumber("1.5556667777e10")).toBe("+15556667777");
+    expect(parsePhoneNumber("5.556667777E+9")).toBe("+15556667777");
+  });
+
+  test("rejects rounded scientific notation instead of fabricating digits (#1057)", () => {
+    // A rounded export lost real digits; expanding it would import a
+    // plausible-looking wrong number ending in zeros.
+    expect(parsePhoneNumber("1.55567E+10")).toBeNull();
+    expect(parsePhoneNumber("1.5E+10")).toBeNull();
   });
 });
 


### PR DESCRIPTION
**Stacked on #1085** (base is that branch purely so CI runs on a green baseline — the code change is independent; will retarget to `dev` when #1085 merges).

`parsePhoneNumber` / `normalizePhoneNumber` validated length only. This closes the gaps called out in #1057's analysis:

- **11-digit non-NANP values were accepted verbatim**: `25556667777` → `+25556667777`, which is not a dialable number. Now rejected.
- **Invalid area codes passed**: `+10555550100` (area code starting 0) now rejected. Exchange-code strictness is deliberately *not* enforced — `555-123-4567`-style legacy/test data is ubiquitous and must keep importing (enforcing it broke 36 existing tests and would silently null real contacts).
- **Spreadsheet scientific notation**: `1.5556667777E+10` now expands to `+15556667777`. Rounded exports (`1.55567E+10`) are rejected rather than expanded — expanding would fabricate a plausible-looking wrong number ending in zeros, which is worse than a null.
- Every format on #1057's checklist is covered by unit tests (all normalize to the same E.164 value through both the strict and lenient helpers).

International parsing remains intentionally out of scope — dialing/billing is NANP-only today, and quietly importing international numbers would change cost behavior. If that's wanted, it should be a deliberate product decision (likely via libphonenumber).

Verification: full node suite 299 files / 2058 passed, UI suite, typecheck, lint all green.

Closes the actionable scope of #1057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)