### PR TITLE
feat(boot): opt-in client-migration bootstrap for fresh databases

### DIFF
--- a/app/server/bootstrap-migrations.server.ts
+++ b/app/server/bootstrap-migrations.server.ts
@@ -1,0 +1,160 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import postgres from "postgres";
+import { logger } from "@/lib/logger.server";
+
+/**
+ * Opt-in, forward-only replay of `client/migrations/*.sql` at boot.
+ *
+ * Why this exists: the Docker entrypoint only starts the app — it never applies
+ * the raw SQL migrations. Persistent environments (dev/staging/production) had
+ * their ledger applied once by hand, but every ephemeral PR-preview environment
+ * gets a fresh database that has none of them, so the app crashes on the
+ * `assertRequiredDbFunctions` guard ("Required database function is missing:
+ * apply_ledger_entry_and_sync_credits"). This heals a fresh database before the
+ * guard runs.
+ *
+ * Safety — three independent interlocks so this can never touch the wrong DB:
+ *   1. Off by default. Only runs when RUN_CLIENT_MIGRATIONS_ON_BOOT is "1"/"true".
+ *      Production never sets it, so production never runs this.
+ *   2. Legacy-database refusal. The v2 migrations DROP the Supabase-era
+ *      `transaction_history_update_credits` trigger, which on the legacy
+ *      customer-prod database IS the live credits mechanism. If that trigger
+ *      (or any banned legacy trigger) is present, this is not a v2 database and
+ *      we abort without running anything.
+ *   3. Per-file isolation. Each file runs on its own; a failure is logged and
+ *      skipped, never left half-applied across files, and the downstream
+ *      `assertRequiredDbFunctions` guard remains the hard gate on readiness.
+ */
+
+const MIGRATIONS_DIRNAME = path.join("client", "migrations");
+const TRACKING_TABLE = "client_migration_bootstrap";
+
+/**
+ * Presence of any of these legacy triggers means the target is a Supabase-era
+ * database where the forward migrations here would be destructive. Mirrors the
+ * banned-trigger list asserted by db-health.server.ts.
+ */
+const LEGACY_SENTINEL_TRIGGERS = [
+  "add_contact_to_queues_trigger",
+  "campaign_is_active_change_trigger",
+  "campaign_schedule_change_trigger",
+  "outreach_trigger",
+  "transaction_history_update_credits",
+  "trigger_inherit_parent_call_data",
+];
+
+export type BootstrapResult =
+  | { ran: false; reason: "disabled" | "no-database-url" }
+  | { ran: false; reason: "legacy-database"; triggers: string[] }
+  | { ran: true; applied: string[]; skipped: string[] };
+
+export function bootstrapEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = env.RUN_CLIENT_MIGRATIONS_ON_BOOT;
+  return value === "1" || value === "true";
+}
+
+/** Sort client migrations by filename — the version prefix is time-ordered. */
+function listMigrationFiles(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".sql"))
+    .sort();
+}
+
+/**
+ * Apply any not-yet-recorded client migrations to DATABASE_URL. Keyed by
+ * filename (not version) so the three grandfathered files that share version
+ * `20260705000200` are each tracked independently. Idempotent: already-applied
+ * files are recorded in {@link TRACKING_TABLE} and skipped on later boots, and
+ * the migration SQL itself is written to be re-runnable.
+ */
+export async function applyClientMigrationsOnBoot(options: {
+  env?: NodeJS.ProcessEnv;
+  rootDir: string;
+}): Promise<BootstrapResult> {
+  const env = options.env ?? process.env;
+
+  if (!bootstrapEnabled(env)) {
+    return { ran: false, reason: "disabled" };
+  }
+
+  const databaseUrl = env.DATABASE_URL;
+  if (!databaseUrl) {
+    logger.error(
+      "RUN_CLIENT_MIGRATIONS_ON_BOOT is set but DATABASE_URL is missing — cannot bootstrap the database",
+    );
+    return { ran: false, reason: "no-database-url" };
+  }
+
+  const dir = path.join(options.rootDir, MIGRATIONS_DIRNAME);
+  const files = listMigrationFiles(dir);
+  const sql = postgres(databaseUrl, { prepare: false, max: 1 });
+
+  try {
+    const legacyTriggers = await sql<{ tgname: string }[]>`
+      select tgname
+      from pg_trigger
+      where tgname = any(${LEGACY_SENTINEL_TRIGGERS})
+    `;
+    if (legacyTriggers.length > 0) {
+      const triggers = legacyTriggers.map((row) => row.tgname);
+      logger.error(
+        "client-migration bootstrap refused: legacy Supabase-era trigger(s) present — refusing to migrate what looks like a legacy database",
+        { triggers },
+      );
+      return { ran: false, reason: "legacy-database", triggers };
+    }
+
+    await sql.unsafe(`
+      create table if not exists public.${TRACKING_TABLE} (
+        filename text primary key,
+        applied_at timestamptz not null default now()
+      )
+    `);
+
+    const appliedRows = await sql<{ filename: string }[]>`
+      select filename from public.client_migration_bootstrap
+    `;
+    const alreadyApplied = new Set(appliedRows.map((row) => row.filename));
+
+    const applied: string[] = [];
+    const skipped: string[] = [];
+
+    for (const file of files) {
+      if (alreadyApplied.has(file)) {
+        skipped.push(file);
+        continue;
+      }
+      const content = readFileSync(path.join(dir, file), "utf8");
+      try {
+        // Simple-protocol so multi-statement files with their own BEGIN/COMMIT
+        // and dollar-quoted function bodies execute as written.
+        await sql.unsafe(content).simple();
+        await sql`
+          insert into public.client_migration_bootstrap (filename)
+          values (${file})
+          on conflict (filename) do nothing
+        `;
+        applied.push(file);
+        logger.info("client-migration bootstrap applied", { file });
+      } catch (error) {
+        // A file that conflicts with the drizzle baseline (already present) or
+        // otherwise fails is logged and skipped, not recorded. The db-health
+        // guard downstream is the hard gate on whether boot proceeds.
+        skipped.push(file);
+        logger.error("client-migration bootstrap skipped a file", {
+          file,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    logger.info("client-migration bootstrap complete", {
+      appliedCount: applied.length,
+      skippedCount: skipped.length,
+    });
+    return { ran: true, applied, skipped };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}

--- a/server/bun.ts
+++ b/server/bun.ts
@@ -318,6 +318,20 @@ export async function createServer(options: CreateServerOptions = {}) {
     })());
 
   if (!options.skipDbHealthCheck) {
+    // Opt-in, self-guarding: on a fresh (e.g. PR-preview) database this applies
+    // the client/migrations the db-health guard below requires. No-op unless
+    // RUN_CLIENT_MIGRATIONS_ON_BOOT is set, and it refuses on legacy databases.
+    try {
+      const { applyClientMigrationsOnBoot } = await import(
+        "../app/server/bootstrap-migrations.server.ts"
+      );
+      await applyClientMigrationsOnBoot({ rootDir: ROOT_DIR });
+    } catch (error) {
+      log("error", "client-migration bootstrap errored", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     try {
       const { assertRequiredDbFunctions } = await import(
         "../app/server/db-health.server.ts"

--- a/test/bootstrap-migrations.server.test.ts
+++ b/test/bootstrap-migrations.server.test.ts
@@ -1,0 +1,145 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, "..");
+
+/** Mutable state the postgres mock reads, reset per test. */
+const dbState = vi.hoisted(() => ({
+  legacyTriggers: [] as { tgname: string }[],
+  appliedRows: [] as { filename: string }[],
+  inserted: [] as string[],
+  simpleApplied: [] as string[],
+  factoryCalls: 0,
+}));
+
+vi.mock("postgres", () => {
+  function sqlTag(strings: TemplateStringsArray, ...values: unknown[]) {
+    const text = Array.isArray(strings) ? strings.join("?") : String(strings);
+    if (text.includes("pg_trigger")) return Promise.resolve(dbState.legacyTriggers);
+    if (text.includes("from public.client_migration_bootstrap")) {
+      return Promise.resolve(dbState.appliedRows);
+    }
+    if (text.includes("insert into public.client_migration_bootstrap")) {
+      dbState.inserted.push(String(values[0]));
+      return Promise.resolve([]);
+    }
+    return Promise.resolve([]);
+  }
+  (sqlTag as unknown as { unsafe: (s: string) => Promise<unknown[]> & { simple: () => Promise<unknown[]> } }).unsafe = (
+    s: string,
+  ) => {
+    const p = Promise.resolve([]) as Promise<unknown[]> & { simple: () => Promise<unknown[]> };
+    p.simple = () => {
+      dbState.simpleApplied.push(s);
+      return Promise.resolve([]);
+    };
+    return p;
+  };
+  (sqlTag as unknown as { end: () => Promise<void> }).end = () => Promise.resolve();
+  return {
+    default: vi.fn(() => {
+      dbState.factoryCalls += 1;
+      return sqlTag;
+    }),
+  };
+});
+
+vi.mock("@/lib/logger.server", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import {
+  applyClientMigrationsOnBoot,
+  bootstrapEnabled,
+} from "../app/server/bootstrap-migrations.server";
+
+describe("bootstrap-migrations.server", () => {
+  beforeEach(() => {
+    dbState.legacyTriggers = [];
+    dbState.appliedRows = [];
+    dbState.inserted = [];
+    dbState.simpleApplied = [];
+    dbState.factoryCalls = 0;
+  });
+
+  test("bootstrapEnabled only true for explicit opt-in", () => {
+    expect(bootstrapEnabled({ RUN_CLIENT_MIGRATIONS_ON_BOOT: "1" })).toBe(true);
+    expect(bootstrapEnabled({ RUN_CLIENT_MIGRATIONS_ON_BOOT: "true" })).toBe(true);
+    expect(bootstrapEnabled({ RUN_CLIENT_MIGRATIONS_ON_BOOT: "0" })).toBe(false);
+    expect(bootstrapEnabled({ RUN_CLIENT_MIGRATIONS_ON_BOOT: "yes" })).toBe(false);
+    expect(bootstrapEnabled({})).toBe(false);
+  });
+
+  test("does nothing (never connects) when the flag is off", async () => {
+    const result = await applyClientMigrationsOnBoot({
+      env: { DATABASE_URL: "postgres://x" },
+      rootDir: ROOT_DIR,
+    });
+    expect(result).toEqual({ ran: false, reason: "disabled" });
+    expect(dbState.factoryCalls).toBe(0);
+  });
+
+  test("returns no-database-url when enabled without DATABASE_URL", async () => {
+    const result = await applyClientMigrationsOnBoot({
+      env: { RUN_CLIENT_MIGRATIONS_ON_BOOT: "1" },
+      rootDir: ROOT_DIR,
+    });
+    expect(result).toEqual({ ran: false, reason: "no-database-url" });
+    expect(dbState.factoryCalls).toBe(0);
+  });
+
+  test("refuses to touch a legacy database and applies nothing", async () => {
+    dbState.legacyTriggers = [{ tgname: "transaction_history_update_credits" }];
+    const result = await applyClientMigrationsOnBoot({
+      env: { RUN_CLIENT_MIGRATIONS_ON_BOOT: "1", DATABASE_URL: "postgres://x" },
+      rootDir: ROOT_DIR,
+    });
+    expect(result).toEqual({
+      ran: false,
+      reason: "legacy-database",
+      triggers: ["transaction_history_update_credits"],
+    });
+    expect(dbState.simpleApplied).toHaveLength(0);
+    expect(dbState.inserted).toHaveLength(0);
+  });
+
+  test("applies every pending migration on a fresh database", async () => {
+    const result = await applyClientMigrationsOnBoot({
+      env: { RUN_CLIENT_MIGRATIONS_ON_BOOT: "1", DATABASE_URL: "postgres://x" },
+      rootDir: ROOT_DIR,
+    });
+    expect(result.ran).toBe(true);
+    if (!result.ran) return;
+    // Real client/migrations directory drives this — every file applies + records.
+    expect(result.applied.length).toBeGreaterThan(0);
+    expect(result.skipped).toHaveLength(0);
+    expect(dbState.inserted).toEqual(result.applied);
+    // Applied in sorted (version-prefixed) filename order.
+    expect(result.applied).toEqual([...result.applied].sort());
+  });
+
+  test("skips migrations already recorded as applied", async () => {
+    // Pretend the first two files (sorted) are already applied.
+    const result0 = await applyClientMigrationsOnBoot({
+      env: { RUN_CLIENT_MIGRATIONS_ON_BOOT: "1", DATABASE_URL: "postgres://x" },
+      rootDir: ROOT_DIR,
+    });
+    if (!result0.ran) throw new Error("expected first run to apply");
+    const [firstApplied] = result0.applied;
+
+    dbState.appliedRows = [{ filename: firstApplied }];
+    dbState.inserted = [];
+    dbState.simpleApplied = [];
+
+    const result = await applyClientMigrationsOnBoot({
+      env: { RUN_CLIENT_MIGRATIONS_ON_BOOT: "1", DATABASE_URL: "postgres://x" },
+      rootDir: ROOT_DIR,
+    });
+    if (!result.ran) throw new Error("expected second run to apply");
+    expect(result.skipped).toContain(firstApplied);
+    expect(result.applied).not.toContain(firstApplied);
+    expect(dbState.inserted).not.toContain(firstApplied);
+  });
+});


### PR DESCRIPTION
## Problem
Every PR-preview deploy shows a red Railway check ("Deployment failed"). Root cause: Railway gives each ephemeral PR environment a **fresh database**, and the Docker entrypoint (`bun run ./server/bun.ts`) only starts the app — it never applies the raw `client/migrations/*.sql`. So the fresh DB lacks `apply_ledger_entry_and_sync_credits`, the startup guard `assertRequiredDbFunctions` throws, and the app crashes on boot. Persistent envs (dev/staging/production) had their migrations applied by hand once, so they're unaffected — which is why nothing customer-facing is broken, only PR-preview deploys.

## Fix
`applyClientMigrationsOnBoot` (new `app/server/bootstrap-migrations.server.ts`) does a forward-only replay of `client/migrations`, wired into `server/bun.ts` just **before** the db-health guard so a fresh database is healed before the guard runs.

### Three independent safety interlocks
1. **Off by default** — runs only when `RUN_CLIENT_MIGRATIONS_ON_BOOT` is `1`/`true`. Production never sets it, so production never runs this. The merged code is a **no-op on every current environment** until the flag is set.
2. **Legacy-database refusal** — the v2 migrations `DROP` the Supabase-era `transaction_history_update_credits` trigger, which on the legacy customer-prod DB *is* the live credits mechanism. If that (or any banned legacy trigger) is present, the runner aborts and touches nothing — even if the flag were set by mistake.
3. **Per-file isolation + tracking table** — applied files are recorded in `client_migration_bootstrap` (keyed by **filename**, so the three grandfathered files sharing version `20260705000200` track independently) and skipped on later boots. A file that conflicts with the drizzle baseline is logged and skipped; `assertRequiredDbFunctions` remains the hard readiness gate.

## Tests
`test/bootstrap-migrations.server.test.ts` (6 cases): flag parsing, no-op when disabled (never connects), `no-database-url`, legacy-DB refusal applies nothing, applies all pending on a fresh DB in sorted order, skips already-recorded files. Bun boot test (`server-runtime.test.ts`) still 6/6. Typecheck clean.

## Activation (follow-up ops step — not in this PR)
Set `RUN_CLIENT_MIGRATIONS_ON_BOOT=1` on the **dev** and **staging** Railway environments so PR-preview envs inherit it. **Leave it unset on production.** Until then this change does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)