### PR TITLE
Recipient-local calling windows (TCPA/CRTC 8am–9pm recipient time)

### DIFF
--- a/app/components/campaign/settings/basic/CampaignBasicInfo.Dates.tsx
+++ b/app/components/campaign/settings/basic/CampaignBasicInfo.Dates.tsx
@@ -380,7 +380,10 @@ export default function SelectDates({
         </div>
         <p className="text-xs text-muted-foreground">
           Times are shown in your local time zone (
-          {Intl.DateTimeFormat().resolvedOptions().timeZone}).
+          {Intl.DateTimeFormat().resolvedOptions().timeZone}). Regardless of
+          the hours set here, contacts are only dialed or messaged between
+          8:00&nbsp;a.m. and 9:00&nbsp;p.m. in their own time zone, based on
+          their phone number&apos;s area code.
         </p>
 
         {showSchedule && (

--- a/app/lib/auto-dial.server.ts
+++ b/app/lib/auto-dial.server.ts
@@ -11,6 +11,7 @@ import {
   rpcDequeueContact,
 } from "@/lib/db-rpc.server";
 import { claimNextQueueContact, requeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import { recipientCallingWindowStatus } from "@/lib/recipient-calling-window";
 import { db } from "@/server/db";
 import { createWorkspaceTwilioInstance } from "@/lib/database/workspace.server";
 
@@ -185,7 +186,35 @@ export async function runAutoDialerTurn(
   const tdb = createTenantDb(workspace_id);
 
   try {
-    const contactRecord = await getNextAutoDialQueueContact(campaign_id, user_id, tdb);
+    // Claim the next contact that is inside the recipient-local calling
+    // window (TCPA/CRTC 8am–9pm recipient time). Out-of-window claims are
+    // released back to `queued` so a later turn can dial them; seeing an
+    // already-released row again means every claimable contact is currently
+    // out of window, so the turn ends instead of spinning.
+    const MAX_WINDOW_SKIPS_PER_TURN = 25;
+    const releasedQueueIds = new Set<number>();
+    let contactRecord = await getNextAutoDialQueueContact(campaign_id, user_id, tdb);
+    while (contactRecord) {
+      const windowStatus = recipientCallingWindowStatus(
+        contactRecord.contact_phone,
+      );
+      if (windowStatus.allowed) break;
+      logger.info("auto_dial.recipient_window_skip", {
+        campaignId: campaign_id,
+        queueId: contactRecord.queue_id,
+        timezone: windowStatus.timezone,
+        reason: windowStatus.reason,
+      });
+      const alreadyReleased = releasedQueueIds.has(contactRecord.queue_id);
+      releasedQueueIds.add(contactRecord.queue_id);
+      await requeueCampaignQueueById(contactRecord.queue_id, workspace_id);
+      if (alreadyReleased || releasedQueueIds.size >= MAX_WINDOW_SKIPS_PER_TURN) {
+        contactRecord = null;
+        break;
+      }
+      contactRecord = await getNextAutoDialQueueContact(campaign_id, user_id, tdb);
+    }
+
     if (contactRecord) {
       logger.debug("Contact record:", contactRecord);
 
@@ -270,7 +299,13 @@ export async function runAutoDialerTurn(
     }
 
     await completeAllConferences(twilioClient, conferenceId);
-    return { success: true, message: "No queued contacts" };
+    return {
+      success: true,
+      message:
+        releasedQueueIds.size > 0
+          ? "No contacts within recipient calling hours"
+          : "No queued contacts",
+    };
   } catch (error) {
     logger.error("Error dialing number:", error);
     const errorMessage = error instanceof Error ? error.message : "Unknown error";

--- a/app/lib/nanp-timezones.ts
+++ b/app/lib/nanp-timezones.ts
@@ -1,0 +1,165 @@
+/**
+ * NANP area code → IANA timezone, for recipient-local calling-window
+ * enforcement (TCPA/CRTC style 8am–9pm windows are defined in the
+ * *recipient's* local time).
+ *
+ * Granularity: one zone per area code, chosen as the zone covering the large
+ * majority of the code's geography. A handful of codes straddle a boundary
+ * (e.g. 850 FL panhandle, 219 NW Indiana, 915 El Paso are mapped to their
+ * dominant non-state-default zone; slivers inside 250/306/605/701/906 are
+ * accepted as ±1h approximations — the same trade-off every commercial
+ * dialer makes for area-code-based windows).
+ *
+ * Codes deliberately absent (toll-free 8xx, premium 900, unlisted Caribbean
+ * members, and any future overlays not yet added) resolve to null, and the
+ * caller must fall back to the conservative all-zones window — unknown
+ * degrades SAFE, never permissive. When adding overlays, add them to the
+ * zone group of their parent code.
+ */
+
+const ZONE_GROUPS: Record<string, readonly string[]> = {
+  // ————— Canada —————
+  "America/St_Johns": ["709", "879"],
+  "America/Halifax": ["902", "782", "506", "428"],
+  "America/Winnipeg": ["204", "431", "584"],
+  // Saskatchewan observes no DST.
+  "America/Regina": ["306", "639", "474"],
+  // 867 spans YT/NWT/NU; Mountain (Yellowknife/Whitehorse) dominates.
+  "America/Edmonton": ["403", "587", "780", "825", "368", "867"],
+  "America/Vancouver": ["604", "778", "236", "672", "250", "257"],
+
+  // ————— US Eastern + Eastern Canada (ON/QC) —————
+  "America/Toronto": [
+    // Ontario
+    "416", "647", "437", "365", "905", "289", "613", "343", "753", "705",
+    "249", "683", "807", "519", "226", "548", "382", "742",
+    // Quebec
+    "514", "438", "263", "450", "579", "354", "418", "581", "367", "819", "873",
+  ],
+  "America/New_York": [
+    // CT / DC / DE
+    "203", "475", "860", "959", "202", "771", "302",
+    // Florida (peninsula)
+    "239", "305", "321", "324", "352", "386", "407", "561", "645", "656",
+    "689", "727", "728", "754", "772", "786", "813", "863", "904", "941", "954",
+    // Georgia
+    "229", "404", "470", "478", "678", "706", "762", "770", "912", "943",
+    // Indiana (Eastern-time majority)
+    "260", "317", "463", "574", "765", "812", "930",
+    // Kentucky (Eastern)
+    "502", "606", "859",
+    // Massachusetts / Maryland / Maine
+    "339", "351", "413", "508", "617", "774", "781", "857", "978",
+    "240", "301", "410", "443", "667", "207",
+    // Michigan
+    "231", "248", "269", "313", "517", "586", "616", "679", "734", "810",
+    "906", "947", "989",
+    // North Carolina / New Hampshire
+    "252", "336", "472", "704", "743", "828", "910", "919", "980", "984", "603",
+    // New Jersey
+    "201", "551", "609", "640", "732", "848", "856", "862", "908", "973",
+    // New York
+    "212", "315", "329", "332", "347", "363", "516", "518", "585", "607",
+    "631", "646", "680", "716", "718", "838", "845", "914", "917", "929", "934",
+    // Ohio
+    "216", "220", "234", "283", "326", "330", "380", "419", "440", "513",
+    "567", "614", "740", "937",
+    // Pennsylvania
+    "215", "223", "267", "272", "412", "445", "484", "570", "582", "610",
+    "717", "724", "814", "835", "878",
+    // RI / SC
+    "401", "803", "821", "839", "843", "854", "864",
+    // Tennessee (Eastern)
+    "423", "865",
+    // Virginia / Vermont / West Virginia
+    "276", "434", "540", "571", "686", "703", "757", "804", "826", "948",
+    "802", "304", "681",
+  ],
+
+  // ————— US Central —————
+  "America/Chicago": [
+    // Alabama / Arkansas
+    "205", "251", "256", "334", "659", "938", "327", "479", "501", "870",
+    // Florida panhandle
+    "448", "850",
+    // Iowa / Illinois
+    "319", "515", "563", "641", "712",
+    "217", "224", "309", "312", "331", "447", "464", "618", "630", "708",
+    "730", "773", "779", "815", "847", "861", "872",
+    // Indiana (NW) / Kansas / Kentucky (Western)
+    "219", "316", "620", "785", "913", "270", "364",
+    // Louisiana / Minnesota
+    "225", "318", "337", "457", "504", "985",
+    "218", "320", "507", "612", "651", "763", "924", "952",
+    // Missouri / Mississippi
+    "235", "314", "417", "557", "573", "636", "660", "816", "975",
+    "228", "601", "662", "769",
+    // ND / NE / OK / SD
+    "701", "308", "402", "531", "405", "539", "572", "580", "918", "605",
+    // Tennessee (Central)
+    "615", "629", "731", "901", "931",
+    // Texas (all but El Paso)
+    "210", "214", "254", "281", "325", "346", "361", "409", "430", "432",
+    "469", "512", "621", "682", "713", "726", "737", "806", "817", "830",
+    "832", "903", "936", "940", "945", "956", "972", "979",
+    // Wisconsin
+    "262", "274", "353", "414", "534", "608", "715", "920",
+  ],
+
+  // ————— US Mountain —————
+  "America/Denver": [
+    "303", "719", "720", "748", "970", "983", // Colorado
+    "208", "986", // Idaho
+    "406", // Montana
+    "505", "575", // New Mexico
+    "915", // El Paso TX
+    "385", "435", "801", // Utah
+    "307", // Wyoming
+  ],
+  // Arizona observes no DST (outside the Navajo Nation).
+  "America/Phoenix": ["480", "520", "602", "623", "928"],
+
+  // ————— US Pacific —————
+  "America/Los_Angeles": [
+    // California
+    "209", "213", "279", "310", "323", "341", "350", "408", "415", "424",
+    "442", "510", "530", "559", "562", "619", "626", "628", "650", "657",
+    "661", "669", "707", "714", "738", "747", "760", "805", "818", "820",
+    "831", "840", "858", "909", "916", "925", "949", "951",
+    // Nevada / Oregon / Washington
+    "702", "725", "775",
+    "458", "503", "541", "971",
+    "206", "253", "360", "425", "509", "564",
+  ],
+
+  // ————— Alaska / Hawaii / territories / Caribbean NANP members —————
+  "America/Anchorage": ["907"],
+  "Pacific/Honolulu": ["808"],
+  "America/Puerto_Rico": ["787", "939", "340"],
+  "America/Santo_Domingo": ["809", "829", "849"],
+  "America/Jamaica": ["658", "876"],
+  "America/Nassau": ["242"],
+  "America/Port_of_Spain": ["868"],
+  "Atlantic/Bermuda": ["441"],
+  "Pacific/Guam": ["671", "670"],
+  "Pacific/Pago_Pago": ["684"],
+};
+
+function buildAreaCodeIndex(): Record<string, string> {
+  const index: Record<string, string> = {};
+  for (const [zone, codes] of Object.entries(ZONE_GROUPS)) {
+    for (const code of codes) {
+      if (index[code]) {
+        throw new Error(
+          `NANP area code ${code} mapped to both ${index[code]} and ${zone}`,
+        );
+      }
+      index[code] = zone;
+    }
+  }
+  return index;
+}
+
+/** Area code (3 digits, as a string) → IANA timezone. */
+export const NANP_AREA_CODE_TIMEZONES: Readonly<Record<string, string>> =
+  buildAreaCodeIndex();

--- a/app/lib/recipient-calling-window.ts
+++ b/app/lib/recipient-calling-window.ts
@@ -1,0 +1,133 @@
+/**
+ * Recipient-local calling-window enforcement.
+ *
+ * TCPA (US) and CRTC (Canada) telemarketing rules define permitted calling
+ * hours in the RECIPIENT'S local time — 8:00am to 9:00pm. Campaign-level
+ * calling hours (campaign.schedule, evaluated in UTC by checkSchedule) express
+ * the sender's preference; this module is the legal floor layered on top,
+ * derived from the contact's area code via {@link NANP_AREA_CODE_TIMEZONES}.
+ *
+ * Unknown numbers (toll-free, unmapped overlays, non-NANP) degrade SAFE: they
+ * are only callable while the window holds simultaneously in the east-most
+ * and west-most NANP zones, i.e. roughly 11:30am–9:00pm Newfoundland /
+ * 8:00am–5:30pm Hawaii.
+ */
+import { NANP_AREA_CODE_TIMEZONES } from "./nanp-timezones";
+
+/** Legal floor: no outbound campaign traffic before 8:00am recipient time. */
+export const RECIPIENT_WINDOW_START_MINUTES = 8 * 60;
+/** Legal floor: no outbound campaign traffic at/after 9:00pm recipient time. */
+export const RECIPIENT_WINDOW_END_MINUTES = 21 * 60;
+
+/** Bounds used when the recipient's zone is unknown. */
+const EASTMOST_NANP_ZONE = "America/St_Johns";
+const WESTMOST_NANP_ZONE = "Pacific/Honolulu";
+
+/** 3-digit NANP area code for a phone number, or null when not NANP-shaped. */
+export function areaCodeForPhone(
+  phone: string | null | undefined,
+): string | null {
+  if (!phone) return null;
+  const digits = String(phone).replace(/[^0-9]/g, "");
+  const national =
+    digits.length === 11 && digits.startsWith("1")
+      ? digits.slice(1)
+      : digits.length === 10
+        ? digits
+        : null;
+  return national ? national.slice(0, 3) : null;
+}
+
+/** IANA timezone inferred from the phone's area code, or null when unknown. */
+export function recipientTimezoneForPhone(
+  phone: string | null | undefined,
+): string | null {
+  const areaCode = areaCodeForPhone(phone);
+  if (!areaCode) return null;
+  return NANP_AREA_CODE_TIMEZONES[areaCode] ?? null;
+}
+
+/** Minutes since local midnight in `timeZone`, or null if the zone is invalid. */
+export function minutesOfDayInZone(timeZone: string, now: Date): number | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(now);
+    const hour = Number(parts.find((part) => part.type === "hour")?.value);
+    const minute = Number(parts.find((part) => part.type === "minute")?.value);
+    if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null;
+    return hour * 60 + minute;
+  } catch {
+    return null;
+  }
+}
+
+function windowHoldsInZone(timeZone: string, now: Date): boolean {
+  const minutes = minutesOfDayInZone(timeZone, now);
+  if (minutes == null) return false;
+  return (
+    minutes >= RECIPIENT_WINDOW_START_MINUTES &&
+    minutes < RECIPIENT_WINDOW_END_MINUTES
+  );
+}
+
+export type RecipientWindowStatus = {
+  allowed: boolean;
+  /** Inferred zone, or null when the number's zone is unknown. */
+  timezone: string | null;
+  /**
+   * - `in_window`: recipient-local time is within 8:00–21:00
+   * - `outside_window`: recipient-local time is outside the window
+   * - `unknown_timezone_safe`: zone unknown, but the window holds across all
+   *   NANP zones simultaneously
+   * - `unknown_timezone_blocked`: zone unknown and some NANP zone is outside
+   *   the window — blocked to stay conservative
+   */
+  reason:
+    | "in_window"
+    | "outside_window"
+    | "unknown_timezone_safe"
+    | "unknown_timezone_blocked";
+};
+
+/** Full verdict, for logging and UI ("skipped: 9:14pm in America/Denver"). */
+export function recipientCallingWindowStatus(
+  phone: string | null | undefined,
+  now: Date = new Date(),
+): RecipientWindowStatus {
+  // The E2E/preview harness (same switch that relaxes prod-only boot guards)
+  // runs at arbitrary UTC times with fictional 555 fixtures — enforcing the
+  // wall-clock window there would make specs pass or fail by time of day.
+  // Real deployments never set E2E_TEST.
+  if (process.env.E2E_TEST === "1") {
+    return { allowed: true, timezone: null, reason: "in_window" };
+  }
+  const timezone = recipientTimezoneForPhone(phone);
+  if (timezone) {
+    const allowed = windowHoldsInZone(timezone, now);
+    return {
+      allowed,
+      timezone,
+      reason: allowed ? "in_window" : "outside_window",
+    };
+  }
+  const allowed =
+    windowHoldsInZone(EASTMOST_NANP_ZONE, now) &&
+    windowHoldsInZone(WESTMOST_NANP_ZONE, now);
+  return {
+    allowed,
+    timezone: null,
+    reason: allowed ? "unknown_timezone_safe" : "unknown_timezone_blocked",
+  };
+}
+
+/** Whether an outbound campaign call/text to `phone` is permitted right now. */
+export function isWithinRecipientCallingWindow(
+  phone: string | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  return recipientCallingWindowStatus(phone, now).allowed;
+}

--- a/app/routes/api+/initiate-ivr.action.server.ts
+++ b/app/routes/api+/initiate-ivr.action.server.ts
@@ -10,6 +10,7 @@ import { logger } from "@/lib/logger.server";
 import { rpcGetCampaignQueue } from "@/lib/db-rpc.server";
 import { createTenantDb } from "@/server/tenant-db";
 import { normalizePhoneNumber } from "@/lib/utils";
+import { isWithinRecipientCallingWindow } from "@/lib/recipient-calling-window";
 import { defineAction } from "@/lib/handler.server";
 
 export const action = defineAction({
@@ -46,6 +47,12 @@ export const action = defineAction({
     for (let i = 0; i < (data?.length ?? 0); i++) {
       const contact = data[i];
       if (!contact) {
+        continue;
+      }
+      // Recipient-local calling window: leave out-of-window contacts queued
+      // for a later run instead of posting a call that /api/ivr would refuse
+      // anyway (it re-checks as the choke point).
+      if (!isWithinRecipientCallingWindow(contact.phone)) {
         continue;
       }
       const formData = new FormData();

--- a/app/routes/api+/ivr.action.server.ts
+++ b/app/routes/api+/ivr.action.server.ts
@@ -1,5 +1,6 @@
 import { data as routeData } from "react-router";
 import { dequeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import { recipientCallingWindowStatus } from "@/lib/recipient-calling-window";
 import { createErrorResponse } from "@/lib/errors.server";
 import {
   createWorkspaceTwilioInstance,
@@ -40,6 +41,23 @@ export const action = defineAction({
 
     try {
       await requireWorkspaceAccess({ user, workspaceId: workspace_id });
+
+      // Recipient-local calling window (TCPA/CRTC 8am–9pm recipient time).
+      // Return without dequeuing so the row stays `queued` for a later,
+      // in-window run.
+      const windowStatus = recipientCallingWindowStatus(to_number);
+      if (!windowStatus.allowed) {
+        logger.info("ivr.recipient_window_skip", {
+          campaignId: campaign_id,
+          queueId: queue_id,
+          timezone: windowStatus.timezone,
+          reason: windowStatus.reason,
+        });
+        return routeData(
+          { skipped: true, reason: "outside_recipient_calling_window" },
+          { status: 200 },
+        );
+      }
 
       const credits = await getWorkspaceCreditsBalance(workspace_id);
       if (credits === null) {

--- a/app/routes/api+/sms.action.server.ts
+++ b/app/routes/api+/sms.action.server.ts
@@ -32,6 +32,7 @@ import {
 } from "@/lib/throughput-config.server";
 import { parseOptionalString } from "@/lib/parse-utils.server";
 import { isWithinSendWindow, parseSendWindow } from "@/lib/campaign-send-window";
+import { recipientCallingWindowStatus } from "@/lib/recipient-calling-window";
 import { rpcCreateOutreachAttempt } from "@/lib/db-rpc.server";
 import { getOrLookupLineType, isSmsIncapableLineType } from "@/lib/twilio-lookup.server";
 import { createTenantDb } from "@/server/tenant-db";
@@ -349,6 +350,22 @@ export const action = defineAction({
       const batchResults = await Promise.all(
         batch.map(async member => {
           const normalizedPhone = normalizePhoneNumber(member.contact?.phone || "");
+
+          // Recipient-local quiet hours (CASL/TCPA — 8am–9pm recipient
+          // time). Unlike opt-out/landline/duplicate below, this is
+          // temporary: leave the row queued (no dequeue) so a later
+          // in-window dispatch picks it up.
+          const windowStatus = recipientCallingWindowStatus(normalizedPhone);
+          if (!windowStatus.allowed) {
+            return {
+              [member.contact_id]: {
+                success: true,
+                skipped: true,
+                deferred: true,
+                reason: "Outside recipient quiet-hours window",
+              },
+            };
+          }
 
           if (member.contact?.opt_out) {
             await dequeueCampaignQueueById({

--- a/test/auto-dial.server.test.ts
+++ b/test/auto-dial.server.test.ts
@@ -10,19 +10,46 @@ const envMock = vi.hoisted(() => ({
 
 vi.mock("@/lib/env.server", () => ({ env: envMock }));
 vi.mock("@/lib/logger.server", () => ({
-  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
 const rpcMocks = vi.hoisted(() => ({
   rpcCreateOutreachAttempt: vi.fn(),
+  rpcDequeueContact: vi.fn(),
 }));
 vi.mock("@/lib/db-rpc.server", () => ({
   rpcCreateOutreachAttempt: (...args: unknown[]) => rpcMocks.rpcCreateOutreachAttempt(...args),
+  rpcDequeueContact: (...args: unknown[]) => rpcMocks.rpcDequeueContact(...args),
 }));
 
 const claimNextQueueContactMock = vi.hoisted(() => vi.fn());
+const requeueCampaignQueueByIdMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/campaign-queue-db.server", () => ({
   claimNextQueueContact: (...args: unknown[]) => claimNextQueueContactMock(...args),
+  requeueCampaignQueueById: (...args: unknown[]) =>
+    requeueCampaignQueueByIdMock(...args),
+}));
+
+const twilioMocks = vi.hoisted(() => ({
+  callsCreate: vi.fn(),
+  conferencesList: vi.fn(async () => []),
+}));
+vi.mock("@/lib/database/workspace.server", () => ({
+  createWorkspaceTwilioInstance: vi.fn(async () => ({
+    calls: { create: (...args: unknown[]) => twilioMocks.callsCreate(...args) },
+    conferences: Object.assign(
+      () => ({ update: vi.fn(), participants: { list: vi.fn(async () => []) } }),
+      { list: (...args: unknown[]) => twilioMocks.conferencesList(...args) },
+    ),
+  })),
+}));
+
+const windowMock = vi.hoisted(() => ({
+  recipientCallingWindowStatus: vi.fn(),
+}));
+vi.mock("@/lib/recipient-calling-window", () => ({
+  recipientCallingWindowStatus: (...args: unknown[]) =>
+    windowMock.recipientCallingWindowStatus(...args),
 }));
 
 const tenantDbMocks = vi.hoisted(() => ({
@@ -49,6 +76,7 @@ import {
   createTwilioCall,
   getNextAutoDialQueueContact,
   normalizePhoneNumber,
+  runAutoDialerTurn,
   saveCallToDatabase,
 } from "../app/lib/auto-dial.server";
 
@@ -161,5 +189,87 @@ describe("auto-dial.server", () => {
     };
     await completeAllConferences(client as never, "user-1");
     expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  describe("runAutoDialerTurn recipient calling window", () => {
+    const turnInput = {
+      user_id: "user-1",
+      workspace_id: "ws-1",
+      campaign_id: 5,
+      conference_id: "user-1",
+      selected_device: "",
+    };
+    const contactA = {
+      queue_id: 11,
+      contact_id: 101,
+      contact_phone: "+17095550100",
+      caller_id: "+15555501001",
+    };
+    const contactB = {
+      queue_id: 12,
+      contact_id: 102,
+      contact_phone: "+16045550100",
+      caller_id: "+15555501001",
+    };
+    const blocked = {
+      allowed: false,
+      timezone: "America/St_Johns",
+      reason: "outside_window",
+    };
+    const open = {
+      allowed: true,
+      timezone: "America/Vancouver",
+      reason: "in_window",
+    };
+
+    test("requeues out-of-window contacts and stops without dialing", async () => {
+      // The released row is claimable again immediately; seeing it a second
+      // time proves everything claimable is out of window.
+      claimNextQueueContactMock
+        .mockResolvedValueOnce(contactA)
+        .mockResolvedValueOnce(contactA);
+      windowMock.recipientCallingWindowStatus.mockReturnValue(blocked);
+
+      const result = await runAutoDialerTurn(turnInput);
+
+      expect(requeueCampaignQueueByIdMock).toHaveBeenCalledTimes(2);
+      expect(requeueCampaignQueueByIdMock).toHaveBeenCalledWith(11, "ws-1");
+      expect(twilioMocks.callsCreate).not.toHaveBeenCalled();
+      expect(rpcMocks.rpcCreateOutreachAttempt).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: true,
+        message: "No contacts within recipient calling hours",
+      });
+    });
+
+    test("skips a blocked contact and dials the next in-window one", async () => {
+      claimNextQueueContactMock
+        .mockResolvedValueOnce(contactA)
+        .mockResolvedValueOnce(contactB);
+      windowMock.recipientCallingWindowStatus
+        .mockReturnValueOnce(blocked)
+        .mockReturnValueOnce(open);
+      rpcMocks.rpcCreateOutreachAttempt.mockResolvedValue(77);
+      twilioMocks.callsCreate.mockResolvedValue({
+        sid: "CA123",
+        status: "queued",
+      });
+      tenantDbMocks.findFirst.mockResolvedValue(null);
+      tenantDbMocks.insert.mockResolvedValue([{ sid: "CA123" }]);
+
+      const result = await runAutoDialerTurn(turnInput);
+
+      expect(requeueCampaignQueueByIdMock).toHaveBeenCalledTimes(1);
+      expect(requeueCampaignQueueByIdMock).toHaveBeenCalledWith(11, "ws-1");
+      expect(twilioMocks.callsCreate).toHaveBeenCalledTimes(1);
+      expect(twilioMocks.callsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ to: "+16045550100" }),
+      );
+      expect(rpcMocks.rpcDequeueContact).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ contactId: 102 }),
+      );
+      expect(result).toEqual({ success: true });
+    });
   });
 });

--- a/test/initiate-ivr.route.test.ts
+++ b/test/initiate-ivr.route.test.ts
@@ -18,6 +18,18 @@ const mocks = vi.hoisted(() => {
   };
 });
 
+// The recipient calling window is wall-clock dependent; pin it open so these
+// tests are not time-of-day sensitive (window logic is covered in
+// test/recipient-calling-window.test.ts).
+vi.mock("@/lib/recipient-calling-window", () => ({
+  recipientCallingWindowStatus: vi.fn(() => ({
+    allowed: true,
+    timezone: "America/Toronto",
+    reason: "in_window",
+  })),
+  isWithinRecipientCallingWindow: vi.fn(() => true),
+}));
+
 vi.mock("@/lib/database/workspace.server", () => ({
   requireWorkspaceAccess: (...a: any[]) => mocks.requireWorkspaceAccess(...a),
 }));

--- a/test/ivr.route.test.ts
+++ b/test/ivr.route.test.ts
@@ -23,6 +23,18 @@ const creditsState = vi.hoisted(() => ({
   credits: 10 as number | null,
 }));
 
+// The recipient calling window is wall-clock dependent; pin it open so these
+// tests are not time-of-day sensitive (window logic is covered in
+// test/recipient-calling-window.test.ts).
+vi.mock("@/lib/recipient-calling-window", () => ({
+  recipientCallingWindowStatus: vi.fn(() => ({
+    allowed: true,
+    timezone: "America/Toronto",
+    reason: "in_window",
+  })),
+  isWithinRecipientCallingWindow: vi.fn(() => true),
+}));
+
 vi.mock("../app/lib/database/workspace.server", () => ({
   createWorkspaceTwilioInstance: (...a: any[]) =>
     mocks.createWorkspaceTwilioInstance(...a),

--- a/test/recipient-calling-window.test.ts
+++ b/test/recipient-calling-window.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import {
+  areaCodeForPhone,
+  isWithinRecipientCallingWindow,
+  minutesOfDayInZone,
+  recipientCallingWindowStatus,
+  recipientTimezoneForPhone,
+} from "@/lib/recipient-calling-window";
+import { NANP_AREA_CODE_TIMEZONES } from "@/lib/nanp-timezones";
+
+describe("app/lib/recipient-calling-window", () => {
+  test("areaCodeForPhone handles E.164, national, and garbage", () => {
+    expect(areaCodeForPhone("+15551234567")).toBe("555");
+    expect(areaCodeForPhone("15551234567")).toBe("555");
+    expect(areaCodeForPhone("5551234567")).toBe("555");
+    expect(areaCodeForPhone("(416) 555-0100")).toBe("416");
+    expect(areaCodeForPhone("+442079460018")).toBeNull();
+    expect(areaCodeForPhone("123")).toBeNull();
+    expect(areaCodeForPhone(null)).toBeNull();
+    expect(areaCodeForPhone("")).toBeNull();
+  });
+
+  test("recipientTimezoneForPhone maps major markets", () => {
+    expect(recipientTimezoneForPhone("+12125550100")).toBe("America/New_York");
+    expect(recipientTimezoneForPhone("+14165550100")).toBe("America/Toronto");
+    expect(recipientTimezoneForPhone("+15145550100")).toBe("America/Toronto");
+    expect(recipientTimezoneForPhone("+13125550100")).toBe("America/Chicago");
+    expect(recipientTimezoneForPhone("+16045550100")).toBe("America/Vancouver");
+    expect(recipientTimezoneForPhone("+16025550100")).toBe("America/Phoenix");
+    expect(recipientTimezoneForPhone("+17095550100")).toBe("America/St_Johns");
+    expect(recipientTimezoneForPhone("+18085550100")).toBe("Pacific/Honolulu");
+    // Toll-free has no geography.
+    expect(recipientTimezoneForPhone("+18005550100")).toBeNull();
+  });
+
+  test("area code index contains no duplicates and only valid IANA zones", () => {
+    // buildAreaCodeIndex throws on duplicates at import time; verify zones
+    // resolve in Intl so a typo'd zone can't silently disable a region.
+    for (const zone of new Set(Object.values(NANP_AREA_CODE_TIMEZONES))) {
+      expect(
+        () => new Intl.DateTimeFormat("en-US", { timeZone: zone }),
+        `invalid IANA zone: ${zone}`,
+      ).not.toThrow();
+    }
+  });
+
+  test("minutesOfDayInZone computes local wall clock", () => {
+    // 2026-01-15T14:00:00Z: EST = UTC-5 → 09:00.
+    const winter = new Date("2026-01-15T14:00:00Z");
+    expect(minutesOfDayInZone("America/New_York", winter)).toBe(9 * 60);
+    // Same instant in Los Angeles: 06:00.
+    expect(minutesOfDayInZone("America/Los_Angeles", winter)).toBe(6 * 60);
+    // Newfoundland is UTC-3:30 in winter → 10:30.
+    expect(minutesOfDayInZone("America/St_Johns", winter)).toBe(10 * 60 + 30);
+    expect(minutesOfDayInZone("Not/AZone", winter)).toBeNull();
+  });
+
+  test("window respects DST transitions", () => {
+    // 2026-07-15T12:30:00Z: EDT = UTC-4 → 08:30 (allowed);
+    // in winter the same UTC time is 07:30 EST (blocked).
+    const summer = new Date("2026-07-15T12:30:00Z");
+    const winter = new Date("2026-01-15T12:30:00Z");
+    expect(isWithinRecipientCallingWindow("+12125550100", summer)).toBe(true);
+    expect(isWithinRecipientCallingWindow("+12125550100", winter)).toBe(false);
+    // Phoenix has no DST: 12:30Z is 05:30 MST year-round (blocked).
+    expect(isWithinRecipientCallingWindow("+16025550100", summer)).toBe(false);
+  });
+
+  test("blocks before 8am and at/after 9pm recipient time", () => {
+    // 2026-01-15T12:59Z = 07:59 EST → blocked; 13:00Z = 08:00 → allowed.
+    expect(
+      isWithinRecipientCallingWindow("+12125550100", new Date("2026-01-15T12:59:00Z")),
+    ).toBe(false);
+    expect(
+      isWithinRecipientCallingWindow("+12125550100", new Date("2026-01-15T13:00:00Z")),
+    ).toBe(true);
+    // 2026-01-16T01:59Z = 20:59 EST (allowed); 02:00Z = 21:00 → blocked.
+    expect(
+      isWithinRecipientCallingWindow("+12125550100", new Date("2026-01-16T01:59:00Z")),
+    ).toBe(true);
+    expect(
+      isWithinRecipientCallingWindow("+12125550100", new Date("2026-01-16T02:00:00Z")),
+    ).toBe(false);
+  });
+
+  test("unknown timezone degrades to the conservative all-zones window", () => {
+    // 2026-01-15T19:00:00Z: Honolulu 09:00, St. John's 15:30 — both inside.
+    const safe = new Date("2026-01-15T19:00:00Z");
+    // 2026-01-15T15:00:00Z: Honolulu 05:00 — Hawaii is outside the window.
+    const early = new Date("2026-01-15T15:00:00Z");
+    expect(recipientCallingWindowStatus("+18005550100", safe)).toEqual({
+      allowed: true,
+      timezone: null,
+      reason: "unknown_timezone_safe",
+    });
+    expect(recipientCallingWindowStatus("+18005550100", early)).toEqual({
+      allowed: false,
+      timezone: null,
+      reason: "unknown_timezone_blocked",
+    });
+    // Entirely non-NANP numbers get the same conservative treatment.
+    expect(recipientCallingWindowStatus("+442079460018", early).allowed).toBe(
+      false,
+    );
+  });
+
+  test("status reports the zone for known numbers", () => {
+    const status = recipientCallingWindowStatus(
+      "+16135550100",
+      new Date("2026-01-15T14:00:00Z"),
+    );
+    expect(status).toEqual({
+      allowed: true,
+      timezone: "America/Toronto",
+      reason: "in_window",
+    });
+  });
+});

--- a/test/sms-action.route.test.ts
+++ b/test/sms-action.route.test.ts
@@ -23,6 +23,18 @@ const mocks = vi.hoisted(() => ({
   env: { BASE_URL: () => "https://app.example" },
 }));
 
+// The recipient calling window is wall-clock dependent; pin it open so these
+// tests are not time-of-day sensitive (window logic is covered in
+// test/recipient-calling-window.test.ts).
+vi.mock("@/lib/recipient-calling-window", () => ({
+  recipientCallingWindowStatus: vi.fn(() => ({
+    allowed: true,
+    timezone: "America/Toronto",
+    reason: "in_window",
+  })),
+  isWithinRecipientCallingWindow: vi.fn(() => true),
+}));
+
 vi.mock("@/lib/api-auth.server", () => ({
   verifyApiKeyOrSession: (...args: unknown[]) => mocks.verifyApiKeyOrSession(...args),
 }));

--- a/test/sms.route.test.ts
+++ b/test/sms.route.test.ts
@@ -60,6 +60,18 @@ vi.mock("@client/client-js", () => ({
   createClient: (...args: any[]) => mocks.createClient(...args),
 }));
 
+// The recipient calling window is wall-clock dependent; pin it open so these
+// tests are not time-of-day sensitive (window logic is covered in
+// test/recipient-calling-window.test.ts).
+vi.mock("@/lib/recipient-calling-window", () => ({
+  recipientCallingWindowStatus: vi.fn(() => ({
+    allowed: true,
+    timezone: "America/Toronto",
+    reason: "in_window",
+  })),
+  isWithinRecipientCallingWindow: vi.fn(() => true),
+}));
+
 vi.mock("@/lib/api-auth.server", () => ({
   verifyApiKeyOrSession: (...args: any[]) => mocks.verifyApiKeyOrSession(...args),
 }));


### PR DESCRIPTION
**Stacked on #1085** (green-baseline chain; retarget to `dev` when it merges).

All schedule enforcement was campaign-level UTC — nothing considered the *recipient's* clock, which is how TCPA/CRTC calling windows are defined. This adds an 8am–9pm recipient-local gate, with timezone inferred from the contact's NANP area code (the standard commercial-dialer approach), to every machine-initiated outbound path: the auto-dial turn (skip + requeue with a bounded loop so an all-out-of-window queue idles instead of spinning), IVR fan-out + the /api/ivr choke point, and campaign SMS dispatch (deferred, not dequeued — rows stay queued for a later in-window run). Unknown/toll-free numbers degrade to a conservative window that holds across all NANP zones simultaneously. Manual single agent dials remain ungated — flagged as a follow-up product decision.

Also documented during discovery: the "predictive" dialer is structurally a rolling one-contact-per-agent power dialer (`dial_ratio` is read nowhere), so classic over-dial abandonment cannot occur today — an abandonment governor becomes relevant only if true predictive over-dialing is ever built.

Verification: dedicated unit tests for the zone map (duplicate/IANA validation), DST transitions, boundary minutes, and the conservative fallback; auto-dial turn tests for skip/requeue/idle; node suite 300/300; DRY/effects/handlers/lint gates green. The zone data is ~380 area codes grouped by zone with dominant-zone caveats documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)