### PR TITLE
Contact management: real householding, voice DNC path, import dedupe, jsonb custom fields

### DIFF
--- a/app/components/audience/AudienceUploadProgressPanel.tsx
+++ b/app/components/audience/AudienceUploadProgressPanel.tsx
@@ -14,10 +14,28 @@ export type AudienceUploadProgressPanelProps = {
   totalContacts: number;
   errorMessage?: string | null;
   warning?: string | null;
+  /** Rows dropped for invalid/unparseable phone numbers. */
+  skippedInvalidContacts?: number | null;
+  /** Rows dropped as duplicates (within the file or already in the audience). */
+  skippedDuplicateContacts?: number | null;
   /** When false (embedded), hide the terminal success chrome. */
   showCompletionChrome: boolean;
   onTryAgain: () => void;
 };
+
+function skippedSummary(
+  skippedDuplicateContacts: number,
+  skippedInvalidContacts: number,
+): string {
+  const parts: string[] = [];
+  if (skippedDuplicateContacts > 0) {
+    parts.push(`${skippedDuplicateContacts} duplicates skipped`);
+  }
+  if (skippedInvalidContacts > 0) {
+    parts.push(`${skippedInvalidContacts} invalid phone numbers skipped`);
+  }
+  return parts.join(" / ");
+}
 
 export function AudienceUploadProgressPanel({
   status,
@@ -26,9 +44,15 @@ export function AudienceUploadProgressPanel({
   totalContacts,
   errorMessage,
   warning,
+  skippedInvalidContacts,
+  skippedDuplicateContacts,
   showCompletionChrome,
   onTryAgain,
 }: AudienceUploadProgressPanelProps) {
+  const skippedLine = skippedSummary(
+    skippedDuplicateContacts ?? 0,
+    skippedInvalidContacts ?? 0,
+  );
   return (
     <div className="space-y-2">
       {errorMessage ? (
@@ -54,6 +78,10 @@ export function AudienceUploadProgressPanel({
         </span>
       </div>
       <Progress value={progress} className="h-2" />
+
+      {skippedLine ? (
+        <p className="text-xs text-muted-foreground">{skippedLine}</p>
+      ) : null}
 
       <div className="flex justify-center">
         {status === "completed" ? (

--- a/app/components/audience/AudienceUploader.tsx
+++ b/app/components/audience/AudienceUploader.tsx
@@ -321,6 +321,8 @@ export default function AudienceUploader({
                 processedContacts={phase.processedContacts}
                 totalContacts={phase.totalContacts}
                 warning={phase.warning}
+                skippedInvalidContacts={phase.skippedInvalidContacts}
+                skippedDuplicateContacts={phase.skippedDuplicateContacts}
                 showCompletionChrome
                 onTryAgain={resetProgress}
               />
@@ -335,6 +337,8 @@ export default function AudienceUploader({
                 progress={phase.progress}
                 processedContacts={phase.processedContacts}
                 totalContacts={phase.totalContacts}
+                skippedInvalidContacts={phase.skippedInvalidContacts}
+                skippedDuplicateContacts={phase.skippedDuplicateContacts}
                 showCompletionChrome
                 onTryAgain={resetProgress}
               />

--- a/app/components/audience/audience-upload-phase.ts
+++ b/app/components/audience/audience-upload-phase.ts
@@ -20,6 +20,10 @@ export type AudienceUploadServerSnapshot = {
   error_message?: string | null;
   audience_id?: string | number | null;
   stage?: string | null;
+  /** Rows dropped for invalid/unparseable phone numbers. */
+  skipped_invalid_contacts?: number | null;
+  /** Rows dropped as duplicates (within the file or already in the audience). */
+  skipped_duplicate_contacts?: number | null;
 };
 
 export type AudienceUploadProgressStatus =
@@ -33,6 +37,9 @@ type UploadCounters = {
   totalContacts: number;
   processedContacts: number;
   progress: number;
+  /** Import-time skip counters from the server snapshot (absent until known). */
+  skippedInvalidContacts?: number | null;
+  skippedDuplicateContacts?: number | null;
 };
 
 type SubmittingFields = UploadCounters & { warning: string | null };
@@ -94,6 +101,8 @@ export function resolveAudienceUploadPhase(args: {
         processedContacts: progress.processedContacts,
         progress: progress.progress,
         warning: progress.warning,
+        skippedInvalidContacts: progress.skippedInvalidContacts,
+        skippedDuplicateContacts: progress.skippedDuplicateContacts,
       };
     case "completed":
       return {
@@ -102,6 +111,8 @@ export function resolveAudienceUploadPhase(args: {
         totalContacts: progress.totalContacts,
         processedContacts: progress.processedContacts,
         progress: progress.progress,
+        skippedInvalidContacts: progress.skippedInvalidContacts,
+        skippedDuplicateContacts: progress.skippedDuplicateContacts,
       };
     case "error":
       if (!draft) return { kind: "file" };

--- a/app/components/audience/use-audience-upload-progress.ts
+++ b/app/components/audience/use-audience-upload-progress.ts
@@ -102,6 +102,15 @@ export function useAudienceUploadProgress({
         audienceIdRef.current = nextAudienceId;
       }
 
+      const skippedInvalidContacts =
+        typeof snapshot.skipped_invalid_contacts === "number"
+          ? snapshot.skipped_invalid_contacts
+          : (prev.skippedInvalidContacts ?? null);
+      const skippedDuplicateContacts =
+        typeof snapshot.skipped_duplicate_contacts === "number"
+          ? snapshot.skipped_duplicate_contacts
+          : (prev.skippedDuplicateContacts ?? null);
+
       if (nextStatus === "completed") {
         const completedAudienceId = nextAudienceId ?? audienceIdRef.current;
         if (!completedAudienceId) return prev;
@@ -112,6 +121,8 @@ export function useAudienceUploadProgress({
           totalContacts,
           processedContacts: serverProcessed ?? totalContacts,
           progress: 100,
+          skippedInvalidContacts,
+          skippedDuplicateContacts,
         };
       }
 
@@ -150,6 +161,8 @@ export function useAudienceUploadProgress({
           : prev.kind === "processing"
             ? prev.warning
             : null,
+        skippedInvalidContacts,
+        skippedDuplicateContacts,
       };
     });
   };

--- a/app/components/call/CallScreen.CallArea.tsx
+++ b/app/components/call/CallScreen.CallArea.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { callPanelShellClass } from "@/components/call/call-panel-classes";
+import { formatDispositionLabel } from "@/lib/outreach-disposition";
 
 type Attempt = Tables<"outreach_attempt">;
 type Call = Tables<"call">;
@@ -237,7 +238,10 @@ export function DispositionBar({
           <SelectItem value="idle">Select a disposition</SelectItem>
           {dispositionOptions?.map((option, index) => {
             const value = typeof option === "string" ? option : option.value;
-            const label = typeof option === "string" ? option : option.label;
+            const label =
+              typeof option === "string"
+                ? formatDispositionLabel(option)
+                : option.label;
             return (
               <SelectItem value={value} key={index}>
                 {label}

--- a/app/components/contact/ContactDetails.tsx
+++ b/app/components/contact/ContactDetails.tsx
@@ -214,12 +214,19 @@ const ContactDetails = React.forwardRef<
 
       <OtherDataFields
         otherData={(() => {
-          try {
-            const parsed = JSON.parse(contact?.other_data ?? '[]') as Json[];
-            return Array.isArray(parsed) ? parsed : [];
-          } catch {
-            return [];
+          // other_data is a jsonb array since 20260722110000; tolerate a
+          // legacy stringified value defensively (pre-migration snapshots).
+          const raw: unknown = contact?.other_data;
+          if (Array.isArray(raw)) return raw as Json[];
+          if (typeof raw === "string") {
+            try {
+              const parsed = JSON.parse(raw) as Json[];
+              return Array.isArray(parsed) ? parsed : [];
+            } catch {
+              return [];
+            }
           }
+          return [];
         })()}
         editMode={editMode}
         setContact={(data: ContactUpdateData) => {

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -20,6 +20,9 @@ import {
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import type { CoachingConfig } from "@/lib/coaching-schemas";
+// Type-only import; the cycle with db-types (which type-imports this module)
+// is erased at compile time and carries no runtime modules.
+import type { Json } from "@/lib/db-types";
 
 export {
   transcript_segment,
@@ -280,7 +283,7 @@ export const contact = pgTable("contact", {
   line_type: text(),
   line_type_checked_at: timestamp({ withTimezone: true, mode: "string" }),
   opt_out: boolean(),
-  other_data: text().notNull(),
+  other_data: jsonb().$type<Json[]>().notNull().default([]),
   phone: text(),
   postal: text(),
   province: text(),
@@ -330,7 +333,9 @@ export const audience_upload = pgTable("audience_upload", {
 });
 
 export const households = pgTable("households", {
-  id: text().notNull().primaryKey(),
+  // DB column is `uuid DEFAULT gen_random_uuid()` (drizzle/0000_baseline.sql);
+  // modeling it as text() made inserts demand an id the DB generates itself.
+  id: uuid().defaultRandom().notNull().primaryKey(),
   household_key: text().notNull(),
   workspace_id: uuid(),
   address: text(),

--- a/app/lib/audience-upload-db.server.ts
+++ b/app/lib/audience-upload-db.server.ts
@@ -1,11 +1,14 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import {
   audience as audienceTable,
   audience_upload as audienceUploadTable,
   campaign as campaignTable,
   campaign_audience as campaignAudienceTable,
+  contact as contactTable,
+  contact_audience as contactAudienceTable,
 } from "@/db/schema";
 import type { Json } from "@/lib/db-types";
+import { parsePhoneNumber } from "@/lib/phone";
 import { createTenantDb } from "@/server/tenant-db";
 import { db } from "@/server/db";
 
@@ -76,6 +79,37 @@ export async function createAudienceUploadRecord(args: {
     split_name_column: args.splitNameColumn,
   });
   return row ?? null;
+}
+
+/**
+ * Normalized (E.164) phone numbers of every contact already linked to the
+ * audience. Used by the upload processor to skip rows that would duplicate an
+ * existing audience member. Contacts without a parseable phone are skipped.
+ */
+export async function listAudiencePhones(
+  workspaceId: string,
+  audienceId: number,
+): Promise<Set<string>> {
+  const rows = await db
+    .select({ phone: contactTable.phone })
+    .from(contactAudienceTable)
+    .innerJoin(
+      contactTable,
+      eq(contactAudienceTable.contact_id, contactTable.id),
+    )
+    .where(
+      and(
+        eq(contactAudienceTable.audience_id, audienceId),
+        eq(contactTable.workspace, workspaceId),
+      ),
+    );
+
+  const phones = new Set<string>();
+  for (const row of rows) {
+    const normalized = parsePhoneNumber(row.phone ?? null);
+    if (normalized) phones.add(normalized);
+  }
+  return phones;
 }
 
 export async function findCampaignForAudienceUpload(

--- a/app/lib/audience-upload-process.server.ts
+++ b/app/lib/audience-upload-process.server.ts
@@ -5,14 +5,17 @@ import {
   isProcessingStale,
   PROCESSING_INTERRUPTED_MESSAGE,
 } from "@/lib/processing-watchdog.server";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import {
   audience as audienceTable,
   audience_upload as audienceUploadTable,
   contact_audience as contactAudienceTable,
+  households as householdsTable,
 } from "@/db/schema";
 import { db } from "@/server/db";
 import { createTenantDb } from "@/server/tenant-db";
+import { listAudiencePhones } from "@/lib/audience-upload-db.server";
+import { householdKeyFor } from "@/lib/household-key";
 import { parsePhoneNumber } from "@/lib/phone";
 import {
   AUDIENCE_UPLOAD_CHUNK_SIZE,
@@ -80,6 +83,92 @@ export function isOtherDataArray(
     'key' in item &&
     'value' in item
   );
+}
+
+/**
+ * Phone-based dedupe over the parsed CSV rows, run once before any chunking so
+ * `total_contacts` (the progress denominator) reflects only rows that will
+ * actually be processed.
+ *
+ * - Within-file duplicates: first occurrence wins; later rows with the same
+ *   normalized phone are dropped and counted.
+ * - Existing-audience duplicates: rows whose normalized phone is already in
+ *   `existingPhones` are dropped and counted.
+ * - Rows whose phone does not parse are NOT deduped here — they keep the
+ *   existing invalid-phone behavior downstream (skippedInvalidCount).
+ */
+export function dedupeParsedContacts(
+  rows: CSVContact[],
+  phoneHeader: string | null,
+  existingPhones: ReadonlySet<string>,
+): { rows: CSVContact[]; skippedDuplicateCount: number } {
+  if (!phoneHeader) {
+    return { rows, skippedDuplicateCount: 0 };
+  }
+
+  const seen = new Set<string>();
+  let skippedDuplicateCount = 0;
+  const deduped = rows.filter((row) => {
+    const normalized = parsePhoneNumber(row[phoneHeader] ?? null);
+    // Unparseable phones fall through to the invalid-phone skip downstream.
+    if (!normalized) return true;
+    if (seen.has(normalized) || existingPhones.has(normalized)) {
+      skippedDuplicateCount += 1;
+      return false;
+    }
+    seen.add(normalized);
+    return true;
+  });
+
+  return { rows: deduped, skippedDuplicateCount };
+}
+
+export type ChunkHouseholdPlanEntry = {
+  household_key: string;
+  address: string | null;
+  city: string | null;
+  province: string | null;
+  postal: string | null;
+};
+
+function asOptionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+/**
+ * Household stamping plan for one chunk of mapped contacts.
+ *
+ * `keys[i]` is the household key for `chunk[i]` (null when the row has no
+ * usable address+postal). `entries` holds the distinct keys in the chunk with
+ * address/city/province/postal populated from the FIRST row bearing each key —
+ * used to find-or-create `households` rows in a single batched insert.
+ */
+export function chunkHouseholdPlan(
+  // Loose record shape: reads address/city/province/postal when present.
+  chunk: ReadonlyArray<Record<string, unknown>>,
+): { entries: ChunkHouseholdPlanEntry[]; keys: Array<string | null> } {
+  const entries: ChunkHouseholdPlanEntry[] = [];
+  const seen = new Set<string>();
+
+  const keys = chunk.map((row) => {
+    const address = asOptionalString(row.address);
+    const postal = asOptionalString(row.postal);
+    const key = householdKeyFor(address, postal);
+    if (!key) return null;
+    if (!seen.has(key)) {
+      seen.add(key);
+      entries.push({
+        household_key: key,
+        address,
+        city: asOptionalString(row.city),
+        province: asOptionalString(row.province),
+        postal,
+      });
+    }
+    return key;
+  });
+
+  return { entries, keys };
 }
 
 // Generate a unique ID without using uuid package
@@ -223,9 +312,28 @@ export const processAudienceUpload = async (
     }
     const hasPhoneMapping = Object.values(headerMapping).includes("phone");
 
-    // Update total contacts count
+    // Resolve the actual CSV header (correct case) mapped to "phone".
+    const phoneMappingHeader =
+      Object.entries(headerMapping).find(([, target]) => target === "phone")?.[0] ??
+      null;
+    const phoneHeader = phoneMappingHeader
+      ? headerLookup.get(phoneMappingHeader.toLowerCase()) ?? null
+      : null;
+
+    // Phones already in this audience, for cross-upload dedupe. Only fetched
+    // when the upload maps a phone column (dedupe is phone-based).
+    const existingPhones: ReadonlySet<string> = phoneHeader
+      ? await listAudiencePhones(workspaceId, audienceId)
+      : new Set<string>();
+
+    // Drop within-file and already-in-audience duplicate phones up front.
+    const { rows: dedupedContacts, skippedDuplicateCount } =
+      dedupeParsedContacts(parsedContacts, phoneHeader, existingPhones);
+
+    // Update total contacts count. Duplicates are excluded from the
+    // denominator so progress percentages reflect rows actually processed.
     await tdb.audience_upload.update({
-      set: { total_contacts: parsedContacts.length },
+      set: { total_contacts: dedupedContacts.length },
       where: eq(audienceUploadTable.id, uploadId),
     });
 
@@ -244,8 +352,8 @@ export const processAudienceUpload = async (
           }
         : null;
 
-    for (let i = 0; i < parsedContacts.length; i += CHUNK_SIZE) {
-      const chunk = parsedContacts.slice(i, i + CHUNK_SIZE);
+    for (let i = 0; i < dedupedContacts.length; i += CHUNK_SIZE) {
+      const chunk = dedupedContacts.slice(i, i + CHUNK_SIZE);
 
       // Map the contacts according to the header mapping
       const mappedContacts = chunk.flatMap((contact: CSVContact) => {
@@ -329,6 +437,59 @@ export const processAudienceUpload = async (
 
       // Insert contacts
       if (mappedContacts.length > 0) {
+        // Household stamping: find-or-create households for the chunk's
+        // distinct address|postal keys (max 2 queries per chunk, never
+        // per-row), then stamp household_id onto each mapped contact.
+        const { entries: householdEntries, keys: householdKeys } =
+          chunkHouseholdPlan(mappedContacts);
+        if (householdEntries.length > 0) {
+          const householdNowIso = new Date().toISOString();
+          await db
+            .insert(householdsTable)
+            .values(
+              householdEntries.map((entry) => ({
+                // id: uuid DEFAULT gen_random_uuid() — generated by the DB.
+                household_key: entry.household_key,
+                workspace_id: workspaceId,
+                address: entry.address,
+                city: entry.city,
+                province: entry.province,
+                postal: entry.postal,
+                do_not_knock: false,
+                created_at: householdNowIso,
+                updated_at: householdNowIso,
+              })),
+            )
+            .onConflictDoNothing({
+              target: [householdsTable.workspace_id, householdsTable.household_key],
+            });
+
+          const householdRows = await db
+            .select({
+              id: householdsTable.id,
+              household_key: householdsTable.household_key,
+            })
+            .from(householdsTable)
+            .where(
+              and(
+                eq(householdsTable.workspace_id, workspaceId),
+                inArray(
+                  householdsTable.household_key,
+                  householdEntries.map((entry) => entry.household_key),
+                ),
+              ),
+            );
+          const householdIdByKey = new Map(
+            householdRows.map((row) => [row.household_key, row.id]),
+          );
+          mappedContacts.forEach((mapped, index) => {
+            const key = householdKeys[index];
+            if (!key) return;
+            const householdId = householdIdByKey.get(key);
+            if (householdId) mapped.household_id = householdId;
+          });
+        }
+
         const insertedContacts = await tdb.contact.insertMany(
           mappedContacts.map((contact) => ({
             ...contact,
@@ -365,30 +526,31 @@ export const processAudienceUpload = async (
         where: eq(audienceUploadTable.id, uploadId),
       });
 
-      const isLastChunk = i + CHUNK_SIZE >= parsedContacts.length;
+      const isLastChunk = i + CHUNK_SIZE >= dedupedContacts.length;
       const now = Date.now();
       if (
         audienceUploadShouldWriteStatus({
-          total: parsedContacts.length,
+          total: dedupedContacts.length,
           chunkSize: CHUNK_SIZE,
           isLastChunk,
           lastProgressAt,
           now,
         })
       ) {
-        const progress = Math.round((processedCount / parsedContacts.length) * 100);
+        const progress = Math.round((processedCount / dedupedContacts.length) * 100);
 
         await writeAudienceUploadStatus(workspaceId, uploadId, {
           ...statusData,
           progress,
-          stage: `Processing contacts (${processedCount}/${parsedContacts.length}; ${skippedInvalidCount} skipped)`,
+          stage: `Processing contacts (${processedCount}/${dedupedContacts.length}; ${skippedInvalidCount} skipped)`,
           skipped_invalid_contacts: skippedInvalidCount,
+          skipped_duplicate_contacts: skippedDuplicateCount,
         });
 
         lastProgressAt = now;
       }
 
-      const chunkDelayMs = audienceUploadChunkDelayMs(parsedContacts.length);
+      const chunkDelayMs = audienceUploadChunkDelayMs(dedupedContacts.length);
       if (chunkDelayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, chunkDelayMs));
       }
@@ -419,8 +581,9 @@ export const processAudienceUpload = async (
       ...statusData,
       status: "completed",
       progress: 100,
-      stage: `Upload completed (${importedCount} imported; ${skippedInvalidCount} skipped)`,
+      stage: `Upload completed (${importedCount} imported; ${skippedInvalidCount} invalid skipped; ${skippedDuplicateCount} duplicates skipped)`,
       skipped_invalid_contacts: skippedInvalidCount,
+      skipped_duplicate_contacts: skippedDuplicateCount,
     });
 
   } catch (error) {

--- a/app/lib/campaign-queue-db.server.ts
+++ b/app/lib/campaign-queue-db.server.ts
@@ -90,6 +90,8 @@ async function deleteCampaignQueueAndEmit(args: {
   return deleted;
 }
 
+const MAX_OPT_OUT_CLAIM_SKIPS = 10;
+
 /**
  * Atomically claim the next queued contact for a campaign.
  *
@@ -98,33 +100,59 @@ async function deleteCampaignQueueAndEmit(args: {
  * `FOR UPDATE SKIP LOCKED`. The row is updated to `status = 'assigned'` and
  * `assigned_to_user_id = userId` only if it is still queued. Returns the claimed
  * row only when the update succeeded.
+ *
+ * Claims whose contact has `opt_out = true` are dequeued and skipped (bounded
+ * by {@link MAX_OPT_OUT_CLAIM_SKIPS}); returns null when the bound is hit.
  */
 export async function claimNextQueueContact(
   tdb: TenantDb,
   campaignId: number,
   userId: string,
 ): Promise<ClaimedQueueContact | null> {
-  const rows = await tdb.execute(
-    sql`select * from claim_next_queue_contact(${campaignId}, ${userId}::uuid)`,
-  );
-  const row = rows[0] as ClaimedQueueContact | undefined;
-  if (!row || !row.queue_id) return null;
-
-  const [queueRow] = await db
-    .select()
-    .from(campaignQueueTable)
-    .where(eq(campaignQueueTable.id, row.queue_id))
-    .limit(1);
-  if (queueRow) {
-    await emitQueueEvent(
-      queueRow.workspace,
-      "UPDATE",
-      queueRow as Record<string, unknown>,
-      null,
+  for (let attempt = 0; attempt < MAX_OPT_OUT_CLAIM_SKIPS; attempt++) {
+    const rows = await tdb.execute(
+      sql`select * from claim_next_queue_contact(${campaignId}, ${userId}::uuid)`,
     );
-  }
+    const row = rows[0] as ClaimedQueueContact | undefined;
+    if (!row || !row.queue_id) return null;
 
-  return row;
+    const [queueRow] = await db
+      .select()
+      .from(campaignQueueTable)
+      .where(eq(campaignQueueTable.id, row.queue_id))
+      .limit(1);
+    if (queueRow) {
+      await emitQueueEvent(
+        queueRow.workspace,
+        "UPDATE",
+        queueRow as Record<string, unknown>,
+        null,
+      );
+    }
+
+    // Belt-and-suspenders opt-out guard: `claim_next_queue_contact` does not
+    // filter on `contact.opt_out`, so a contact opted out by a writer that did
+    // not also dequeue their rows could still be claimed. Dequeue such claims
+    // and try again (bounded so a queue full of opted-out rows can't loop
+    // forever).
+    const [contactRow] = await db
+      .select({ opt_out: contactTable.opt_out })
+      .from(contactTable)
+      .where(eq(contactTable.id, row.contact_id))
+      .limit(1);
+    if (contactRow?.opt_out) {
+      await dequeueCampaignQueueById({
+        queueId: row.queue_id,
+        userId,
+        reason: "Contact opted out",
+        workspaceId: queueRow?.workspace,
+      });
+      continue;
+    }
+
+    return row;
+  }
+  return null;
 }
 
 export function buildQueueStatusUpdatePayload(status: string) {
@@ -421,11 +449,14 @@ export async function resolveContactWorkspaceIdFromQueue(
   return row?.workspace ?? null;
 }
 
-/** Dequeue campaign_queue rows for a contact (optionally scoped to one campaign). */
+/**
+ * Dequeue campaign_queue rows for a contact (optionally scoped to one campaign).
+ * `userId` may be null for system-initiated dequeues (e.g. inbound SMS STOP).
+ */
 export async function dequeueCampaignQueueByContact(args: {
   contactId: number;
   campaignId?: number | null;
-  userId: string;
+  userId: string | null;
   reason: string;
   workspaceId?: string;
 }) {

--- a/app/lib/database/contact.server.ts
+++ b/app/lib/database/contact.server.ts
@@ -7,9 +7,15 @@ import { Contact } from "../types";
 import { logger } from "../logger.server";
 import { rpcFindContactByPhone } from "@/lib/db-rpc.server";
 import { buildContactSearchWhere } from "@/lib/contacts/search.server";
-import { audience as audienceTable, contact as contactTable, contact_audience } from "@/db/schema";
+import {
+  audience as audienceTable,
+  contact as contactTable,
+  contact_audience,
+  households as householdsTable,
+} from "@/db/schema";
 import { db } from "@/server/db";
 import { createTenantDb, type TenantDb } from "@/server/tenant-db";
+import { householdKeyFor } from "@/lib/household-key";
 
 function dedupeContactsById(contacts: Contact[]): Contact[] {
   return Array.from(
@@ -286,6 +292,62 @@ async function findOrCreateDefaultChatAudience(
   return created?.id ?? null;
 }
 
+/**
+ * Find-or-create the household for a contact's address within a workspace.
+ *
+ * Returns the household id, or null when the address/postal pair doesn't
+ * normalize to a household key (see app/lib/household-key.ts). Concurrency-safe
+ * via the households_workspace_key_uniq unique index: the insert is
+ * ON CONFLICT DO NOTHING, and a lost race falls through to selecting the row
+ * the winner created. The tenant-db wrapper doesn't expose onConflict, so this
+ * uses the raw db client with an explicit workspace_id (matching the
+ * contact_audience insert below).
+ */
+async function findOrCreateHouseholdId(
+  workspaceId: string,
+  fields: {
+    address?: string | null;
+    city?: string | null;
+    province?: string | null;
+    postal?: string | null;
+  },
+): Promise<string | null> {
+  const householdKey = householdKeyFor(fields.address ?? null, fields.postal ?? null);
+  if (!householdKey) return null;
+
+  const nowIso = new Date().toISOString();
+  const [inserted] = await db
+    .insert(householdsTable)
+    .values({
+      workspace_id: workspaceId,
+      household_key: householdKey,
+      address: fields.address ?? null,
+      city: fields.city ?? null,
+      province: fields.province ?? null,
+      postal: fields.postal ?? null,
+      do_not_knock: false,
+      created_at: nowIso,
+      updated_at: nowIso,
+    })
+    .onConflictDoNothing({
+      target: [householdsTable.workspace_id, householdsTable.household_key],
+    })
+    .returning({ id: householdsTable.id });
+  if (inserted) return inserted.id;
+
+  const [existing] = await db
+    .select({ id: householdsTable.id })
+    .from(householdsTable)
+    .where(
+      and(
+        eq(householdsTable.workspace_id, workspaceId),
+        eq(householdsTable.household_key, householdKey),
+      ),
+    )
+    .limit(1);
+  return existing?.id ?? null;
+}
+
 export const createContact = async (
   contactData: Partial<Contact>,
   audience_id: string,
@@ -306,7 +368,15 @@ export const createContact = async (
   }
 
   const tenantDb = opts?.tdb ?? createTenantDb(contactData.workspace);
-  const { workspace, firstname, surname, phone, email, address } = contactData;
+  const { workspace, firstname, surname, phone, email, address, city, province, postal } =
+    contactData;
+
+  const household_id = await findOrCreateHouseholdId(workspace, {
+    address,
+    city,
+    province,
+    postal,
+  });
 
   const [inserted] = await tenantDb.contact.insert({
     firstname,
@@ -314,6 +384,13 @@ export const createContact = async (
     phone,
     email,
     address,
+    city,
+    province,
+    postal,
+    household_id,
+    // Explicit empty jsonb array (matches the DB default) so the insert type
+    // stays satisfied independent of the schema-level default.
+    other_data: [],
     created_by: user_id,
   });
 

--- a/app/lib/household-key.ts
+++ b/app/lib/household-key.ts
@@ -1,0 +1,37 @@
+/**
+ * Canonical household key derivation (TS side).
+ *
+ * A "household" is identified within a workspace by a normalized
+ * `address|postal` key. Two contacts whose address + postal normalize to the
+ * same key belong to the same household.
+ *
+ * IMPORTANT: this function MUST stay in lockstep with the SQL function
+ * `public.household_key_for(addr text, postal text)` defined in
+ * client/migrations/20260722100000_households_backfill.sql — the backfill and
+ * any future SQL-side grouping use the SQL twin, while app-side inserts use
+ * this one. Parity is enforced by test/household-key-sql-parity.test.ts, which
+ * runs both implementations against the same fixture set on a real Postgres.
+ * If you change the normalization here, change the SQL function in a new
+ * migration and extend the parity fixtures.
+ *
+ * Normalization rules (identical in both implementations):
+ * - Address: lowercase, then every run of characters outside [a-z0-9] becomes
+ *   a single space (punctuation, unicode accents, and whitespace all collapse
+ *   to one space), then trim. "123 Main St., Apt #4" → "123 main st apt 4".
+ * - Postal: lowercase, then strip every character outside [a-z0-9].
+ *   "M5V 2T6" → "m5v2t6".
+ * - Returns null unless BOTH parts are non-empty after normalization.
+ * - Key: `${normalizedAddress}|${normalizedPostal}`.
+ */
+export function householdKeyFor(
+  address: string | null | undefined,
+  postal: string | null | undefined,
+): string | null {
+  const normalizedAddress = (address ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+  const normalizedPostal = (postal ?? "").toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (!normalizedAddress || !normalizedPostal) return null;
+  return `${normalizedAddress}|${normalizedPostal}`;
+}

--- a/app/lib/outreach-disposition.ts
+++ b/app/lib/outreach-disposition.ts
@@ -26,14 +26,52 @@ export function canTransitionOutreachDisposition(
 }
 
 /**
+ * Canonical "do not call" disposition. Always offered on the call screen and
+ * matched server-side to set `contact.opt_out` and dequeue the contact from
+ * every campaign.
+ */
+export const DNC_DISPOSITION = "do_not_call";
+
+const DISPOSITION_LABELS: Record<string, string> = {
+  [DNC_DISPOSITION]: "Do not call",
+};
+
+/**
+ * Canonical comparison key for disposition values: campaigns define options as
+ * free strings, so "Do Not Call", "do-not-call", and "do_not_call" must all
+ * count as the same disposition.
+ */
+function canonicalDisposition(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+/** True when a raw disposition value (or its display label) means "do not call". */
+export function isDncDisposition(value: string | null | undefined): boolean {
+  if (!value) return false;
+  return canonicalDisposition(value) === DNC_DISPOSITION;
+}
+
+/** Display label for a disposition option (falls back to the raw string). */
+export function formatDispositionLabel(option: string): string {
+  return DISPOSITION_LABELS[canonicalDisposition(option)] ?? option;
+}
+
+/**
  * `campaign.disposition_options` is a nullable jsonb column (`Json`), so it can be
  * null, a scalar, or an array of anything. Narrow it to the string list the call
  * screen expects instead of casting the `Json` away.
+ *
+ * Always appends {@link DNC_DISPOSITION} (deduped case/format-insensitively) so
+ * every campaign offers a "do not call" option regardless of its configuration.
  */
 export function normalizeDispositionOptions(value: unknown): string[] {
-  return Array.isArray(value)
+  const options = Array.isArray(value)
     ? value.filter((option): option is string => typeof option === "string")
     : [];
+  if (!options.some((option) => isDncDisposition(option))) {
+    options.push(DNC_DISPOSITION);
+  }
+  return options;
 }
 
 export function shouldUpdateOutreachDisposition(args: {

--- a/app/routes/api+/inbound-sms.action.server.ts
+++ b/app/routes/api+/inbound-sms.action.server.ts
@@ -14,6 +14,7 @@ import { createTenantDb } from "@/server/tenant-db";
 import { uploadObject } from "@/lib/object-storage.server";
 import { getWorkspaceMessagingOnboardingState } from "@/lib/messaging-onboarding.server";
 import { isOptOutMessage, parseOptOutKeywords } from "@/lib/chat-opt-out";
+import { dequeueCampaignQueueByContact } from "@/lib/campaign-queue-db.server";
 import { defineAction } from "@/lib/handler.server";
 import { emitChatMessageEvent } from "@/lib/workspace-events.server";
 
@@ -179,6 +180,23 @@ export const action = defineAction({
           set: { opt_out: true },
           where: inArray(contactTable.id, matchingContactIds),
         });
+        // Opted-out contacts must also leave every campaign queue in the
+        // workspace; log-don't-throw so the inbound message is still recorded.
+        try {
+          for (const contactId of matchingContactIds) {
+            await dequeueCampaignQueueByContact({
+              contactId,
+              userId: null,
+              reason: "Contact opted out via SMS",
+              workspaceId: workspaceNumber.workspace,
+            });
+          }
+        } catch (error) {
+          logger.error(
+            "Failed to dequeue opted-out contact from campaign queues:",
+            error,
+          );
+        }
       }
     } else if (body.toLowerCase() === "start" || body.toLowerCase() === '"start"') {
       // Onboarding only configures opt-out keywords today (no configurable

--- a/app/routes/api+/questions.action.server.ts
+++ b/app/routes/api+/questions.action.server.ts
@@ -7,7 +7,12 @@ import { requireJsonAuth } from "@/lib/api-auth.server";
 import { defineAction } from "@/lib/handler.server";
 import { rpcCreateOutreachAttempt } from "@/lib/db-rpc.server";
 import { createTenantDb } from "@/server/tenant-db";
-import { outreach_attempt as outreachAttemptTable } from "@/db/schema";
+import { dequeueCampaignQueueByContact } from "@/lib/campaign-queue-db.server";
+import { isDncDisposition } from "@/lib/outreach-disposition";
+import {
+  contact as contactTable,
+  outreach_attempt as outreachAttemptTable,
+} from "@/db/schema";
 import { and, eq, gte, desc } from "drizzle-orm";
 
 import type { Json } from "@/lib/db-types";
@@ -214,6 +219,26 @@ export const action = defineAction({
       },
       where: eq(outreachAttemptTable.id, outreachAttemptId),
     });
+
+    // "Do not call" side effects run AFTER the attempt is persisted: opt the
+    // contact out and pull them from every campaign queue in the workspace.
+    // Failures are logged but never fail the disposition save itself.
+    if (isDncDisposition(disposition)) {
+      try {
+        await tdb.contact.update({
+          set: { opt_out: true },
+          where: eq(contactTable.id, Number(contact_id)),
+        });
+        await dequeueCampaignQueueByContact({
+          contactId: Number(contact_id),
+          userId: user.id,
+          reason: "Do not call requested",
+          workspaceId: workspace,
+        });
+      } catch (error) {
+        logger.error("Do-not-call side effects failed after disposition save:", error);
+      }
+    }
 
     return routeData(finalUpdated, { headers });
   },

--- a/client/migrations/20260722100000_households_backfill.sql
+++ b/client/migrations/20260722100000_households_backfill.sql
@@ -1,0 +1,65 @@
+-- Householding, DB layer: canonical household-key function + backfill.
+--
+-- The `households` table has existed since the baseline (unique index
+-- households_workspace_key_uniq on (workspace_id, household_key), and
+-- contact.household_id FK → households(id) ON DELETE SET NULL), and
+-- dequeue_contact already groups queue entries by household_id — but nothing
+-- ever populated households, so household grouping was dead code.
+--
+-- This migration:
+--   1. Defines public.household_key_for(addr, postal) — the SQL twin of the
+--      TS `householdKeyFor` in app/lib/household-key.ts. The two MUST stay in
+--      lockstep; parity is enforced by test/household-key-sql-parity.test.ts.
+--      Normalization: address lowercased with every run of non-[a-z0-9]
+--      characters (punctuation, accents, whitespace) collapsed to a single
+--      space then trimmed; postal lowercased with all non-[a-z0-9] stripped.
+--      NULL unless both parts are non-empty after normalization.
+--      Key = normalized_address || '|' || normalized_postal.
+--   2. Backfills one households row per distinct (workspace, key) from
+--      existing contacts, then points contact.household_id at it.
+--
+-- Idempotent: ON CONFLICT DO NOTHING on the unique key, and the UPDATE only
+-- touches contacts whose household_id is still NULL.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.household_key_for(addr text, postal text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN parts.a = '' OR parts.p = '' THEN NULL
+    ELSE parts.a || '|' || parts.p
+  END
+  FROM (
+    SELECT
+      btrim(regexp_replace(lower(coalesce(addr, '')), '[^a-z0-9]+', ' ', 'g')) AS a,
+      regexp_replace(lower(coalesce(postal, '')), '[^a-z0-9]', '', 'g') AS p
+  ) AS parts;
+$$;
+
+-- One household per distinct (workspace, key); DISTINCT ON keeps the
+-- lowest-id contact's address fields as the household's display address.
+INSERT INTO public.households (workspace_id, household_key, address, city, province, postal)
+SELECT DISTINCT ON (c.workspace, public.household_key_for(c.address, c.postal))
+  c.workspace,
+  public.household_key_for(c.address, c.postal),
+  c.address,
+  c.city,
+  c.province,
+  c.postal
+FROM public.contact c
+WHERE public.household_key_for(c.address, c.postal) IS NOT NULL
+  AND c.workspace IS NOT NULL
+ORDER BY c.workspace, public.household_key_for(c.address, c.postal), c.id
+ON CONFLICT (workspace_id, household_key) DO NOTHING;
+
+UPDATE public.contact c
+SET household_id = h.id
+FROM public.households h
+WHERE c.household_id IS NULL
+  AND h.workspace_id = c.workspace
+  AND h.household_key = public.household_key_for(c.address, c.postal);
+
+COMMIT;

--- a/client/migrations/20260722110000_contact_other_data_jsonb.sql
+++ b/client/migrations/20260722110000_contact_other_data_jsonb.sql
@@ -1,0 +1,475 @@
+-- contact.other_data → plain jsonb (a single JSON array).
+--
+-- Pre-state (0000_baseline): `other_data jsonb[] DEFAULT '{}'::jsonb[] NOT NULL`
+-- — a Postgres ARRAY of jsonb values, not a JSON array. Note the app's
+-- hand-synced app/db/schema.ts had drifted and declared it `text` (hand-
+-- maintained-list drift); this migration is written to converge from any of
+-- the three observed pre-states (jsonb[], text, or already-converted jsonb).
+--
+-- Why: every writer passes a raw JS array of single-key objects
+-- (e.g. [{"Company": "Acme"}]) and every reader wants that array back.
+-- The jsonb[] column made drizzle/pg round-trips inconsistent (readers that
+-- JSON.parse got arrays-of-objects or strings depending on path), and the
+-- `get_campaign_*_chunk` RPCs already declare `other_data jsonb` while
+-- selecting the jsonb[] column — a latent runtime type mismatch that this
+-- conversion fixes.
+--
+-- Consequences handled here:
+--   * get_campaign_attempts / get_campaign_calls / get_campaign_messages
+--     declared `other_data jsonb[]` in RETURNS TABLE; a changed return type
+--     cannot be CREATE OR REPLACEd, so they are dropped and recreated with
+--     `other_data jsonb` (bodies otherwise identical to baseline).
+--   * get_outreach_data_column_definitions / _names / _structure and
+--     get_pivoted_outreach_data used `unnest(c.other_data)` (array-only);
+--     replaced with `jsonb_array_elements(...)` via CREATE OR REPLACE
+--     (return types unchanged).
+--   * Functions returning SETOF public.contact track the rowtype
+--     automatically and need no changes.
+--
+-- Safety / idempotency:
+--   * The type change is gated on information_schema so re-running against a
+--     database where the column is already jsonb is a no-op.
+--   * jsonb[] pre-state converts via to_jsonb(): '{}'::jsonb[] → '[]',
+--     ARRAY['{"a":1}'::jsonb] → '[{"a":1}]'.
+--   * text pre-state converts via a guarded cast helper that collapses
+--     invalid-JSON / NULL / blank rows to '[]' instead of aborting.
+--   * SET DEFAULT / SET NOT NULL and the function recreations are idempotent.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.try_cast_jsonb(input text)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+BEGIN
+  IF input IS NULL OR btrim(input) = '' THEN
+    RETURN '[]'::jsonb;
+  END IF;
+  RETURN input::jsonb;
+EXCEPTION WHEN others THEN
+  RETURN '[]'::jsonb;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_type text;
+BEGIN
+  SELECT data_type INTO v_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'contact'
+    AND column_name = 'other_data';
+
+  IF v_type = 'ARRAY' THEN
+    -- Real baseline pre-state: jsonb[]. The old '{}'::jsonb[] default cannot
+    -- be auto-cast to jsonb, so drop it before the type change (the new
+    -- default is set unconditionally below).
+    ALTER TABLE public.contact ALTER COLUMN other_data DROP DEFAULT;
+    ALTER TABLE public.contact
+      ALTER COLUMN other_data TYPE jsonb
+      USING to_jsonb(other_data);
+  ELSIF v_type = 'text' THEN
+    ALTER TABLE public.contact ALTER COLUMN other_data DROP DEFAULT;
+    ALTER TABLE public.contact
+      ALTER COLUMN other_data TYPE jsonb
+      USING public.try_cast_jsonb(other_data);
+  END IF;
+  -- v_type = 'jsonb': already converted; nothing to do.
+END;
+$$;
+
+DROP FUNCTION public.try_cast_jsonb(text);
+
+ALTER TABLE public.contact
+  ALTER COLUMN other_data SET DEFAULT '[]'::jsonb;
+
+ALTER TABLE public.contact
+  ALTER COLUMN other_data SET NOT NULL;
+
+-- ─── RPCs whose RETURNS TABLE declared other_data jsonb[] ─────────────────
+-- Return-type changes require DROP + CREATE (OR REPLACE refuses them).
+
+DROP FUNCTION IF EXISTS public.get_campaign_attempts(integer);
+
+CREATE FUNCTION public.get_campaign_attempts(p_campaign_id integer) RETURNS TABLE(attempt_id bigint, disposition text, attempt_result jsonb, attempt_start timestamp with time zone, call_sid text, duration_seconds bigint, answered_by text, call_start timestamp with time zone, call_end timestamp with time zone, contact_id bigint, firstname text, surname text, phone text, email text, address text, city text, opt_out boolean, created_at timestamp with time zone, workspace uuid, postal text, other_data jsonb, province text, country text, campaign_name text, campaign_start_date timestamp with time zone, campaign_end_date timestamp with time zone, campaign_type text, campaign_status text, credits_used bigint)
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        oa.id as attempt_id,
+        COALESCE(oa.disposition, c.status::text) as disposition,
+        oa.result as attempt_result,
+        oa.created_at as attempt_start,
+        c.sid as call_sid,
+        COALESCE(NULLIF(c.duration, '')::bigint, 0) as duration_seconds,
+        c.answered_by::text,
+        COALESCE(c.start_time, c.date_created)::timestamptz as call_start,
+        COALESCE(c.end_time, c.date_updated)::timestamptz as call_end,
+        con.id as contact_id,
+        con.firstname,
+        con.surname,
+        con.phone,
+        con.email,
+        con.address,
+        con.city,
+        con.opt_out,
+        con.created_at,
+        con.workspace,
+        con.postal,
+        con.other_data,
+        con.province,
+        con.country,
+        camp.title as campaign_name,
+        camp.start_date as campaign_start_date,
+        camp.end_date as campaign_end_date,
+        camp.type::text as campaign_type,
+        camp.status::text as campaign_status,
+        GREATEST(1, CEIL(COALESCE(NULLIF(c.duration, '')::numeric, 0) / 60))::bigint as credits_used
+    FROM public.outreach_attempt oa
+    JOIN contact con ON con.id = oa.contact_id
+    JOIN campaign camp ON camp.id = oa.campaign_id
+    LEFT JOIN public.call c ON c.outreach_attempt_id = oa.id
+    WHERE oa.campaign_id = p_campaign_id
+        AND (camp.type != 'live_call' OR c.parent_call_sid is not null)
+    ORDER BY attempt_start ASC;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.get_campaign_calls(uuid, bigint);
+
+CREATE FUNCTION public.get_campaign_calls(prop_workspace_id uuid, prop_campaign_id bigint) RETURNS TABLE(call_sid text, call_status public.call_status, call_direction text, call_duration integer, answered_by public.answered_by, recording_url text, call_start timestamp with time zone, call_end timestamp with time zone, attempt_id bigint, disposition text, attempt_result jsonb, current_step text, contact_id bigint, firstname text, surname text, phone text, email text, address text, city text, opt_out boolean, created_at timestamp with time zone, workspace text, postal text, other_data jsonb, province text, country text, campaign_name text, campaign_start_date timestamp with time zone, campaign_end_date timestamp with time zone, campaign_type public.campaign_type, campaign_status public.campaign_status)
+    LANGUAGE sql STABLE
+    AS $$
+    SELECT
+        c.sid as call_sid,
+        c.status as call_status,
+        c.direction as call_direction,
+        c.call_duration,
+        c.answered_by,
+        c.recording_url,
+        COALESCE(c.start_time, c.date_created)::timestamp with time zone as call_start,
+        COALESCE(c.end_time, c.date_updated)::timestamp with time zone as call_end,
+        oa.id as attempt_id,
+        oa.disposition,
+        oa.result as attempt_result,
+        oa.current_step,
+        con.id as contact_id,
+        con.firstname,
+        con.surname,
+        con.phone,
+        con.email,
+        con.address,
+        con.city,
+        con.opt_out,
+        con.created_at,
+        con.workspace,
+        con.postal,
+        con.other_data,
+        con.province,
+        con.country,
+        camp.title as campaign_name,
+        camp.start_date as campaign_start_date,
+        camp.end_date as campaign_end_date,
+        camp.type as campaign_type,
+        camp.status as campaign_status
+        FROM public.call c
+    JOIN campaign camp ON camp.id = c.campaign_id
+        AND (camp.type != 'live_call' OR c.parent_call_sid is not null)
+    JOIN outreach_attempt oa ON oa.id = c.outreach_attempt_id
+    JOIN contact con ON con.id = c.contact_id
+    WHERE c.workspace = prop_workspace_id
+        AND c.campaign_id = prop_campaign_id
+    ORDER BY call_start ASC;
+$$;
+
+DROP FUNCTION IF EXISTS public.get_campaign_messages(uuid, integer);
+
+CREATE FUNCTION public.get_campaign_messages(prop_workspace_id uuid, prop_campaign_id integer) RETURNS TABLE(body text, direction text, status text, message_date timestamp without time zone, id integer, firstname text, surname text, phone text, email text, address text, city text, opt_out boolean, created_at timestamp without time zone, workspace text, external_id text, address_id text, postal text, other_data jsonb, date_updated timestamp without time zone, carrier text, province text, country text, created_by text, contact_phone text, campaign_name text, campaign_start_date timestamp without time zone, campaign_end_date timestamp without time zone)
+    LANGUAGE sql SECURITY DEFINER
+    SET search_path TO 'public'
+    AS $$
+    -- Get campaign dates once to avoid repeated lookups
+    WITH campaign_info AS (
+        SELECT
+            id,
+            title,
+            start_date,
+            end_date + INTERVAL '5 days' AS extended_end_date,
+            end_date
+        FROM public.campaign
+        WHERE id = prop_campaign_id
+    ),
+    -- Get relevant contacts from campaign queue first (much smaller subset)
+    campaign_contacts AS (
+        SELECT
+            c.*,
+            REGEXP_REPLACE(c.phone, '[^0-9]', '', 'g') AS clean_phone,
+            SUBSTR(REGEXP_REPLACE(c.phone, '[^0-9]', '', 'g'), 2) AS clean_phone_no_country,
+            CONCAT('1', REGEXP_REPLACE(c.phone, '[^0-9]', '', 'g')) AS clean_phone_with_country
+        FROM public.contact c
+        JOIN public.campaign_queue cq ON c.id = cq.contact_id AND cq.campaign_id = prop_campaign_id
+        WHERE c.workspace = prop_workspace_id
+    ),
+    -- Get pre-filtered messages using campaign dates
+    filtered_messages AS (
+        SELECT
+            m.*,
+            REGEXP_REPLACE(m."from", '[^0-9]', '', 'g') AS clean_from,
+            REGEXP_REPLACE(m."to", '[^0-9]', '', 'g') AS clean_to,
+            COALESCE(m.date_sent, m.date_created) as message_date
+        FROM public.message m, campaign_info ci
+        WHERE
+            m.workspace = prop_workspace_id
+            AND m.date_created >= ci.start_date
+            AND m.date_created <= ci.extended_end_date
+    )
+    SELECT
+        m.body,
+        m.direction,
+        m.status,
+        m.message_date,
+        cc.id,
+        cc.firstname,
+        cc.surname,
+        cc.phone,
+        cc.email,
+        cc.address,
+        cc.city,
+        cc.opt_out,
+        cc.created_at,
+        cc.workspace,
+        cc.external_id,
+        -- contact.address_id / contact.carrier no longer exist; the baseline
+        -- dump created this function unvalidated (check_function_bodies=false)
+        -- so the stale references only blew up at call time. Keep the return
+        -- shape, return NULLs.
+        NULL::text AS address_id,
+        cc.postal,
+        cc.other_data,
+        cc.date_updated,
+        NULL::text AS carrier,
+        cc.province,
+        cc.country,
+        cc.created_by,
+        cc.clean_phone as contact_phone,
+        ci.title as campaign_name,
+        ci.start_date as campaign_start_date,
+        ci.end_date as campaign_end_date
+    FROM filtered_messages m
+    JOIN campaign_info ci ON 1=1
+    JOIN campaign_contacts cc ON (
+        cc.clean_phone = m.clean_from
+        OR cc.clean_phone = m.clean_to
+        OR cc.clean_phone_no_country = m.clean_from
+        OR cc.clean_phone_no_country = m.clean_to
+        OR cc.clean_phone_with_country = m.clean_from
+        OR cc.clean_phone_with_country = m.clean_to
+    )
+    ORDER BY m.message_date ASC;
+$$;
+
+-- ─── Legacy export helpers that unnest()ed the jsonb[] column ─────────────
+-- unnest() only works on Postgres arrays; the jsonb equivalent is
+-- jsonb_array_elements(). Return types are unchanged, so OR REPLACE is fine.
+
+CREATE OR REPLACE FUNCTION public.get_outreach_data_column_definitions(campaign_id_param integer) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    dynamic_columns TEXT;
+    result_columns TEXT;
+BEGIN
+    -- Get all possible keys
+    SELECT string_agg(
+        format('%I TEXT', key),
+        ', '
+    ) INTO dynamic_columns
+    FROM (
+        SELECT DISTINCT jsonb_object_keys(unnested_data) AS key
+        FROM outreach_attempt oa
+        LEFT JOIN contact c ON oa.contact_id = c.id
+        LEFT JOIN LATERAL jsonb_array_elements(c.other_data) AS unnested_data ON TRUE
+        WHERE oa.campaign_id = campaign_id_param
+    ) all_keys;
+
+    -- Construct the result columns list
+    result_columns := '
+        outreach_attempt_id BIGINT,
+        disposition TEXT,
+        call_duration INTERVAL,
+        firstname TEXT,
+        surname TEXT,
+        phone TEXT,
+        username TEXT,
+        created_at TIMESTAMP WITH TIME ZONE,
+        full_result JSONB,
+        ' || COALESCE(dynamic_columns, '');
+
+    RETURN result_columns;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_outreach_data_column_names(campaign_id_param integer) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    dynamic_columns TEXT;
+    result_columns TEXT;
+BEGIN
+    -- Get all possible keys
+    SELECT string_agg(
+        format('%I', key),
+        ', '
+    ) INTO dynamic_columns
+    FROM (
+        SELECT DISTINCT jsonb_object_keys(unnested_data) AS key
+        FROM outreach_attempt oa
+        LEFT JOIN contact c ON oa.contact_id = c.id
+        LEFT JOIN LATERAL jsonb_array_elements(c.other_data) AS unnested_data ON TRUE
+        WHERE oa.campaign_id = campaign_id_param
+    ) all_keys;
+
+    -- Construct the result columns list
+    result_columns := '
+        outreach_attempt_id,
+        disposition,
+        call_duration,
+        firstname,
+        surname,
+        phone,
+        username,
+        created_at,
+        full_result,
+        ' || COALESCE(dynamic_columns, '');
+
+    RETURN result_columns;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_outreach_data_column_structure(campaign_id_param integer) RETURNS text
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    dynamic_columns TEXT;
+    result_columns TEXT;
+BEGIN
+    -- Get all possible keys
+    SELECT string_agg(
+        format('%I TEXT', key),
+        ', '
+    ) INTO dynamic_columns
+    FROM (
+        SELECT DISTINCT jsonb_object_keys(unnested_data) AS key
+        FROM outreach_attempt oa
+        LEFT JOIN contact c ON oa.contact_id = c.id
+        LEFT JOIN LATERAL jsonb_array_elements(c.other_data) AS unnested_data ON TRUE
+        WHERE oa.campaign_id = campaign_id_param
+    ) all_keys;
+
+    -- Construct the result columns list
+    result_columns := '
+        outreach_attempt_id BIGINT,
+        disposition TEXT,
+        call_duration INTERVAL,
+        firstname TEXT,
+        surname TEXT,
+        phone TEXT,
+        username TEXT,
+        created_at TIMESTAMP WITH TIME ZONE,
+        full_result JSONB,
+        ' || dynamic_columns;
+
+    RETURN result_columns;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_pivoted_outreach_data(campaign_id_param integer) RETURNS SETOF record
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    dynamic_columns TEXT;
+    query TEXT;
+    result_columns TEXT;
+BEGIN
+    -- Get all possible keys
+    SELECT string_agg(
+        format('MAX(CASE WHEN (ed.unnested_data->>%L) IS NOT NULL THEN ed.unnested_data->>%L END) AS %I', key, key, key),
+        ', '
+    ) INTO dynamic_columns
+    FROM (
+        SELECT DISTINCT jsonb_object_keys(unnested_data) AS key
+        FROM outreach_attempt oa
+        LEFT JOIN contact c ON oa.contact_id = c.id
+        LEFT JOIN LATERAL jsonb_array_elements(c.other_data) AS unnested_data ON TRUE
+        WHERE oa.campaign_id = campaign_id_param
+    ) all_keys;
+
+    -- Construct the result columns list
+    result_columns := '
+        outreach_attempt_id BIGINT,
+        disposition TEXT,
+        call_duration INTERVAL,
+        firstname TEXT,
+        surname TEXT,
+        phone TEXT,
+        username TEXT,
+        created_at TIMESTAMP WITH TIME ZONE,
+        full_result JSONB,
+        ' || dynamic_columns;
+
+    -- Construct the query
+    query := format('
+        WITH expanded_data AS (
+            SELECT
+                oa.id AS outreach_attempt_id,
+                oa.disposition,
+                oa.ended_at - oa.created_at AS call_duration,
+                c.firstname,
+                c.surname,
+                c.phone,
+                u.username,
+                oa.created_at,
+                oa.result AS full_result,
+                unnested_data
+            FROM
+                outreach_attempt oa
+                LEFT JOIN contact c ON oa.contact_id = c.id
+                LEFT JOIN public.user u ON oa.user_id = u.id::uuid
+                LEFT JOIN LATERAL jsonb_array_elements(c.other_data) AS unnested_data ON TRUE
+            WHERE
+                oa.campaign_id = %s
+        )
+        SELECT
+            ed.outreach_attempt_id,
+            ed.disposition,
+            ed.call_duration,
+            ed.firstname,
+            ed.surname,
+            ed.phone,
+            ed.username,
+            ed.created_at,
+            ed.full_result,
+            %s
+        FROM
+            expanded_data ed
+        GROUP BY
+            ed.outreach_attempt_id,
+            ed.disposition,
+            ed.call_duration,
+            ed.firstname,
+            ed.surname,
+            ed.phone,
+            ed.username,
+            ed.created_at,
+            ed.full_result
+    ', campaign_id_param, dynamic_columns);
+
+    -- Execute the query
+    RETURN QUERY EXECUTE query;
+END;
+$$;
+
+COMMIT;

--- a/scripts/e2e/bootstrap-compose-db.mjs
+++ b/scripts/e2e/bootstrap-compose-db.mjs
@@ -48,6 +48,8 @@ const steps = [
   "client/migrations/20260716120000_fix_handle_campaign_queue_entry_queue_state.sql",
   "client/migrations/20260716130000_fix_remaining_queue_dial_rpcs.sql",
   "client/migrations/20260716140000_fix_dequeue_contact_bigint.sql",
+  "client/migrations/20260722100000_households_backfill.sql",
+  "client/migrations/20260722110000_contact_other_data_jsonb.sql",
 ];
 
 /**

--- a/test/audience-upload-dedupe.test.ts
+++ b/test/audience-upload-dedupe.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, vi } from "vitest";
+
+// The pure helpers under test live in a .server module whose siblings touch
+// the DB and object storage at import time in some configs — stub those out
+// so this suite stays DB-free.
+vi.mock("@/server/db", () => ({ db: {}, dbDirect: {} }));
+vi.mock("@/server/tenant-db", () => ({ createTenantDb: vi.fn() }));
+vi.mock("@/lib/object-storage.server", () => ({ uploadObject: vi.fn() }));
+vi.mock("@/lib/audience-upload-db.server", () => ({
+  listAudiencePhones: vi.fn(async () => new Set<string>()),
+}));
+
+import {
+  chunkHouseholdPlan,
+  dedupeParsedContacts,
+} from "../app/lib/audience-upload-process.server";
+
+describe("dedupeParsedContacts", () => {
+  test("within-file duplicates: first occurrence wins and later rows are counted", () => {
+    const rows = [
+      { Phone: "(416) 555-1234", Name: "First" },
+      { Phone: "4165551234", Name: "Same phone, different format" },
+      { Phone: "+14165551234", Name: "Same phone, E.164" },
+      { Phone: "416-555-9999", Name: "Different phone" },
+    ];
+
+    const result = dedupeParsedContacts(rows, "Phone", new Set());
+
+    expect(result.rows).toEqual([rows[0], rows[3]]);
+    expect(result.skippedDuplicateCount).toBe(2);
+  });
+
+  test("existing-audience phones are skipped and counted", () => {
+    const rows = [
+      { Phone: "416-555-0000" },
+      { Phone: "416-555-1111" },
+    ];
+    const existing = new Set(["+14165550000"]);
+
+    const result = dedupeParsedContacts(rows, "Phone", existing);
+
+    expect(result.rows).toEqual([rows[1]]);
+    expect(result.skippedDuplicateCount).toBe(1);
+  });
+
+  test("invalid phones are NOT deduped (kept for the downstream invalid-skip path)", () => {
+    const rows = [
+      { Phone: "123" },
+      { Phone: "123" },
+      { Phone: "" },
+      { Phone: "" },
+    ];
+
+    const result = dedupeParsedContacts(rows, "Phone", new Set());
+
+    expect(result.rows).toEqual(rows);
+    expect(result.skippedDuplicateCount).toBe(0);
+  });
+
+  test("no phone header: rows pass through untouched", () => {
+    const rows = [{ Name: "A" }, { Name: "A" }];
+
+    const result = dedupeParsedContacts(rows, null, new Set(["+14165551234"]));
+
+    expect(result.rows).toBe(rows);
+    expect(result.skippedDuplicateCount).toBe(0);
+  });
+
+  test("a within-file duplicate of an existing phone counts once per dropped row", () => {
+    const rows = [
+      { Phone: "4165550000" }, // duplicate of existing
+      { Phone: "4165550000" }, // duplicate again
+      { Phone: "4165552222" },
+    ];
+    const existing = new Set(["+14165550000"]);
+
+    const result = dedupeParsedContacts(rows, "Phone", existing);
+
+    expect(result.rows).toEqual([rows[2]]);
+    expect(result.skippedDuplicateCount).toBe(2);
+  });
+});
+
+describe("chunkHouseholdPlan", () => {
+  test("groups rows by normalized address|postal key; first row bearing a key populates the entry", () => {
+    const chunk = [
+      {
+        address: "123 Main St., Apt #4",
+        postal: "M5V 2T6",
+        city: "Toronto",
+        province: "ON",
+      },
+      {
+        // Same household, different formatting; different city should NOT win.
+        address: "123 main st apt 4",
+        postal: "m5v2t6",
+        city: "Somewhere Else",
+        province: "QC",
+      },
+      {
+        address: "9 Elm Road",
+        postal: "K1A 0B1",
+        city: undefined,
+        province: undefined,
+      },
+    ];
+
+    const { entries, keys } = chunkHouseholdPlan(chunk);
+
+    expect(keys).toEqual([
+      "123 main st apt 4|m5v2t6",
+      "123 main st apt 4|m5v2t6",
+      "9 elm road|k1a0b1",
+    ]);
+    expect(entries).toEqual([
+      {
+        household_key: "123 main st apt 4|m5v2t6",
+        address: "123 Main St., Apt #4",
+        postal: "M5V 2T6",
+        city: "Toronto",
+        province: "ON",
+      },
+      {
+        household_key: "9 elm road|k1a0b1",
+        address: "9 Elm Road",
+        postal: "K1A 0B1",
+        city: null,
+        province: null,
+      },
+    ]);
+  });
+
+  test("rows without a usable address+postal get a null key and no entry", () => {
+    const chunk = [
+      { address: "123 Main St", postal: undefined },
+      { address: undefined, postal: "M5V 2T6" },
+      { address: "   ", postal: "M5V 2T6" },
+      { address: undefined, postal: undefined },
+    ];
+
+    const { entries, keys } = chunkHouseholdPlan(chunk);
+
+    expect(keys).toEqual([null, null, null, null]);
+    expect(entries).toEqual([]);
+  });
+
+  test("non-string mapped values are treated as absent", () => {
+    const chunk = [{ address: 42 as unknown, postal: "M5V 2T6" }];
+
+    const { entries, keys } = chunkHouseholdPlan(chunk);
+
+    expect(keys).toEqual([null]);
+    expect(entries).toEqual([]);
+  });
+});

--- a/test/audience-upload.route.test.ts
+++ b/test/audience-upload.route.test.ts
@@ -78,6 +78,8 @@ vi.mock("@/server/db", () => ({
   },
 }));
 vi.mock("@/lib/audience-upload-db.server", () => ({
+  // processAudienceUpload dedupes against phones already in the audience.
+  listAudiencePhones: vi.fn(async () => new Set<string>()),
   findAudienceInWorkspace: (...args: unknown[]) => dbMocks.findAudienceInWorkspace(...args),
   markAudienceUpdating: (...args: unknown[]) => dbMocks.markAudienceUpdating(...args),
   createAudienceForUpload: (...args: unknown[]) => dbMocks.createAudienceForUpload(...args),

--- a/test/call-screen.server.test.ts
+++ b/test/call-screen.server.test.ts
@@ -216,7 +216,7 @@ describe("call-screen.server", () => {
     expect(result.completedCount).toBe(4);
   });
 
-  test("getCallScreenData defaults null disposition_options to an empty array", async () => {
+  test("getCallScreenData defaults null disposition_options to the DNC-only list", async () => {
     tenantDbMocks.fetchCampaignWithScriptForWorkspace.mockResolvedValue({
       id: 1,
       script: null,
@@ -226,12 +226,13 @@ describe("call-screen.server", () => {
     tenantDbMocks.callFindMany.mockResolvedValue([]);
 
     const result = await getCallScreenData("1", "ws-1", "user-1");
-    expect(result.campaignDetails.disposition_options).toEqual([]);
+    // "do_not_call" is always offered, even for unconfigured campaigns.
+    expect(result.campaignDetails.disposition_options).toEqual(["do_not_call"]);
     // The call screen maps over this directly — it must never be null.
     expect(() => result.campaignDetails.disposition_options.map((o) => o)).not.toThrow();
   });
 
-  test("getCallScreenData narrows non-string disposition_options entries", async () => {
+  test("getCallScreenData narrows non-string disposition_options entries and appends do_not_call", async () => {
     tenantDbMocks.fetchCampaignWithScriptForWorkspace.mockResolvedValue({
       id: 1,
       script: null,
@@ -241,6 +242,10 @@ describe("call-screen.server", () => {
     tenantDbMocks.callFindMany.mockResolvedValue([]);
 
     const result = await getCallScreenData("1", "ws-1", "user-1");
-    expect(result.campaignDetails.disposition_options).toEqual(["answered", "busy"]);
+    expect(result.campaignDetails.disposition_options).toEqual([
+      "answered",
+      "busy",
+      "do_not_call",
+    ]);
   });
 });

--- a/test/campaign-queue-db.claim.test.ts
+++ b/test/campaign-queue-db.claim.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * Unit tests for the opt-out claim guard in claimNextQueueContact
+ * (app/lib/campaign-queue-db.server.ts): the claim_next_queue_contact RPC does
+ * not filter on contact.opt_out, so the TS wrapper must dequeue opted-out
+ * claims and try again (bounded).
+ */
+
+const dbMocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+}));
+
+const emitQueueEventMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@/server/db", () => ({ db: dbMocks }));
+vi.mock("@/lib/workspace-events.server", () => ({
+  emitQueueEvent: (...args: unknown[]) => emitQueueEventMock(...args),
+}));
+
+// Per-test responder: returns the rows for the Nth db.select() call.
+let selectResponder: (callIndex: number) => unknown[] = () => [];
+let selectCallCount = 0;
+
+// Captured `set` payloads from db.update().set(...) calls.
+let updateSetCalls: unknown[] = [];
+
+function installDbMockImplementations() {
+  dbMocks.select.mockImplementation(() => {
+    const callIndex = selectCallCount++;
+    const chain: any = {
+      from: () => chain,
+      where: () => chain,
+      limit: () => Promise.resolve(selectResponder(callIndex)),
+      then: (onFulfilled: any, onRejected: any) =>
+        Promise.resolve(selectResponder(callIndex)).then(onFulfilled, onRejected),
+    };
+    return chain;
+  });
+  dbMocks.update.mockImplementation(() => ({
+    set: (setPayload: unknown) => {
+      updateSetCalls.push(setPayload);
+      return {
+        where: () => ({
+          returning: () => Promise.resolve([{ id: 999, workspace: "w1" }]),
+        }),
+      };
+    },
+  }));
+}
+
+function makeTdb(executeMock: ReturnType<typeof vi.fn>) {
+  return { execute: executeMock } as any;
+}
+
+const claimRow = (contactId: number, queueId: number) => ({
+  contact_id: contactId,
+  queue_id: queueId,
+  caller_id: "+15550001111",
+  contact_phone: "+15550002222",
+});
+
+describe("claimNextQueueContact opt-out guard", () => {
+  beforeEach(() => {
+    dbMocks.select.mockReset();
+    dbMocks.update.mockReset();
+    emitQueueEventMock.mockClear();
+    selectCallCount = 0;
+    updateSetCalls = [];
+    selectResponder = () => [];
+    installDbMockImplementations();
+  });
+
+  test("returns the claimed row when the contact is not opted out", async () => {
+    const { claimNextQueueContact } = await import("@/lib/campaign-queue-db.server");
+    const execute = vi.fn().mockResolvedValueOnce([claimRow(5, 11)]);
+    // Call order: queue row lookup, then contact opt_out lookup.
+    const responses = [[{ id: 11, workspace: "w1" }], [{ opt_out: false }]];
+    selectResponder = (i) => responses[i] ?? [];
+
+    const result = await claimNextQueueContact(makeTdb(execute), 1, "user-1");
+
+    expect(result).toEqual(claimRow(5, 11));
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  test("returns null when no row is claimed", async () => {
+    const { claimNextQueueContact } = await import("@/lib/campaign-queue-db.server");
+    const execute = vi.fn().mockResolvedValueOnce([]);
+
+    const result = await claimNextQueueContact(makeTdb(execute), 1, "user-1");
+
+    expect(result).toBeNull();
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(dbMocks.select).not.toHaveBeenCalled();
+  });
+
+  test("dequeues an opted-out claim and returns the next non-opted-out contact", async () => {
+    const { claimNextQueueContact } = await import("@/lib/campaign-queue-db.server");
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([claimRow(5, 11)])
+      .mockResolvedValueOnce([claimRow(6, 12)]);
+    const responses = [
+      // iteration 1: queue row, opted-out contact, dequeue's old-rows read
+      [{ id: 11, workspace: "w1" }],
+      [{ opt_out: true }],
+      [{ id: 11, workspace: "w1" }],
+      // iteration 2: queue row, contact ok
+      [{ id: 12, workspace: "w1" }],
+      [{ opt_out: false }],
+    ];
+    selectResponder = (i) => responses[i] ?? [];
+
+    const result = await claimNextQueueContact(makeTdb(execute), 1, "user-1");
+
+    expect(result).toEqual(claimRow(6, 12));
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(dbMocks.update).toHaveBeenCalledTimes(1);
+    expect(updateSetCalls[0]).toMatchObject({
+      queue_state: "dequeued",
+      dequeued_by: "user-1",
+      dequeued_reason: "Contact opted out",
+    });
+  });
+
+  test("gives up after 10 opted-out claims and returns null", async () => {
+    const { claimNextQueueContact } = await import("@/lib/campaign-queue-db.server");
+    const execute = vi.fn().mockResolvedValue([claimRow(5, 11)]);
+    // Every iteration: queue row, opted-out contact, dequeue's old-rows read.
+    selectResponder = (i) => {
+      const step = i % 3;
+      if (step === 0) return [{ id: 11, workspace: "w1" }];
+      if (step === 1) return [{ opt_out: true }];
+      return [{ id: 11, workspace: "w1" }];
+    };
+
+    const result = await claimNextQueueContact(makeTdb(execute), 1, "user-1");
+
+    expect(result).toBeNull();
+    expect(execute).toHaveBeenCalledTimes(10);
+    expect(dbMocks.update).toHaveBeenCalledTimes(10);
+  });
+});

--- a/test/household-key-sql-parity.test.ts
+++ b/test/household-key-sql-parity.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { householdKeyFor } from "../app/lib/household-key";
+
+/**
+ * app/lib/household-key.ts (TS) and public.household_key_for (SQL, defined in
+ * client/migrations/20260722100000_households_backfill.sql) are twin
+ * implementations of the household-key normalization: the app derives keys at
+ * contact-creation time while the migration backfill (and any future SQL-side
+ * grouping) derives them in Postgres. If they drift, contacts silently land in
+ * different households depending on which code path touched them.
+ *
+ * This suite runs both implementations over the same fixture set against a
+ * real Postgres (the docker-compose stack used by `npm run test:e2e:compose`).
+ * It self-skips when no reachable Postgres is configured, matching
+ * test/workspace-conversations-sql-parity.test.ts — run
+ * `docker compose -f docker-compose.dev.yml up -d postgres` and set
+ * PARITY_DATABASE_URL (or DATABASE_URL) to exercise it locally.
+ */
+
+const CANDIDATE_URL =
+  process.env.PARITY_DATABASE_URL ??
+  (process.env.DATABASE_URL?.includes("localhost:5432/test")
+    ? undefined
+    : process.env.DATABASE_URL) ??
+  "postgresql://callcaster:callcaster@127.0.0.1:5433/callcaster";
+
+/** [address, postal] pairs covering every normalization rule. */
+const FIXTURES: Array<[string | null, string | null]> = [
+  // Mixed case + punctuation.
+  ["123 Main St., Apt #4", "M5V 2T6"],
+  ["123  MAIN st apt 4", "m5v2t6"],
+  ["123 Main St, Apt 4", "M5V-2T6"],
+  // Unicode accents: non-[a-z0-9] chars become spaces in BOTH implementations.
+  ["Élysée Blvd", "90210"],
+  ["10—12 Rue de l'Église", "H2X 1Y6"],
+  // Postal formats.
+  ["1 A St", "M5V 2T6"],
+  ["1 A St", "m5v2t6"],
+  ["1 A St", "90210"],
+  // Empty / null / normalizes-to-empty combinations.
+  [null, null],
+  ["", "M5V 2T6"],
+  ["123 Main St", ""],
+  [null, "M5V 2T6"],
+  ["123 Main St", null],
+  ["   ", "M5V 2T6"],
+  ["!!!---", "M5V 2T6"],
+  ["123 Main St", " -- "],
+  // Whitespace runs and edge whitespace.
+  ["  42   Oak\tAve  ", "K1A 0B1"],
+];
+
+describe("household_key_for SQL/TS parity (real Postgres)", () => {
+  let reachable = false;
+  let sqlClient: import("postgres").Sql | undefined;
+
+  beforeAll(async () => {
+    let postgres: typeof import("postgres");
+    try {
+      postgres = (await import("postgres")).default;
+    } catch {
+      return;
+    }
+
+    // max: 1 — the migration file is applied verbatim below and contains
+    // BEGIN/COMMIT, which postgres.js only allows on a single-connection pool.
+    const client = postgres(CANDIDATE_URL, { prepare: false, max: 1, connect_timeout: 2 });
+    try {
+      await client`select 1`;
+    } catch {
+      await client.end({ timeout: 1 }).catch(() => {});
+      return;
+    }
+
+    sqlClient = client;
+
+    // Apply the migration so the SQL function under test is the file's exact
+    // text (the whole migration is idempotent: CREATE OR REPLACE + ON
+    // CONFLICT DO NOTHING + household_id-is-null-guarded UPDATE).
+    const migrationSql = readFileSync(
+      path.resolve(__dirname, "../client/migrations/20260722100000_households_backfill.sql"),
+      "utf8",
+    );
+    await client.unsafe(migrationSql);
+
+    reachable = true;
+  }, 15_000);
+
+  afterAll(async () => {
+    if (!sqlClient) return;
+    await sqlClient.end({ timeout: 2 });
+  });
+
+  function assertSkippedWithoutDb(ctx: { skip: () => void }) {
+    if (!reachable) {
+      ctx.skip();
+    }
+  }
+
+  test("SQL household_key_for matches TS householdKeyFor on every fixture", async (ctx) => {
+    assertSkippedWithoutDb(ctx);
+
+    for (const [address, postal] of FIXTURES) {
+      const [row] = await sqlClient!`
+        select public.household_key_for(${address}, ${postal}) as key
+      `;
+      const sqlKey = (row as { key: string | null }).key;
+      const tsKey = householdKeyFor(address, postal);
+      expect(sqlKey, `address=${JSON.stringify(address)} postal=${JSON.stringify(postal)}`).toBe(
+        tsKey,
+      );
+    }
+  });
+
+  test("equivalent formattings produce one shared key, distinct addresses do not", async (ctx) => {
+    assertSkippedWithoutDb(ctx);
+
+    const [same] = await sqlClient!`
+      select
+        public.household_key_for('123 Main St., Apt #4', 'M5V 2T6') =
+        public.household_key_for('123  MAIN st apt 4', 'm5v2t6') as matches
+    `;
+    expect((same as { matches: boolean }).matches).toBe(true);
+
+    const [different] = await sqlClient!`
+      select
+        public.household_key_for('123 Main St', '90210') is distinct from
+        public.household_key_for('124 Main St', '90210') as differs
+    `;
+    expect((different as { differs: boolean }).differs).toBe(true);
+  });
+});

--- a/test/household-key.test.ts
+++ b/test/household-key.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { householdKeyFor } from "../app/lib/household-key";
+
+describe("householdKeyFor (TS unit)", () => {
+  test("normalizes mixed case and punctuation", () => {
+    expect(householdKeyFor("123 Main St., Apt #4", "M5V 2T6")).toBe(
+      "123 main st apt 4|m5v2t6",
+    );
+  });
+
+  test("same key regardless of formatting", () => {
+    const a = householdKeyFor("123 Main St., Apt #4", "M5V 2T6");
+    const b = householdKeyFor("123  MAIN st apt 4", "m5v2t6");
+    expect(a).toBe(b);
+    expect(a).not.toBeNull();
+  });
+
+  test("postal keeps only alphanumerics", () => {
+    expect(householdKeyFor("1 A St", "M5V-2T6")).toBe("1 a st|m5v2t6");
+    expect(householdKeyFor("1 A St", "90210")).toBe("1 a st|90210");
+  });
+
+  test("unicode accents become spaces (then collapse)", () => {
+    // é is outside [a-z0-9], so it turns into a space like any punctuation.
+    expect(householdKeyFor("Élysée Blvd", "90210")).toBe("lys e blvd|90210");
+  });
+
+  test("null unless both parts are non-empty after normalization", () => {
+    expect(householdKeyFor(null, null)).toBeNull();
+    expect(householdKeyFor(undefined, undefined)).toBeNull();
+    expect(householdKeyFor("", "M5V 2T6")).toBeNull();
+    expect(householdKeyFor("123 Main St", "")).toBeNull();
+    expect(householdKeyFor("   ", "M5V 2T6")).toBeNull();
+    expect(householdKeyFor("!!!---", "M5V 2T6")).toBeNull();
+    expect(householdKeyFor("123 Main St", " -- ")).toBeNull();
+    expect(householdKeyFor(null, "M5V 2T6")).toBeNull();
+    expect(householdKeyFor("123 Main St", null)).toBeNull();
+  });
+
+  test("whitespace runs collapse to single spaces and edges trim", () => {
+    expect(householdKeyFor("  42   Oak\tAve  ", "K1A0B1")).toBe("42 oak ave|k1a0b1");
+  });
+});

--- a/test/inbound-sms.route.test.ts
+++ b/test/inbound-sms.route.test.ts
@@ -47,6 +47,15 @@ vi.mock("@/lib/workspace-events.server", () => ({
   emitChatMessageEvent: vi.fn(async () => undefined),
 }));
 
+const queueDbMocks = vi.hoisted(() => ({
+  dequeueCampaignQueueByContact: vi.fn(),
+}));
+
+vi.mock("@/lib/campaign-queue-db.server", () => ({
+  dequeueCampaignQueueByContact: (...args: unknown[]) =>
+    queueDbMocks.dequeueCampaignQueueByContact(...args),
+}));
+
 const onboardingMocks = vi.hoisted(() => ({
   getWorkspaceMessagingOnboardingState: vi.fn(),
 }));
@@ -274,6 +283,8 @@ describe("app/routes/api+/inbound-sms", () => {
     mocks.logger.info.mockReset();
     mocks.logger.warn.mockReset();
     mocks.fetch.mockReset();
+    queueDbMocks.dequeueCampaignQueueByContact.mockReset();
+    queueDbMocks.dequeueCampaignQueueByContact.mockResolvedValue([]);
     vi.stubGlobal("fetch", mocks.fetch);
     onboardingMocks.getWorkspaceMessagingOnboardingState.mockReset();
     onboardingMocks.getWorkspaceMessagingOnboardingState.mockResolvedValue({
@@ -341,6 +352,48 @@ describe("app/routes/api+/inbound-sms", () => {
       );
     });
 
+    test("STOP also dequeues the contact from all campaign queues (workspace-scoped)", async () => {
+      const number = { workspace: "w1", twilio_data: { sid: "sid", authToken: "tok" }, webhook: [] };
+      mocks.createClient.mockReturnValueOnce(
+        makeDbClient({ number, contacts: [{ id: 9 }], mediaOk: true }),
+      );
+      const mod = await import("../app/routes/api+/inbound-sms");
+      const res = await asRouteResponse(mod.action({
+          request: makeInboundSmsRequest({ Body: "stop", NumMedia: "0" }),
+        } as any),
+      );
+      expect(res.status).toBe(201);
+      expect(tenantDbStubState.contactUpdateCalls).toContainEqual(
+        expect.objectContaining({ set: { opt_out: true } }),
+      );
+      expect(queueDbMocks.dequeueCampaignQueueByContact).toHaveBeenCalledWith({
+        contactId: 9,
+        userId: null,
+        reason: "Contact opted out via SMS",
+        workspaceId: "w1",
+      });
+    });
+
+    test("STOP dequeue failure is logged but the message is still recorded", async () => {
+      queueDbMocks.dequeueCampaignQueueByContact.mockRejectedValueOnce(
+        new Error("queue down"),
+      );
+      const number = { workspace: "w1", twilio_data: { sid: "sid", authToken: "tok" }, webhook: [] };
+      mocks.createClient.mockReturnValueOnce(
+        makeDbClient({ number, contacts: [{ id: 9 }], mediaOk: true }),
+      );
+      const mod = await import("../app/routes/api+/inbound-sms");
+      const res = await asRouteResponse(mod.action({
+          request: makeInboundSmsRequest({ Body: "stop", NumMedia: "0" }),
+        } as any),
+      );
+      expect(res.status).toBe(201);
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        "Failed to dequeue opted-out contact from campaign queues:",
+        expect.any(Error),
+      );
+    });
+
     test("START re-subscribes regardless of configured opt-out keywords", async () => {
       onboardingMocks.getWorkspaceMessagingOnboardingState.mockResolvedValueOnce({
         businessProfile: { optOutKeywords: "QUIT" },
@@ -358,6 +411,8 @@ describe("app/routes/api+/inbound-sms", () => {
       expect(tenantDbStubState.contactUpdateCalls).toContainEqual(
         expect.objectContaining({ set: { opt_out: false } }),
       );
+      // Re-subscribe must NOT touch campaign queues (no re-queueing).
+      expect(queueDbMocks.dequeueCampaignQueueByContact).not.toHaveBeenCalled();
     });
   });
 

--- a/test/outreach-disposition.test.ts
+++ b/test/outreach-disposition.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "vitest";
 
 import {
   canTransitionOutreachDisposition,
+  DNC_DISPOSITION,
+  formatDispositionLabel,
+  isDncDisposition,
   normalizeDispositionOptions,
   shouldUpdateOutreachDisposition,
   TERMINAL_OUTREACH_DISPOSITIONS,
@@ -41,27 +44,58 @@ describe("outreach disposition helpers", () => {
     ).toBe(true);
   });
 
-  test("normalizeDispositionOptions returns [] for null/undefined jsonb", () => {
-    expect(normalizeDispositionOptions(null)).toEqual([]);
-    expect(normalizeDispositionOptions(undefined)).toEqual([]);
+  test("normalizeDispositionOptions yields only do_not_call for null/undefined jsonb", () => {
+    expect(normalizeDispositionOptions(null)).toEqual([DNC_DISPOSITION]);
+    expect(normalizeDispositionOptions(undefined)).toEqual([DNC_DISPOSITION]);
   });
 
-  test("normalizeDispositionOptions returns [] for non-array jsonb values", () => {
-    expect(normalizeDispositionOptions("answered")).toEqual([]);
-    expect(normalizeDispositionOptions(42)).toEqual([]);
-    expect(normalizeDispositionOptions({ answered: true })).toEqual([]);
+  test("normalizeDispositionOptions yields only do_not_call for non-array jsonb values", () => {
+    expect(normalizeDispositionOptions("answered")).toEqual([DNC_DISPOSITION]);
+    expect(normalizeDispositionOptions(42)).toEqual([DNC_DISPOSITION]);
+    expect(normalizeDispositionOptions({ answered: true })).toEqual([DNC_DISPOSITION]);
   });
 
-  test("normalizeDispositionOptions keeps only string entries", () => {
+  test("normalizeDispositionOptions keeps only string entries and appends do_not_call last", () => {
     expect(normalizeDispositionOptions(["answered", "no_answer"])).toEqual([
       "answered",
       "no_answer",
+      DNC_DISPOSITION,
     ]);
     expect(normalizeDispositionOptions(["answered", null, 3, { a: 1 }, "busy"])).toEqual([
       "answered",
       "busy",
+      DNC_DISPOSITION,
     ]);
-    expect(normalizeDispositionOptions([])).toEqual([]);
+    expect(normalizeDispositionOptions([])).toEqual([DNC_DISPOSITION]);
+  });
+
+  test("normalizeDispositionOptions does not duplicate campaign-defined DNC variants", () => {
+    expect(normalizeDispositionOptions(["answered", "do_not_call"])).toEqual([
+      "answered",
+      "do_not_call",
+    ]);
+    expect(normalizeDispositionOptions(["Do Not Call"])).toEqual(["Do Not Call"]);
+    expect(normalizeDispositionOptions(["do-not-call", "busy"])).toEqual([
+      "do-not-call",
+      "busy",
+    ]);
+  });
+
+  test("isDncDisposition matches raw value, label, and casing/separator variants", () => {
+    expect(isDncDisposition(DNC_DISPOSITION)).toBe(true);
+    expect(isDncDisposition("Do not call")).toBe(true);
+    expect(isDncDisposition("DO-NOT-CALL")).toBe(true);
+    expect(isDncDisposition(" do_not_call ")).toBe(true);
+    expect(isDncDisposition("completed")).toBe(false);
+    expect(isDncDisposition(null)).toBe(false);
+    expect(isDncDisposition(undefined)).toBe(false);
+    expect(isDncDisposition("")).toBe(false);
+  });
+
+  test("formatDispositionLabel maps do_not_call variants and passes other strings through", () => {
+    expect(formatDispositionLabel("do_not_call")).toBe("Do not call");
+    expect(formatDispositionLabel("Do Not Call")).toBe("Do not call");
+    expect(formatDispositionLabel("answered")).toBe("answered");
   });
 });
 

--- a/test/questions.route.test.ts
+++ b/test/questions.route.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
     requireWorkspaceAccess: vi.fn(),
     safeParseJson: vi.fn(),
     rpcCreateOutreachAttempt: vi.fn(),
+    dequeueCampaignQueueByContact: vi.fn(),
     logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
   };
 });
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => {
 const tenantDbMocks = vi.hoisted(() => ({
   findFirst: vi.fn(),
   update: vi.fn(),
+  contactUpdate: vi.fn(),
 }));
 
 vi.mock("@/lib/auth.server", () => ({
@@ -35,11 +37,18 @@ vi.mock("@/lib/db-rpc.server", () => ({
   rpcCreateOutreachAttempt: (...args: any[]) => mocks.rpcCreateOutreachAttempt(...args),
 }));
 vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
+vi.mock("@/lib/campaign-queue-db.server", () => ({
+  dequeueCampaignQueueByContact: (...args: any[]) =>
+    mocks.dequeueCampaignQueueByContact(...args),
+}));
 vi.mock("@/server/tenant-db", () => ({
   createTenantDb: () => ({
     outreach_attempt: {
       findFirst: (...args: any[]) => tenantDbMocks.findFirst(...args),
       update: (...args: any[]) => tenantDbMocks.update(...args),
+    },
+    contact: {
+      update: (...args: any[]) => tenantDbMocks.contactUpdate(...args),
     },
   }),
 }));
@@ -71,9 +80,13 @@ describe("app/routes/api+/questions/route.tsx", () => {
     mocks.requireWorkspaceAccess.mockReset();
     mocks.safeParseJson.mockReset();
     mocks.rpcCreateOutreachAttempt.mockReset();
+    mocks.dequeueCampaignQueueByContact.mockReset();
     mocks.logger.error.mockReset();
     tenantDbMocks.findFirst.mockReset();
     tenantDbMocks.update.mockReset();
+    tenantDbMocks.contactUpdate.mockReset();
+    tenantDbMocks.contactUpdate.mockResolvedValue([{ id: 1, opt_out: true }]);
+    mocks.dequeueCampaignQueueByContact.mockResolvedValue([]);
 
     mocks.getSession.mockResolvedValue({ headers, user: { id: "u1" } });
     mocks.requireJsonAuth.mockResolvedValue({ user: { id: "u1" } });
@@ -187,5 +200,71 @@ describe("app/routes/api+/questions/route.tsx", () => {
     const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
     expect(res.status).toBe(500);
     await expect(res.json()).resolves.toEqual({ error: "Failed to create or update outreach attempt" });
+  });
+
+  describe("do-not-call disposition side effects", () => {
+    test("do_not_call sets contact.opt_out and dequeues the contact from all campaigns", async () => {
+      mocks.safeParseJson.mockResolvedValueOnce({
+        ...defaultBody,
+        disposition: "do_not_call",
+      });
+      tenantDbMocks.update.mockResolvedValue([{ id: 7, disposition: "do_not_call" }]);
+      const mod = await import("../app/routes/api+/questions");
+      const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
+      expect(res.status).toBe(200);
+      expect(tenantDbMocks.contactUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ set: { opt_out: true } }),
+      );
+      // All-campaigns dequeue: campaignId must be omitted.
+      expect(mocks.dequeueCampaignQueueByContact).toHaveBeenCalledWith({
+        contactId: 1,
+        userId: "u1",
+        reason: "Do not call requested",
+        workspaceId: "w1",
+      });
+    });
+
+    test("matches display-label and cased variants of do_not_call", async () => {
+      for (const variant of ["Do not call", "DO-NOT-CALL"]) {
+        tenantDbMocks.contactUpdate.mockClear();
+        mocks.dequeueCampaignQueueByContact.mockClear();
+        mocks.safeParseJson.mockResolvedValueOnce({
+          ...defaultBody,
+          disposition: variant,
+        });
+        const mod = await import("../app/routes/api+/questions");
+        const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
+        expect(res.status).toBe(200);
+        expect(tenantDbMocks.contactUpdate).toHaveBeenCalledTimes(1);
+        expect(mocks.dequeueCampaignQueueByContact).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    test("non-DNC dispositions do not touch contact.opt_out or the queue", async () => {
+      mocks.safeParseJson.mockResolvedValueOnce({
+        ...defaultBody,
+        disposition: "completed",
+      });
+      const mod = await import("../app/routes/api+/questions");
+      const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
+      expect(res.status).toBe(200);
+      expect(tenantDbMocks.contactUpdate).not.toHaveBeenCalled();
+      expect(mocks.dequeueCampaignQueueByContact).not.toHaveBeenCalled();
+    });
+
+    test("side-effect failures are logged but do not fail the disposition save", async () => {
+      mocks.safeParseJson.mockResolvedValueOnce({
+        ...defaultBody,
+        disposition: "do_not_call",
+      });
+      tenantDbMocks.contactUpdate.mockRejectedValueOnce(new Error("opt-out failed"));
+      const mod = await import("../app/routes/api+/questions");
+      const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
+      expect(res.status).toBe(200);
+      expect(mocks.logger.error).toHaveBeenCalledWith(
+        "Do-not-call side effects failed after disposition save:",
+        expect.any(Error),
+      );
+    });
   });
 });

--- a/test/ui/contact-details-form-values.test.tsx
+++ b/test/ui/contact-details-form-values.test.tsx
@@ -90,6 +90,28 @@ describe("ContactDetails form values", () => {
             id: 5,
             firstname: "Original",
             surname: "Name",
+            // jsonb column: selects return a real array, not a JSON string.
+            other_data: [{ notes: "VIP" }],
+          } as any
+        }
+        audiences={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    expect(
+      screen.getByRole("button", { name: "Remove notes field" }),
+    ).toBeInTheDocument();
+  });
+
+  test("tolerates legacy stringified other_data (pre-jsonb snapshots)", () => {
+    render(
+      <ContactDetails
+        contact={
+          {
+            id: 6,
+            firstname: "Legacy",
+            surname: "Row",
             other_data: JSON.stringify([{ notes: "VIP" }]),
           } as any
         }


### PR DESCRIPTION
**Stacked on #1089** (chain: #1085 → #1089 → this; retarget as parents merge).

Resolves the three contact-management gaps from the assessment, orchestrated as four parallel workstreams with runtime verification against the compose DB.

## Householding was a dead switch — now real
The "Group by household" campaign toggle, the household-aware `dequeue_contact` RPC, and the `households` table all existed, but nothing ever created a household or set `contact.household_id`. Now the CSV import find-or-creates households per chunk (batched, 2 queries/chunk, using the existing unique `(workspace_id, household_key)` index), manual contact creation does the same, and migration `20260722100000` backfills existing contacts. The key normalization exists twice (TS + SQL) by necessity, so a **real-Postgres parity test** (modeled on the workspace-conversations one) pins them together. The dequeue RPC needed zero changes — it activates automatically on populated data. Verified live: two same-address contacts resolve to one household on the compose DB.

## Voice DNC — closing a compliance hole from both ends
`opt_out`'s only writer was SMS STOP, and the auto-dial claim RPC neither returns nor filters it — **a contact who texted STOP could still be auto-dialed**. Now:
- A built-in **"Do not call"** disposition on the agent call screen (always offered; deduped case-insensitively against campaign-defined variants). Saving it sets `opt_out` and dequeues the contact from **all** campaigns.
- SMS STOP now also dequeues from voice campaign queues.
- `claimNextQueueContact` double-checks `opt_out` post-claim (dequeues and re-claims, bounded) so any future opt-out writer that forgets to dequeue is still safe.
- IVR needed nothing — discovery showed `get_campaign_queue` already filters and auto-dequeues opted-out contacts.

## Import dedupe + honest counts
Within-file duplicates (first occurrence wins) and numbers already in the audience are skipped by normalized phone; `total_contacts` reflects the post-dedupe denominator so progress is truthful; "N duplicates / N invalid skipped" surfaces in the upload progress panel.

## `other_data` → queryable jsonb (with a plot twist)
The column was documented/typed as TEXT but is actually **`jsonb[]`** in the real DB — hand-sync drift in schema.ts (this repo's signature bug class, twice in this PR: `households.id` had the same problem). Migration `20260722110000` converts to plain `jsonb` (`'[]'` default) with type-gated idempotent casts, updates the three RPCs whose return types embedded `jsonb[]`, and **repairs `get_campaign_messages`, which was broken at runtime** (referenced columns that don't exist on `contact`; the pg_dump baseline never validated it). Readers that already assumed parsed arrays — the contacts-table custom columns and the audience CSV export, both silently broken today — start working.

## Verification
- Migrations applied + re-applied (idempotent) on the compose DB; RPC smoke calls pass
- SQL/TS household-key parity: 8/8 against live Postgres
- Full suite: 304 node files (2081 tests) + bun 22 + 96 UI files (521 tests), all green on Node 22
- typecheck / lint / DRY (242≤242) / effects (104/0) / handler gates green

Out of scope, flagged separately: `get_campaign_attempts_chunk` has an unrelated pre-existing type bug (dead code, chip filed); the queue-RPC `not_before` work lands with the redial/callbacks feature next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)