### PR TITLE
fix(dialer): let manual dialing see unassigned queued contacts (#1099)

### DIFF
--- a/app/lib/call-screen.server.ts
+++ b/app/lib/call-screen.server.ts
@@ -10,6 +10,7 @@ import {
   fetchActiveCampaignQueueWithContacts,
 } from "@/lib/campaign-queue-search.server";
 import {
+  getAssignedUserId,
   isAssignedToUser,
   isQueued,
 } from "@/lib/queue-status";
@@ -117,7 +118,21 @@ export async function getQueueByDialType(
     return queueItems.filter((item) => isQueued(item)).slice(0, 50);
   }
   if (dialType === "call") {
-    return queueItems.filter((item) => isAssignedToUser(item, userId)).slice(0, 50);
+    // Manual dialing works off a shared queue. Enqueue (rpcHandleCampaignQueueEntry)
+    // never assigns a user, so rows land unassigned + queued. Filtering to only
+    // rows already assigned to this operator left `nextRecipient` null for every
+    // fresh manual campaign — the header showed "N remaining" but the Dial button
+    // stayed disabled (#1099). Include unassigned queued rows so the operator has
+    // a next contact to dial; keep this operator's own assigned rows so an
+    // in-progress row is never dropped. Rows assigned to another operator are
+    // excluded to avoid two operators dialing the same contact.
+    return queueItems
+      .filter(
+        (item) =>
+          isAssignedToUser(item, userId) ||
+          (getAssignedUserId(item) === null && isQueued(item)),
+      )
+      .slice(0, 50);
   }
   throw new Error("Invalid dial type");
 }

--- a/test/call-screen.server.test.ts
+++ b/test/call-screen.server.test.ts
@@ -182,9 +182,33 @@ describe("call-screen.server", () => {
   });
 
   test("getQueueByDialType throws for invalid dial type", async () => {
-    await expect(getQueueByDialType({} as never, "1", "invalid", "user-1")).rejects.toThrow(
+    await expect(getQueueByDialType("1", "invalid", "user-1")).rejects.toThrow(
       "Invalid dial type",
     );
+  });
+
+  test("getQueueByDialType (call) includes unassigned queued rows and this operator's own rows, but not other operators' (#1099)", async () => {
+    // Manual enqueue never assigns a user, so a fresh manual campaign has only
+    // unassigned queued rows. Those must be dialable, or the Dial button is
+    // permanently disabled while the header still shows contacts remaining.
+    queueSearchMocks.fetchActiveCampaignQueueWithContacts.mockResolvedValue([
+      { id: 1, queue_state: "queued", assigned_to_user_id: null, dequeued_at: null },
+      { id: 2, queue_state: "queued", assigned_to_user_id: "user-1", dequeued_at: null },
+      { id: 3, queue_state: "queued", assigned_to_user_id: "user-2", dequeued_at: null },
+    ] as never);
+
+    const queue = await getQueueByDialType("1", "call", "user-1");
+    expect(queue.map((row) => (row as { id: number }).id)).toEqual([1, 2]);
+  });
+
+  test("getQueueByDialType (call) excludes unassigned rows that are not queued", async () => {
+    queueSearchMocks.fetchActiveCampaignQueueWithContacts.mockResolvedValue([
+      { id: 1, queue_state: "assigned", assigned_to_user_id: null, dequeued_at: null },
+      { id: 2, queue_state: "queued", assigned_to_user_id: null, dequeued_at: null },
+    ] as never);
+
+    const queue = await getQueueByDialType("1", "call", "user-1");
+    expect(queue.map((row) => (row as { id: number }).id)).toEqual([2]);
   });
 
   test("getCallScreenData throws when any query errors", async () => {


### PR DESCRIPTION
## Problem
On a manual-dial campaign the call screen header shows "N remaining" but the green **Dial** button is permanently disabled — there is no way to start dialing ([#1099](https://github.com/chester-hill-solutions/callcaster/issues/1099)).

## Root cause
Manual (`dial_type: "call"`) campaigns enqueue contacts through `rpcHandleCampaignQueueEntry`, which takes no `userId` — rows land **unassigned** (`assigned_to_user_id = null`), `queue_state = "queued"`. But `getQueueByDialType("call")` filtered the queue to `isAssignedToUser(item, userId)` only, so for a fresh manual campaign the dialable queue was empty → `getNextRecipient` returned `null` → the Dial button's `!nextRecipient` guard kept it disabled. The header count (`countCampaignQueueRows`, unfiltered) still showed the contact, hence "N remaining but can't dial." A regression from the `queue_state` / `assigned_to_user_id` queue normalization that the manual screen never adopted (the only code that assigns is the predictive `claimNextQueueContact` path).

## Fix
`getQueueByDialType("call")` now includes **unassigned queued rows** alongside this operator's own assigned rows, so `nextRecipient` is populated and Dial works. Rows assigned to *another* operator are still excluded so two operators don't dial the same contact. Single-file loader change in `app/lib/call-screen.server.ts`.

## Tests
Added two cases to `test/call-screen.server.test.ts`:
- includes unassigned queued rows + this operator's own rows, excludes another operator's rows
- excludes unassigned rows that aren't `queued`

All 15 `call-screen.server` tests pass.

## Known follow-up (out of scope)
Unassigned rows are visible to every operator until a contact is dispositioned (dequeued). A claim-on-dial step (assign the row to the operator when Dial is pressed, mirroring `claimNextQueueContact`) would close the small concurrent-dial window for multi-operator manual campaigns. Not needed for the reported single-operator case.

Fixes #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)