### PR TITLE
fix(onboarding): Sai 2026-07-28 QA pass (#1103)

### DIFF
--- a/app/components/audience/AudienceUploadFileStep.tsx
+++ b/app/components/audience/AudienceUploadFileStep.tsx
@@ -12,7 +12,7 @@ export const AudienceUploadFileStep = forwardRef<
   return (
     <label
       htmlFor="contacts"
-      className="flex min-h-[11rem] cursor-pointer flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-muted/30 px-6 py-16 text-center transition-colors hover:border-border hover:bg-muted/50"
+      className="flex min-h-[8rem] cursor-pointer flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-muted/30 px-6 py-8 text-center transition-colors hover:border-border hover:bg-muted/50"
     >
       <span className="inline-flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
         <MdUploadFile className="size-5" aria-hidden />

--- a/app/components/phone-numbers/ServiceAddressGate.tsx
+++ b/app/components/phone-numbers/ServiceAddressGate.tsx
@@ -1,8 +1,8 @@
+import { useState } from "react";
 import { Form, useNavigation } from "react-router";
 import { Button } from "@/components/ui/button";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
-import { Section, SectionHeader } from "@/components/shared/Section";
 import type { WorkspaceMessagingOnboardingState } from "@/lib/types";
 
 function addressComplete(
@@ -33,6 +33,9 @@ export function isServiceAddressComplete(
 /**
  * Capability gate: collect the service / emergency address before renting.
  * Posts to the workspace onboarding action (`save_service_address`).
+ *
+ * When complete, shows a compact summary until the user chooses Edit (#1112).
+ * Nested under the phone-number step without a second page-level heading (#1111).
  */
 export function ServiceAddressGate({
   workspaceId,
@@ -43,6 +46,7 @@ export function ServiceAddressGate({
   const navigation = useNavigation();
   const address = onboarding.emergencyVoice.address;
   const complete = addressComplete(address);
+  const [isEditing, setIsEditing] = useState(!complete);
   const pendingAction =
     navigation.state === "idle"
       ? null
@@ -51,112 +55,143 @@ export function ServiceAddressGate({
   const isReviewing = pendingAction === "review_emergency_voice";
   const returnPath =
     returnTo ?? `/workspaces/${workspaceId}/settings/numbers`;
+  const showForm = !complete || isEditing;
 
   return (
-    <Section variant="flat" data-testid="service-address-gate">
-      <SectionHeader
-        compact
-        title="Service address"
-        description={
-          complete
-            ? "Required before renting a phone number. Validate the address so voice numbers can be emergency-ready."
-            : "Add a physical service address before renting a number. PO boxes are not accepted."
-        }
-      />
-      <Form
-        method="post"
-        action={`/workspaces/${workspaceId}/onboarding`}
-        className="grid gap-4 md:grid-cols-2"
-      >
-        <input type="hidden" name="_action" value="save_service_address" />
-        <input type="hidden" name="returnTo" value={returnPath} />
-        <FormField
-          className="md:col-span-2"
-          htmlFor="addressStreet"
-          label="Street address"
-          required
-        >
-          <Input
-            id="addressStreet"
-            name="addressStreet"
-            defaultValue={address.street}
-            disabled={isReadOnly || isSaving}
-            required
-            placeholder="123 Main St"
-          />
-        </FormField>
-        <FormField htmlFor="addressCity" label="City" required>
-          <Input
-            id="addressCity"
-            name="addressCity"
-            defaultValue={address.city}
-            disabled={isReadOnly || isSaving}
-            required
-            placeholder="Toronto"
-          />
-        </FormField>
-        <FormField htmlFor="addressRegion" label="Province or region" required>
-          <Input
-            id="addressRegion"
-            name="addressRegion"
-            defaultValue={address.region}
-            disabled={isReadOnly || isSaving}
-            required
-            placeholder="ON"
-          />
-        </FormField>
-        <FormField htmlFor="addressPostalCode" label="Postal code" required>
-          <Input
-            id="addressPostalCode"
-            name="addressPostalCode"
-            defaultValue={address.postalCode}
-            disabled={isReadOnly || isSaving}
-            required
-            placeholder="M5V 2T6"
-          />
-        </FormField>
-        <FormField htmlFor="addressCountryCode" label="Country code">
-          <Input
-            id="addressCountryCode"
-            name="addressCountryCode"
-            defaultValue={address.countryCode || "CA"}
-            disabled={isReadOnly || isSaving}
-            placeholder="CA"
-          />
-        </FormField>
-        {!isReadOnly ? (
-          <div className="flex flex-wrap gap-2 md:col-span-2">
-            <Button type="submit" disabled={isSaving} aria-busy={isSaving}>
-              {isSaving ? "Saving…" : complete ? "Update address" : "Save address"}
-            </Button>
-          </div>
-        ) : null}
-      </Form>
-      {complete && !isReadOnly ? (
-        <Form
-          method="post"
-          action={`/workspaces/${workspaceId}/onboarding`}
-          className="mt-4"
-        >
-          <input type="hidden" name="_action" value="review_emergency_voice" />
-          <input type="hidden" name="returnTo" value={returnPath} />
-          <p className="mb-2 text-sm text-muted-foreground">
-            Address status:{" "}
+    <div data-testid="service-address-gate" className="max-w-xl space-y-3">
+      <div>
+        <h3 className="text-sm font-medium">Service address</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {complete && !isEditing
+            ? "Required before renting a phone number."
+            : "Add a physical service address before renting a number. PO boxes are not accepted."}
+        </p>
+      </div>
+
+      {complete && !isEditing ? (
+        <div className="space-y-3 rounded-md bg-muted/40 p-3 text-sm">
+          <p className="text-foreground">
+            {[address.street, address.city, address.region, address.postalCode]
+              .filter(Boolean)
+              .join(", ")}
+            {address.countryCode ? ` (${address.countryCode})` : null}
+          </p>
+          <p className="text-muted-foreground">
+            Status:{" "}
             <span className="font-medium text-foreground">
               {address.status.replaceAll("_", " ")}
             </span>
             {address.validationError ? ` — ${address.validationError}` : null}
           </p>
-          <Button
-            type="submit"
-            variant="outline"
-            disabled={isReviewing}
-            aria-busy={isReviewing}
-          >
-            {isReviewing ? "Validating…" : "Validate address"}
-          </Button>
+          {!isReadOnly ? (
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setIsEditing(true)}
+              >
+                Edit address
+              </Button>
+              <Form
+                method="post"
+                action={`/workspaces/${workspaceId}/onboarding`}
+              >
+                <input type="hidden" name="_action" value="review_emergency_voice" />
+                <input type="hidden" name="returnTo" value={returnPath} />
+                <Button
+                  type="submit"
+                  variant="outline"
+                  size="sm"
+                  disabled={isReviewing}
+                  aria-busy={isReviewing}
+                >
+                  {isReviewing ? "Validating…" : "Validate address"}
+                </Button>
+              </Form>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {showForm ? (
+        <Form
+          method="post"
+          action={`/workspaces/${workspaceId}/onboarding`}
+          className="grid max-w-xl gap-3"
+        >
+          <input type="hidden" name="_action" value="save_service_address" />
+          <input type="hidden" name="returnTo" value={returnPath} />
+          <FormField htmlFor="addressStreet" label="Street address" required>
+            <Input
+              id="addressStreet"
+              name="addressStreet"
+              defaultValue={address.street}
+              disabled={isReadOnly || isSaving}
+              required
+              placeholder="123 Main St"
+            />
+          </FormField>
+          <FormField htmlFor="addressCity" label="City" required>
+            <Input
+              id="addressCity"
+              name="addressCity"
+              defaultValue={address.city}
+              disabled={isReadOnly || isSaving}
+              required
+              placeholder="Toronto"
+            />
+          </FormField>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <FormField htmlFor="addressRegion" label="Province or region" required>
+              <Input
+                id="addressRegion"
+                name="addressRegion"
+                defaultValue={address.region}
+                disabled={isReadOnly || isSaving}
+                required
+                placeholder="ON"
+              />
+            </FormField>
+            <FormField htmlFor="addressPostalCode" label="Postal code" required>
+              <Input
+                id="addressPostalCode"
+                name="addressPostalCode"
+                defaultValue={address.postalCode}
+                disabled={isReadOnly || isSaving}
+                required
+                placeholder="M5V 2T6"
+              />
+            </FormField>
+          </div>
+          <FormField htmlFor="addressCountryCode" label="Country code">
+            <Input
+              id="addressCountryCode"
+              name="addressCountryCode"
+              defaultValue={address.countryCode || "CA"}
+              disabled={isReadOnly || isSaving}
+              placeholder="CA"
+            />
+          </FormField>
+          {!isReadOnly ? (
+            <div className="flex flex-wrap gap-2">
+              <Button type="submit" disabled={isSaving} aria-busy={isSaving}>
+                {isSaving ? "Saving…" : complete ? "Update address" : "Save address"}
+              </Button>
+              {complete ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setIsEditing(false)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
         </Form>
       ) : null}
-    </Section>
+    </div>
   );
 }

--- a/app/components/phone-numbers/SmsComplianceGate.tsx
+++ b/app/components/phone-numbers/SmsComplianceGate.tsx
@@ -102,6 +102,9 @@ export function SmsComplianceGate({
             <p className="md:col-span-2 text-sm font-medium">
               Toll-free verification
             </p>
+            <p className="md:col-span-2 text-sm text-muted-foreground">
+              Toll-free setup requires a Canadian business number (BN) for carrier approval.
+            </p>
             <div className="space-y-2">
               <Label htmlFor="doingBusinessAs">Doing business as (DBA)</Label>
               <Input
@@ -113,14 +116,24 @@ export function SmsComplianceGate({
             </div>
             <div className="space-y-2">
               <Label htmlFor="businessRegistrationNumber">
-                Business registration number (BN)
+                Business registration number (BN){" "}
+                <span className="text-destructive" aria-hidden>
+                  *
+                </span>
               </Label>
               <Input
                 id="businessRegistrationNumber"
                 name="businessRegistrationNumber"
                 defaultValue={profile.businessRegistrationNumber}
                 disabled={isReadOnly}
+                required
+                aria-required
+                placeholder="123456789RC0001"
               />
+              <p className="text-xs text-muted-foreground">
+                Required to set up toll-free SMS. Your CRA business number (9 digits + RC +
+                account).
+              </p>
             </div>
           </div>
         ) : null}

--- a/app/components/shared/InfoPopover.tsx
+++ b/app/components/shared/InfoPopover.tsx
@@ -20,8 +20,15 @@ export default function InfoPopover({
   return (
     <TooltipProvider delayDuration={200}>
       <Tooltip>
-        <TooltipTrigger>
-          <Info size={size} />
+        <TooltipTrigger asChild>
+          {/* type="button" so this never submits a surrounding <Form> (#1107). */}
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+            aria-label="More information"
+          >
+            <Info size={size} />
+          </button>
         </TooltipTrigger>
         <TooltipContent align={align}>
           <p>{tooltip}</p>

--- a/app/lib/campaign-goals.ts
+++ b/app/lib/campaign-goals.ts
@@ -85,6 +85,9 @@ export function productGoalForOnboardingGoal(
       return "text_campaign";
     case "ivr":
       return "automated_phone_menu";
+    case "rent_number":
+      // Number-only path; default new campaigns to live calling when they start one.
+      return "live_calling";
     default: {
       const _exhaustive: never = onboardingGoal;
       return _exhaustive;

--- a/app/lib/campaign-goals.ts
+++ b/app/lib/campaign-goals.ts
@@ -77,7 +77,7 @@ export function productGoalForCampaignType(
 /** Translate the existing onboarding vocabulary into product-level goals. */
 export function productGoalForOnboardingGoal(
   onboardingGoal: WorkspaceOnboardingGoal,
-): CampaignProductGoal {
+): CampaignProductGoal | null {
   switch (onboardingGoal) {
     case "live_call":
       return "live_calling";
@@ -86,8 +86,8 @@ export function productGoalForOnboardingGoal(
     case "ivr":
       return "automated_phone_menu";
     case "rent_number":
-      // Number-only path; default new campaigns to live calling when they start one.
-      return "live_calling";
+      // Number-only path has no campaign product goal.
+      return null;
     default: {
       const _exhaustive: never = onboardingGoal;
       return _exhaustive;

--- a/app/lib/database/campaign.server.ts
+++ b/app/lib/database/campaign.server.ts
@@ -88,6 +88,37 @@ function cleanObject<T extends object>(obj: T): Partial<T> {
   }, {} as Partial<T>);
 }
 
+/**
+ * Prefer a non-empty primary string; otherwise keep the nested details value.
+ * Callers often send top-level `body_text: ""` while the real content lives on
+ * `campaignDetails` (script/message editor), and `??` would keep the empty
+ * string and wipe the message (#1115).
+ */
+function coalesceCampaignText(
+  primary: unknown,
+  fallback: unknown,
+): string {
+  if (typeof primary === "string" && primary.length > 0) return primary;
+  if (typeof fallback === "string") return fallback;
+  if (typeof primary === "string") return primary;
+  return "";
+}
+
+function coalesceMessageMedia(
+  primary: unknown,
+  fallback: unknown,
+): string[] {
+  const fromPrimary = Array.isArray(primary)
+    ? primary.filter((item): item is string => typeof item === "string")
+    : null;
+  const fromFallback = Array.isArray(fallback)
+    ? fallback.filter((item): item is string => typeof item === "string")
+    : null;
+  if (fromPrimary && fromPrimary.length > 0) return fromPrimary;
+  if (fromFallback && fromFallback.length > 0) return fromFallback;
+  return fromPrimary ?? fromFallback ?? [];
+}
+
 function buildUnifiedCampaignFields(
   campaignData: CampaignData,
   campaignDetails: CampaignDetails,
@@ -104,8 +135,14 @@ function buildUnifiedCampaignFields(
         : scriptId === undefined
           ? undefined
           : Number(scriptId),
-    body_text: campaignData.body_text ?? campaignDetails.body_text ?? "",
-    message_media: campaignData.message_media ?? campaignDetails.message_media ?? [],
+    body_text: coalesceCampaignText(
+      campaignData.body_text,
+      campaignDetails.body_text,
+    ),
+    message_media: coalesceMessageMedia(
+      campaignData.message_media,
+      campaignDetails.message_media,
+    ),
     voicedrop_audio: campaignData.voicedrop_audio ?? campaignDetails.voicedrop_audio ?? null,
     disposition_options: campaignDetails.disposition_options,
     live_questions: campaignDetails.questions ?? campaignDetails.live_questions,
@@ -186,8 +223,16 @@ export async function updateCampaign({
     campaignData.script_id === null
       ? null
       : campaignData.script_id?.toString() ?? campaignDetails.script_id;
-  campaignDetails.body_text = campaignData.body_text || "";
-  campaignDetails.message_media = campaignData.message_media || [];
+  // Do not clobber nested message fields with empty top-level placeholders
+  // from the script editor PATCH payload (#1115).
+  campaignDetails.body_text = coalesceCampaignText(
+    campaignData.body_text,
+    campaignDetails.body_text,
+  );
+  campaignDetails.message_media = coalesceMessageMedia(
+    campaignData.message_media,
+    campaignDetails.message_media,
+  );
   campaignDetails.voicedrop_audio = campaignData.voicedrop_audio || null;
 
   const tdb = tdbIn ?? createTenantDb(workspace);

--- a/app/lib/database/campaign.server.ts
+++ b/app/lib/database/campaign.server.ts
@@ -95,28 +95,33 @@ function cleanObject<T extends object>(obj: T): Partial<T> {
  * string and wipe the message (#1115).
  */
 function coalesceCampaignText(
-  primary: unknown,
-  fallback: unknown,
+  primary: string | null | undefined,
+  fallback: string | null | undefined,
 ): string {
-  if (typeof primary === "string" && primary.length > 0) return primary;
-  if (typeof fallback === "string") return fallback;
-  if (typeof primary === "string") return primary;
-  return "";
+  if (primary != null && primary.length > 0) return primary;
+  if (fallback != null) return fallback;
+  return primary ?? "";
 }
 
 function coalesceMessageMedia(
-  primary: unknown,
-  fallback: unknown,
+  primary: string[] | null | undefined,
+  fallback: string[] | null | undefined,
 ): string[] {
-  const fromPrimary = Array.isArray(primary)
-    ? primary.filter((item): item is string => typeof item === "string")
-    : null;
-  const fromFallback = Array.isArray(fallback)
-    ? fallback.filter((item): item is string => typeof item === "string")
-    : null;
-  if (fromPrimary && fromPrimary.length > 0) return fromPrimary;
-  if (fromFallback && fromFallback.length > 0) return fromFallback;
-  return fromPrimary ?? fromFallback ?? [];
+  if (primary != null && primary.length > 0) return primary;
+  if (fallback != null && fallback.length > 0) return fallback;
+  return primary ?? fallback ?? [];
+}
+
+function asOptionalString(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) return value;
+  return typeof value === "string" ? value : undefined;
+}
+
+function asOptionalStringArray(value: unknown): string[] | null | undefined {
+  if (value === null || value === undefined) return value;
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : undefined;
 }
 
 function buildUnifiedCampaignFields(
@@ -136,12 +141,12 @@ function buildUnifiedCampaignFields(
           ? undefined
           : Number(scriptId),
     body_text: coalesceCampaignText(
-      campaignData.body_text,
-      campaignDetails.body_text,
+      asOptionalString(campaignData.body_text),
+      asOptionalString(campaignDetails.body_text),
     ),
     message_media: coalesceMessageMedia(
-      campaignData.message_media,
-      campaignDetails.message_media,
+      asOptionalStringArray(campaignData.message_media),
+      asOptionalStringArray(campaignDetails.message_media),
     ),
     voicedrop_audio: campaignData.voicedrop_audio ?? campaignDetails.voicedrop_audio ?? null,
     disposition_options: campaignDetails.disposition_options,
@@ -219,24 +224,27 @@ export async function updateCampaign({
   if (!id) throw new Error("Campaign ID is required");
   if (!workspace) throw new Error("Workspace is required");
 
-  campaignDetails.script_id =
-    campaignData.script_id === null
-      ? null
-      : campaignData.script_id?.toString() ?? campaignDetails.script_id;
-  // Do not clobber nested message fields with empty top-level placeholders
-  // from the script editor PATCH payload (#1115).
-  campaignDetails.body_text = coalesceCampaignText(
-    campaignData.body_text,
-    campaignDetails.body_text,
-  );
-  campaignDetails.message_media = coalesceMessageMedia(
-    campaignData.message_media,
-    campaignDetails.message_media,
-  );
-  campaignDetails.voicedrop_audio = campaignData.voicedrop_audio || null;
+  // Resolve nested fields without mutating the caller's campaignDetails
+  // object; empty top-level placeholders must not wipe nested content (#1115).
+  const resolvedDetails: CampaignDetails = {
+    ...campaignDetails,
+    script_id:
+      campaignData.script_id === null
+        ? null
+        : campaignData.script_id?.toString() ?? campaignDetails.script_id,
+    body_text: coalesceCampaignText(
+      asOptionalString(campaignData.body_text),
+      asOptionalString(campaignDetails.body_text),
+    ),
+    message_media: coalesceMessageMedia(
+      asOptionalStringArray(campaignData.message_media),
+      asOptionalStringArray(campaignDetails.message_media),
+    ),
+    voicedrop_audio: campaignData.voicedrop_audio || null,
+  };
 
   const tdb = tdbIn ?? createTenantDb(workspace);
-  const unifiedFields = buildUnifiedCampaignFields(campaignData, campaignDetails);
+  const unifiedFields = buildUnifiedCampaignFields(campaignData, resolvedDetails);
   const cleanCampaignData = {
     ...stripCampaignMetaFields(restCampaignData as Record<string, unknown>),
     ...unifiedFields,

--- a/app/lib/messaging-onboarding/goals.ts
+++ b/app/lib/messaging-onboarding/goals.ts
@@ -38,6 +38,11 @@ export const ONBOARDING_GOAL_OPTIONS: Array<{
     label: "SMS blast",
     description: "Send a text outreach campaign to an uploaded audience.",
   },
+  {
+    id: "rent_number",
+    label: "Just rent a number",
+    description: "Get a workspace phone number first. Add campaigns later.",
+  },
 ];
 
 /**
@@ -52,6 +57,8 @@ export function channelsForOnboardingGoal(
     case "live_call":
       return ["local_number", "voice_compliance"];
     case "ivr":
+      return ["local_number"];
+    case "rent_number":
       return ["local_number"];
     case "sms_blast": {
       if (operatingCountry === "US") return ["a2p10dlc"];
@@ -69,6 +76,9 @@ export function channelsForOnboardingGoal(
 export function checklistStepsForGoal(
   goal: WorkspaceOnboardingGoal | null,
 ): WizardOnboardingStepId[] {
+  if (goal === "rent_number") {
+    return ["first_number", "credits", "launch_checks"];
+  }
   const shared: WizardOnboardingStepId[] = ["audience", "first_number"];
   if (goal === "live_call") {
     return [...shared, "campaign_info", "credits", "launch_checks"];
@@ -77,15 +87,18 @@ export function checklistStepsForGoal(
   return [...shared, "script", "campaign_info", "credits", "launch_checks"];
 }
 
+/**
+ * Goal first (#1104), then minimal identity, then program only when SMS
+ * compliance needs it (#1105/#1106), then the goal checklist.
+ */
 export function wizardStepsForGoal(
   goal: WorkspaceOnboardingGoal | null,
 ): WizardOnboardingStepId[] {
-  return [
-    "business_identity",
-    "business_program",
-    "path_selection",
-    ...checklistStepsForGoal(goal),
-  ];
+  const afterGoal: WizardOnboardingStepId[] = ["business_identity"];
+  if (goalNeedsSmsCompliance(goal)) {
+    afterGoal.push("business_program");
+  }
+  return ["path_selection", ...afterGoal, ...checklistStepsForGoal(goal)];
 }
 
 export function nextWizardStep(
@@ -109,7 +122,7 @@ export function previousWizardStep(
 }
 
 export function goalNeedsScript(goal: WorkspaceOnboardingGoal | null): boolean {
-  return goal !== "live_call";
+  return goal !== "live_call" && goal !== "rent_number";
 }
 
 export function goalNeedsSmsCompliance(goal: WorkspaceOnboardingGoal | null): boolean {

--- a/app/lib/messaging-onboarding/goals.ts
+++ b/app/lib/messaging-onboarding/goals.ts
@@ -121,8 +121,16 @@ export function previousWizardStep(
   return steps[index - 1]!;
 }
 
+/** Whether the goal checklist includes a given post-goal step. */
+export function goalIncludesChecklistStep(
+  goal: WorkspaceOnboardingGoal | null,
+  stepId: WizardOnboardingStepId,
+): boolean {
+  return checklistStepsForGoal(goal).includes(stepId);
+}
+
 export function goalNeedsScript(goal: WorkspaceOnboardingGoal | null): boolean {
-  return goal !== "live_call" && goal !== "rent_number";
+  return goalIncludesChecklistStep(goal, "script");
 }
 
 export function goalNeedsSmsCompliance(goal: WorkspaceOnboardingGoal | null): boolean {

--- a/app/lib/messaging-onboarding/readiness.server.ts
+++ b/app/lib/messaging-onboarding/readiness.server.ts
@@ -125,14 +125,14 @@ export function buildOnboardingStepsForState(
   const pathSelected =
     predicatePassed("path_selection_complete", ctx) || Boolean(onboarding.selectedGoal);
   const audienceComplete = audienceCount > 0;
-  const scriptComplete = scriptCount > 0 || onboarding.selectedGoal === "live_call";
+  const scriptComplete = scriptCount > 0 || onboarding.selectedGoal === "live_call" || onboarding.selectedGoal === "rent_number";
   const campaignComplete = campaignCount > 0;
   const creditsComplete = creditsBalance > 0;
+  const rentNumberOnly = onboarding.selectedGoal === "rent_number";
   const launchComplete =
     messagingProvisioned &&
     hasFirstNumber &&
-    audienceComplete &&
-    campaignComplete &&
+    (rentNumberOnly || (audienceComplete && campaignComplete)) &&
     (!onboarding.selectedChannels.includes("voice_compliance") || emergencyReady);
 
   const steps: WorkspaceOnboardingStepState[] = [
@@ -144,28 +144,35 @@ export function buildOnboardingStepsForState(
       ...pathSelectionStep,
       status: pathSelected ? "complete" : "in_progress",
     },
-    {
-      ...audienceStep,
-      status: audienceComplete ? "complete" : "in_progress",
-    },
-    {
-      ...firstNumberStep,
-      status: hasFirstNumber ? "complete" : "in_progress",
-    },
   ];
 
-  if (onboarding.selectedGoal !== "live_call") {
+  if (!rentNumberOnly) {
+    steps.push({
+      ...audienceStep,
+      status: audienceComplete ? "complete" : "in_progress",
+    });
+  }
+
+  steps.push({
+    ...firstNumberStep,
+    status: hasFirstNumber ? "complete" : "in_progress",
+  });
+
+  if (onboarding.selectedGoal !== "live_call" && !rentNumberOnly) {
     steps.push({
       ...scriptStep,
       status: scriptComplete ? "complete" : "in_progress",
     });
   }
 
-  steps.push(
-    {
+  if (!rentNumberOnly) {
+    steps.push({
       ...campaignInfoStep,
       status: campaignComplete ? "complete" : "in_progress",
-    },
+    });
+  }
+
+  steps.push(
     {
       ...creditsStep,
       status: creditsComplete ? "complete" : "in_progress",

--- a/app/lib/messaging-onboarding/readiness.server.ts
+++ b/app/lib/messaging-onboarding/readiness.server.ts
@@ -5,6 +5,10 @@ import type {
 } from "@/lib/types";
 import { isRcsOnboardingEnabled } from "@/lib/rcs-onboarding.server";
 import { DEFAULT_WORKSPACE_ONBOARDING_STEPS } from "@/lib/messaging-onboarding/defaults.server";
+import {
+  checklistStepsForGoal,
+  goalIncludesChecklistStep,
+} from "@/lib/messaging-onboarding/goals";
 import { isWorkspaceIntakeComplete } from "@/lib/messaging-onboarding/intake";
 import {
   type WorkspaceReadinessContext,
@@ -21,6 +25,7 @@ import {
   countVerifiedCallerIdNumbers,
   isVerifiedCallerIdNumber,
 } from "@/lib/messaging-onboarding/predicates";
+import type { WizardOnboardingStepId } from "@/lib/messaging-onboarding/wizard-steps";
 import {
   buildWorkspaceLaunchChecklist,
   launchChecklistProgress,
@@ -110,78 +115,70 @@ export function buildOnboardingStepsForState(
   const stepById = Object.fromEntries(
     DEFAULT_WORKSPACE_ONBOARDING_STEPS.map((step) => [step.id, step]),
   ) as Record<string, WorkspaceOnboardingStepState>;
-  const businessProfileStep = stepById.business_profile!;
-  const pathSelectionStep = stepById.path_selection!;
-  const audienceStep = stepById.audience!;
-  const firstNumberStep = stepById.first_number!;
-  const scriptStep = stepById.script!;
-  const campaignInfoStep = stepById.campaign_info!;
-  const creditsStep = stepById.credits!;
-  const launchChecksStep = stepById.launch_checks!;
+  const goal = onboarding.selectedGoal;
 
   const businessBasicsComplete = isBusinessBasicsComplete(ctx);
   const emergencyReady = isEmergencyReady(onboarding);
   const messagingProvisioned = predicatePassed("messaging_service_provisioned", ctx);
   const pathSelected =
-    predicatePassed("path_selection_complete", ctx) || Boolean(onboarding.selectedGoal);
+    predicatePassed("path_selection_complete", ctx) || Boolean(goal);
   const audienceComplete = audienceCount > 0;
-  const scriptComplete = scriptCount > 0 || onboarding.selectedGoal === "live_call" || onboarding.selectedGoal === "rent_number";
   const campaignComplete = campaignCount > 0;
-  const creditsComplete = creditsBalance > 0;
-  const rentNumberOnly = onboarding.selectedGoal === "rent_number";
+  const needsAudience = goalIncludesChecklistStep(goal, "audience");
+  const needsCampaign = goalIncludesChecklistStep(goal, "campaign_info");
   const launchComplete =
     messagingProvisioned &&
     hasFirstNumber &&
-    (rentNumberOnly || (audienceComplete && campaignComplete)) &&
+    (!needsAudience || audienceComplete) &&
+    (!needsCampaign || campaignComplete) &&
     (!onboarding.selectedChannels.includes("voice_compliance") || emergencyReady);
+
+  const checklistStatus = (
+    stepId: WizardOnboardingStepId,
+  ): WorkspaceOnboardingStepState["status"] => {
+    switch (stepId) {
+      case "audience":
+        return audienceComplete ? "complete" : "in_progress";
+      case "first_number":
+        return hasFirstNumber ? "complete" : "in_progress";
+      case "script":
+        return scriptCount > 0 ? "complete" : "in_progress";
+      case "campaign_info":
+        return campaignComplete ? "complete" : "in_progress";
+      case "credits":
+        return creditsBalance > 0 ? "complete" : "in_progress";
+      case "launch_checks":
+        return launchComplete ? "complete" : "pending";
+      case "business_identity":
+      case "business_program":
+      case "path_selection":
+        return "pending";
+      default: {
+        const _exhaustive: never = stepId;
+        return _exhaustive;
+      }
+    }
+  };
 
   const steps: WorkspaceOnboardingStepState[] = [
     {
-      ...businessProfileStep,
+      ...stepById.business_profile!,
       status: businessBasicsComplete ? "complete" : "in_progress",
     },
     {
-      ...pathSelectionStep,
+      ...stepById.path_selection!,
       status: pathSelected ? "complete" : "in_progress",
     },
   ];
 
-  if (!rentNumberOnly) {
+  for (const stepId of checklistStepsForGoal(goal)) {
+    const template = stepById[stepId];
+    if (!template) continue;
     steps.push({
-      ...audienceStep,
-      status: audienceComplete ? "complete" : "in_progress",
+      ...template,
+      status: checklistStatus(stepId),
     });
   }
-
-  steps.push({
-    ...firstNumberStep,
-    status: hasFirstNumber ? "complete" : "in_progress",
-  });
-
-  if (onboarding.selectedGoal !== "live_call" && !rentNumberOnly) {
-    steps.push({
-      ...scriptStep,
-      status: scriptComplete ? "complete" : "in_progress",
-    });
-  }
-
-  if (!rentNumberOnly) {
-    steps.push({
-      ...campaignInfoStep,
-      status: campaignComplete ? "complete" : "in_progress",
-    });
-  }
-
-  steps.push(
-    {
-      ...creditsStep,
-      status: creditsComplete ? "complete" : "in_progress",
-    },
-    {
-      ...launchChecksStep,
-      status: launchComplete ? "complete" : "pending",
-    },
-  );
 
   return steps;
 }

--- a/app/lib/platform-onboarding-handlers.server.ts
+++ b/app/lib/platform-onboarding-handlers.server.ts
@@ -103,11 +103,11 @@ async function handleSaveWorkspaceName(
     actorUserId: ctx.actorUserId,
     updates: {
       status: "collecting_business",
-      currentStep: "business_identity",
+      currentStep: "path_selection",
     },
   });
 
-  return { kind: "redirect", step: "business_identity" };
+  return { kind: "redirect", step: "path_selection" };
 }
 
 async function handleSkipFirstNumber(ctx: OnboardingActionContext): Promise<OnboardingHandlerResult> {
@@ -217,6 +217,9 @@ async function handleSaveChannels(ctx: OnboardingActionContext): Promise<Onboard
     channelsFromForm.length > 0 ? selectedChannels : channelsForGoal,
   );
 
+  const nextStep =
+    nextWizardStep("path_selection", selectedGoal) ?? "business_identity";
+
   await persistWorkspaceOnboardingState({workspaceId: ctx.workspaceId,
     actorUserId: ctx.actorUserId,
     updates: {
@@ -225,7 +228,7 @@ async function handleSaveChannels(ctx: OnboardingActionContext): Promise<Onboard
       operatingCountry,
       businessProfile,
       status: "collecting_business",
-      currentStep: "audience",
+      currentStep: nextStep,
     },
   });
 
@@ -240,7 +243,7 @@ async function handleSaveChannels(ctx: OnboardingActionContext): Promise<Onboard
     await enqueueWorkspaceComplianceJob(ctx.workspaceId, "channels_selected");
   }
 
-  return { kind: "redirect", step: "audience" };
+  return { kind: "redirect", step: nextStep };
 }
 
 /**
@@ -308,12 +311,11 @@ async function handleSaveBusinessProfile(
     current.operatingCountry,
   );
 
+  // Goal is chosen first; identity/program advance along wizardStepsForGoal (#1104).
   const nextStep =
-    wizardStep === "business_identity"
-      ? "business_program"
-      : wizardStep === "business_program"
-        ? "path_selection"
-        : "path_selection";
+    wizardStep === "business_identity" || wizardStep === "business_program"
+      ? (nextWizardStep(wizardStep, current.selectedGoal) ?? "audience")
+      : (nextWizardStep("business_identity", current.selectedGoal) ?? "audience");
 
   await persistWorkspaceOnboardingState({workspaceId: ctx.workspaceId,
     actorUserId: ctx.actorUserId,

--- a/app/lib/workspace-onboarding-goals.ts
+++ b/app/lib/workspace-onboarding-goals.ts
@@ -7,6 +7,7 @@ export const WORKSPACE_ONBOARDING_GOAL_VALUES = [
   "live_call",
   "ivr",
   "sms_blast",
+  "rent_number",
 ] as const;
 
 export type WorkspaceOnboardingGoal =

--- a/app/lib/workspace-today.server.ts
+++ b/app/lib/workspace-today.server.ts
@@ -106,9 +106,10 @@ export function selectWorkspaceToday(
 
   if (canAdminister && input.campaigns.length === 0) {
     const goal = input.selectedGoal;
+    const productGoal = goal != null ? productGoalForOnboardingGoal(goal) : null;
     const href =
-      goal != null
-        ? `${baseUrl}/campaigns/new?goal=${encodeURIComponent(productGoalForOnboardingGoal(goal))}`
+      productGoal != null
+        ? `${baseUrl}/campaigns/new?goal=${encodeURIComponent(productGoal)}`
         : `${baseUrl}/campaigns/new`;
     return selection("create_campaign", href, input);
   }

--- a/app/routes/workspaces+/$id.tsx
+++ b/app/routes/workspaces+/$id.tsx
@@ -8,6 +8,7 @@ import {
   useOutlet,
   useOutletContext,
   useRevalidator,
+  useLocation,
 } from "react-router";
 import WorkspaceNav from "@/components/workspace/WorkspaceNav";
 import { OnboardingProgressStrip } from "./$id/onboarding/OnboardingProgressStrip";
@@ -121,6 +122,10 @@ function WorkspaceResolvedView({
 
   const liveCredits = workspace.credits;
   const canManageBilling = userRole === "admin" || userRole === "owner";
+  const location = useLocation();
+  // Credits page is where users top up — keep the low-credit banner off it (#1097).
+  const isBillingPage = /\/billing(?:\/|$)/.test(location.pathname);
+  const showLowCreditBanner = !isBillingPage && liveCredits < LOW_CREDIT_THRESHOLD;
 
   return (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
@@ -138,7 +143,7 @@ function WorkspaceResolvedView({
         tabIndex={-1}
         className="flex min-w-0 flex-1 flex-col gap-4 focus:outline-none"
       >
-        {liveCredits <= 0 ? (
+        {showLowCreditBanner && liveCredits <= 0 ? (
           <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
             <div className="font-medium">
               Credit balance is depleted. Add credits to resume campaigns and
@@ -152,7 +157,7 @@ function WorkspaceResolvedView({
               </Button>
             ) : null}
           </div>
-        ) : liveCredits < LOW_CREDIT_THRESHOLD ? (
+        ) : showLowCreditBanner ? (
           <div className="rounded-lg border border-warning/50 bg-warning/10 p-4 text-sm text-foreground">
             <div className="font-medium">
               Credits are running low ({liveCredits} left). Add credits to keep

--- a/app/routes/workspaces+/$id/audiences/new.route.tsx
+++ b/app/routes/workspaces+/$id/audiences/new.route.tsx
@@ -51,10 +51,6 @@ export default function AudiencesNew() {
     setCurrentStep(2);
   };
 
-  const goToPreviousStep = () => {
-    setCurrentStep(prev => prev - 1);
-  };
-
   return (
     <section id="form" className="px-4 pb-8 pt-6 sm:px-6">
       <PageShell title="Add a Call list" maxWidth="narrow">
@@ -141,16 +137,6 @@ export default function AudiencesNew() {
                     setCurrentStep(3);
                   }}
                 />
-                
-                <div className="flex items-center justify-between gap-4">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={goToPreviousStep}
-                  >
-                    Back
-                  </Button>
-                </div>
               </div>
             </Section>
           ) : null}

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.route.tsx
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.route.tsx
@@ -59,8 +59,19 @@ export default function ScriptEditor() {
   const handleSaveUpdate = async (saveScriptAsCopy: boolean) => {
     setIsSaving(true);
     try {
+      // Message edits live on campaignDetails; flatten onto the campaign row
+      // payload so PATCH does not persist an empty top-level body_text (#1115).
+      const campaignPayload =
+        pageData.type === "message"
+          ? {
+              ...pageData,
+              body_text: pageData.campaignDetails.body_text ?? "",
+              message_media: pageData.campaignDetails.message_media ?? [],
+            }
+          : pageData;
+
       const formData = new FormData();
-      formData.append("campaignData", JSON.stringify(pageData));
+      formData.append("campaignData", JSON.stringify(campaignPayload));
       formData.append(
         "campaignDetails",
         JSON.stringify(pageData.campaignDetails),
@@ -101,10 +112,16 @@ export default function ScriptEditor() {
       setPageData(savedPageData);
       setInitData(savedPageData);
       setShowSaveModal(false);
-      toast.success("Script saved");
+      toast.success(
+        pageData.type === "message" ? "Message saved" : "Script saved",
+      );
     } catch (error) {
       loggerClient.error("Error saving update:", error);
-      toast.error("Couldn't save the script. Please try again.");
+      toast.error(
+        pageData.type === "message"
+          ? "Couldn't save the message. Please try again."
+          : "Couldn't save the script. Please try again.",
+      );
     } finally {
       setIsSaving(false);
     }
@@ -180,7 +197,14 @@ export default function ScriptEditor() {
         <SaveBar
           isChanged={isChanged}
           isSaving={isSaving}
-          onSave={() => setShowSaveModal(true)}
+          onSave={() => {
+            // Message campaigns have no script copy flow — save directly (#1115).
+            if (pageData.type === "message") {
+              void handleSaveUpdate(false);
+              return;
+            }
+            setShowSaveModal(true);
+          }}
           onReset={handleReset}
         />
         <div className="flex h-full flex-grow flex-col gap-4 p-4">

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.route.tsx
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.route.tsx
@@ -59,19 +59,8 @@ export default function ScriptEditor() {
   const handleSaveUpdate = async (saveScriptAsCopy: boolean) => {
     setIsSaving(true);
     try {
-      // Message edits live on campaignDetails; flatten onto the campaign row
-      // payload so PATCH does not persist an empty top-level body_text (#1115).
-      const campaignPayload =
-        pageData.type === "message"
-          ? {
-              ...pageData,
-              body_text: pageData.campaignDetails.body_text ?? "",
-              message_media: pageData.campaignDetails.message_media ?? [],
-            }
-          : pageData;
-
       const formData = new FormData();
-      formData.append("campaignData", JSON.stringify(campaignPayload));
+      formData.append("campaignData", JSON.stringify(pageData));
       formData.append(
         "campaignDetails",
         JSON.stringify(pageData.campaignDetails),

--- a/app/routes/workspaces+/$id/campaigns/new.route.tsx
+++ b/app/routes/workspaces+/$id/campaigns/new.route.tsx
@@ -149,6 +149,19 @@ export default function CampaignsNew() {
                 })}
               </div>
             </fieldset>
+            {campaignGoal === "text_campaign" ? (
+              <div className="rounded-md bg-muted/40 p-3 text-sm text-muted-foreground">
+                <p className="font-medium text-foreground">
+                  Toll-free setup requires a Business Number (BN)
+                </p>
+                <p className="mt-1">
+                  To set up Canadian toll-free texting you need your CRA business number
+                  (e.g. 123456789RC0001). Add it in workspace onboarding or Settings → Business
+                  before you rent a toll-free number. Local numbers send at lower volume and
+                  skip BN verification.
+                </p>
+              </div>
+            ) : null}
           </Section>
           <div className="flex flex-col gap-2">
             <Button

--- a/app/routes/workspaces+/$id/onboarding.loader.server.ts
+++ b/app/routes/workspaces+/$id/onboarding.loader.server.ts
@@ -62,7 +62,7 @@ export const loader = defineLoader({
       loadWorkspaceOnboardingView(workspaceId),
       getWorkspaceInfo({ workspaceId }),
       getWorkspaceUsers({ workspaceId }),
-      listObjects("workspaceAudio", workspaceId),
+      listObjects("workspaceAudio", workspaceId).catch(() => [] as { id: number | string; name: string }[]),
       tdb.inbound_queue.findMany({
         columns: { id: true, name: true },
         orderBy: (queue, { asc: ascFn }) => [ascFn(queue.name)],

--- a/app/routes/workspaces+/$id/onboarding.route.tsx
+++ b/app/routes/workspaces+/$id/onboarding.route.tsx
@@ -72,10 +72,10 @@ export default function WorkspaceMessagingOnboardingRoute() {
     isReviewingEmergencyVoice: pendingAction === "review_emergency_voice",
     isVerifyingCallerId: pendingAction === "verify_caller_id",
   };
-  const a2pBlockingIssues = onboarding.reviewState.blockingIssues;
+  const a2pBlockingIssues = onboarding.reviewState?.blockingIssues ?? [];
   const a2pErrors = [
-    onboarding.a2p10dlc.rejectionReason,
-    onboarding.reviewState.lastError,
+    onboarding.a2p10dlc?.rejectionReason,
+    onboarding.reviewState?.lastError,
   ].filter((value, index, values): value is string => Boolean(value) && values.indexOf(value) === index);
 
   return (

--- a/app/routes/workspaces+/$id/onboarding/OnboardingBusinessIdentityStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingBusinessIdentityStep.tsx
@@ -10,6 +10,10 @@ type Props = Pick<OnboardingStepProps, "onboarding" | "isReadOnly" | "pending"> 
   formId?: string;
 };
 
+/**
+ * Bare-bones identity (#1105): only what every goal needs — legal name, website,
+ * and operating country (drives SMS channel selection).
+ */
 export function OnboardingBusinessIdentityStep({
   formId = "onboarding-business-identity-form",
   onboarding,
@@ -20,11 +24,15 @@ export function OnboardingBusinessIdentityStep({
 
   return (
     <Section variant="flat">
-      <SectionHeader compact title="Business identity" />
-      <Form id={formId} method="post" className="space-y-6">
+      <SectionHeader
+        compact
+        title="Business identity"
+        description="Just the basics for now. Compliance details can be filled in when a channel needs them."
+      />
+      <Form id={formId} method="post" className="max-w-xl space-y-6">
         <input type="hidden" name="_action" value="save_business_profile" />
         <input type="hidden" name="wizardStep" value="business_identity" />
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4">
           <FormField
             htmlFor="legalBusinessName"
             label="Legal business name"
@@ -39,30 +47,6 @@ export function OnboardingBusinessIdentityStep({
               disabled={isReadOnly}
               {...requiredFieldProps<HTMLInputElement>("legalBusinessName")}
             />
-          </FormField>
-          <FormField htmlFor="businessType" label="Business type">
-            <Input
-              id="businessType"
-              name="businessType"
-              placeholder="LLC"
-              defaultValue={onboarding.businessProfile.businessType}
-              disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField htmlFor="operatingCountry" label="Operating country">
-            <select
-              id="operatingCountry"
-              name="operatingCountry"
-              defaultValue={onboarding.operatingCountry}
-              disabled={isReadOnly}
-              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {OPERATING_COUNTRY_OPTIONS.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
           </FormField>
           <FormField
             htmlFor="websiteUrl"
@@ -80,44 +64,20 @@ export function OnboardingBusinessIdentityStep({
               {...requiredFieldProps<HTMLInputElement>("websiteUrl")}
             />
           </FormField>
-          <FormField htmlFor="privacyPolicyUrl" label="Privacy policy URL">
-            <Input
-              id="privacyPolicyUrl"
-              name="privacyPolicyUrl"
-              type="url"
-              placeholder="https://www.acmehealth.com/privacy"
-              defaultValue={onboarding.businessProfile.privacyPolicyUrl}
+          <FormField htmlFor="operatingCountry" label="Operating country">
+            <select
+              id="operatingCountry"
+              name="operatingCountry"
+              defaultValue={onboarding.operatingCountry}
               disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField htmlFor="termsOfServiceUrl" label="Terms of service URL">
-            <Input
-              id="termsOfServiceUrl"
-              name="termsOfServiceUrl"
-              type="url"
-              placeholder="https://www.acmehealth.com/terms"
-              defaultValue={onboarding.businessProfile.termsOfServiceUrl}
-              disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField htmlFor="supportEmail" label="Support email">
-            <Input
-              id="supportEmail"
-              name="supportEmail"
-              type="email"
-              placeholder="support@acmehealth.com"
-              defaultValue={onboarding.businessProfile.supportEmail}
-              disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField htmlFor="supportPhone" label="Support phone">
-            <Input
-              id="supportPhone"
-              name="supportPhone"
-              placeholder="+1 415 555 0100"
-              defaultValue={onboarding.businessProfile.supportPhone}
-              disabled={isReadOnly}
-            />
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {OPERATING_COUNTRY_OPTIONS.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           </FormField>
         </div>
       </Form>

--- a/app/routes/workspaces+/$id/onboarding/OnboardingBusinessProgramStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingBusinessProgramStep.tsx
@@ -1,6 +1,5 @@
 import { Form } from "react-router";
 import { FormField } from "@/components/ui/form-field";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Section, SectionHeader } from "@/components/shared/Section";
 import type { OnboardingStepProps } from "./types";
@@ -10,6 +9,10 @@ type Props = Pick<OnboardingStepProps, "onboarding" | "isReadOnly" | "pending"> 
   formId?: string;
 };
 
+/**
+ * SMS-only program details (#1106/#1076): strip to fields carriers need that
+ * lack a sensible default — use-case summary and sample messages.
+ */
 export function OnboardingBusinessProgramStep({
   formId = "onboarding-business-program-form",
   onboarding,
@@ -20,69 +23,31 @@ export function OnboardingBusinessProgramStep({
 
   return (
     <Section variant="flat">
-      <SectionHeader compact title="Program details" />
-      <Form id={formId} method="post" className="space-y-6">
+      <SectionHeader
+        compact
+        title="SMS program details"
+        description="Carriers review these when approving bulk texting. Keep them short and specific to how people opt in."
+      />
+      <Form id={formId} method="post" className="max-w-xl space-y-6">
         <input type="hidden" name="_action" value="save_business_profile" />
         <input type="hidden" name="wizardStep" value="business_program" />
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4">
           <FormField
-            className="md:col-span-2"
             htmlFor="useCaseSummary"
-            label="Use case summary"
+            label="What will you text about?"
             required
             error={requiredFieldError("useCaseSummary")}
           >
             <Textarea
               id="useCaseSummary"
               name="useCaseSummary"
-              placeholder="Appointment reminders for patients who opt in during booking."
+              placeholder="Example: Appointment reminders for patients who opt in when they book online."
               defaultValue={onboarding.businessProfile.useCaseSummary}
               disabled={isReadOnly}
               {...requiredFieldProps<HTMLTextAreaElement>("useCaseSummary")}
             />
           </FormField>
           <FormField
-            className="md:col-span-2"
-            htmlFor="optInWorkflow"
-            label="Opt-in workflow"
-          >
-            <Textarea
-              id="optInWorkflow"
-              name="optInWorkflow"
-              placeholder="Customer checks a consent box during online booking to receive calls and texts."
-              defaultValue={onboarding.businessProfile.optInWorkflow}
-              disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField htmlFor="optInKeywords" label="Opt-in keywords">
-            <Input
-              id="optInKeywords"
-              name="optInKeywords"
-              placeholder="START, JOIN"
-              defaultValue={onboarding.businessProfile.optInKeywords}
-              disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField htmlFor="optOutKeywords" label="Opt-out keywords">
-            <Input
-              id="optOutKeywords"
-              name="optOutKeywords"
-              placeholder="STOP, UNSUBSCRIBE"
-              defaultValue={onboarding.businessProfile.optOutKeywords}
-              disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField htmlFor="helpKeywords" label="Help keywords">
-            <Input
-              id="helpKeywords"
-              name="helpKeywords"
-              placeholder="HELP"
-              defaultValue={onboarding.businessProfile.helpKeywords}
-              disabled={isReadOnly}
-            />
-          </FormField>
-          <FormField
-            className="md:col-span-2"
             htmlFor="sampleMessages"
             label="Sample messages"
             required
@@ -96,6 +61,9 @@ export function OnboardingBusinessProgramStep({
               disabled={isReadOnly}
               {...requiredFieldProps<HTMLTextAreaElement>("sampleMessages")}
             />
+            <p className="mt-1 text-xs text-muted-foreground">
+              One example per line. Include your business name and an opt-out line.
+            </p>
           </FormField>
         </div>
       </Form>

--- a/app/routes/workspaces+/$id/onboarding/OnboardingChecklistLinkStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingChecklistLinkStep.tsx
@@ -50,7 +50,7 @@ export function OnboardingChecklistLinkStep({
         {helperText ? (
           <p className="text-sm text-muted-foreground">{helperText}</p>
         ) : null}
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
           <Button asChild>
             <Link to={actionHref}>{actionLabel}</Link>
           </Button>
@@ -63,7 +63,7 @@ export function OnboardingChecklistLinkStep({
             <Form method="post">
               <input type="hidden" name="_action" value="advance_step" />
               <input type="hidden" name="targetStep" value={nextStep} />
-              <Button type="submit" variant="ghost">
+              <Button type="submit" variant={complete ? "default" : "ghost"}>
                 {complete ? "Continue" : skipLabel}
               </Button>
             </Form>

--- a/app/routes/workspaces+/$id/onboarding/OnboardingCreditsStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingCreditsStep.tsx
@@ -19,9 +19,9 @@ export function OnboardingCreditsStep({
       <SectionHeader
         compact
         title="Credits"
-        description="Credits power calls, texts, and phone number rental. Add some when you are ready to run outreach."
+        description="Credits power calls, texts, and number rental."
       />
-      <div className="space-y-4">
+      <div className="space-y-3">
         <div className="flex max-w-md flex-wrap items-center justify-between gap-3 text-sm">
           <div>
             <div className="text-muted-foreground">Current balance</div>
@@ -33,9 +33,9 @@ export function OnboardingCreditsStep({
             <Link to={`/workspaces/${workspaceId}/billing`}>Add credits</Link>
           </Button>
         </div>
-        <p className="text-sm text-muted-foreground">
-          Number rental uses about {NUMBER_RENTAL_MONTHLY_CREDITS.toLocaleString()} credits per
-          30-day period. You can finish setup first and add credits before launching.
+        <p className="text-xs text-muted-foreground">
+          Number rental is about {NUMBER_RENTAL_MONTHLY_CREDITS.toLocaleString()} credits /
+          30 days. You can add credits before launch.
         </p>
         {!isReadOnly ? (
           <Form method="post">

--- a/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
@@ -53,13 +53,12 @@ function presetOrderForGoal(
 ): readonly InboundRoutingPresetId[] {
   switch (goal) {
     case "live_call":
+    case "rent_number":
       return ["agent", "queue", "voicemail", "automated_menu", "forward", "webhook_only"];
     case "ivr":
       return ["automated_menu", "voicemail", "queue", "agent", "forward", "webhook_only"];
     case "sms_blast":
       return ["voicemail", "agent", "queue", "automated_menu", "forward", "webhook_only"];
-    case "rent_number":
-      return ["agent", "queue", "voicemail", "automated_menu", "forward", "webhook_only"];
     case null:
       return ["agent", "queue", "automated_menu", "voicemail", "forward", "webhook_only"];
     default: {

--- a/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx
@@ -58,6 +58,8 @@ function presetOrderForGoal(
       return ["automated_menu", "voicemail", "queue", "agent", "forward", "webhook_only"];
     case "sms_blast":
       return ["voicemail", "agent", "queue", "automated_menu", "forward", "webhook_only"];
+    case "rent_number":
+      return ["agent", "queue", "voicemail", "automated_menu", "forward", "webhook_only"];
     case null:
       return ["agent", "queue", "automated_menu", "voicemail", "forward", "webhook_only"];
     default: {
@@ -163,9 +165,9 @@ export function OnboardingFirstNumberStep({
         <SectionHeader
           compact
           title="Phone number"
-          description="Rent a number for inbound and outbound traffic, or verify a number you already own for outbound calling and texting."
+          description="Set a service address, then rent a number or verify one you already own. Configure inbound routing after a number is on the workspace."
         />
-        <div className="space-y-6">
+        <div className="space-y-8">
           <ServiceAddressGate
             workspaceId={workspaceId}
             onboarding={onboarding}
@@ -176,8 +178,9 @@ export function OnboardingFirstNumberStep({
             <TooltipProvider>
               <div className="rounded-md bg-muted/40 p-3 text-sm text-muted-foreground">
                 <p>
-                  For SMS blasts, a toll-free number supports higher sending volume after
-                  verification. A local number works for lighter texting at a lower rate.
+                  Toll-free numbers support higher SMS volume after verification, and that
+                  path requires a Canadian business number (BN). A local number works for
+                  lighter texting without BN verification.
                 </p>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -186,8 +189,9 @@ export function OnboardingFirstNumberStep({
                     </button>
                   </TooltipTrigger>
                   <TooltipContent className="max-w-xs">
-                    Pick toll-free when you expect higher daily volume. Pick local when you mainly
-                    need a regional presence and lighter sending.
+                    Choose toll-free when you have a BN ready for carrier verification and
+                    expect higher daily volume. Choose local for regional presence and lighter
+                    sending.
                   </TooltipContent>
                 </Tooltip>
               </div>
@@ -208,85 +212,90 @@ export function OnboardingFirstNumberStep({
             </Alert>
           ) : null}
 
-          <div className="grid min-w-0 grid-cols-1 gap-6 xl:grid-cols-2">
-            <fieldset className="min-w-0 space-y-4 overflow-hidden rounded-md bg-muted/40 p-3">
-              <legend className="text-sm font-medium">Rent a Canadian number</legend>
-              <p className="text-sm text-muted-foreground">
-                Best for inbound SMS, inbound calls, and full two-way messaging.
-              </p>
-              {isReadOnly ? (
+          {/* Address first → then choose rent vs verify (#1114). */}
+          {hasServiceAddress ? (
+            <div className="grid min-w-0 grid-cols-1 gap-8">
+              <fieldset className="min-w-0 space-y-4 overflow-hidden rounded-md bg-muted/40 p-4">
+                <legend className="px-1 text-sm font-medium">Rent a Canadian number</legend>
                 <p className="text-sm text-muted-foreground">
-                  Only workspace owners and admins can rent numbers. Ask an admin to complete this
-                  step.
+                  Best for inbound SMS, inbound calls, and full two-way messaging.
                 </p>
-              ) : !hasServiceAddress ? (
-                <Alert>
-                  <AlertDescription>
-                    Save a service address above before searching for numbers to rent.
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <NumberPurchase
-                  fetcher={purchaseFetcher}
-                  workspaceId={workspaceId}
-                  creditsBalance={creditsBalance}
-                  billingLink={`/workspaces/${workspaceId}/billing`}
-                  onPurchaseComplete={handlePurchaseComplete}
-                />
-              )}
-            </fieldset>
+                {isReadOnly ? (
+                  <p className="text-sm text-muted-foreground">
+                    Only workspace owners and admins can rent numbers. Ask an admin to complete this
+                    step.
+                  </p>
+                ) : (
+                  <NumberPurchase
+                    fetcher={purchaseFetcher}
+                    workspaceId={workspaceId}
+                    creditsBalance={creditsBalance}
+                    billingLink={`/workspaces/${workspaceId}/billing`}
+                    onPurchaseComplete={handlePurchaseComplete}
+                  />
+                )}
+              </fieldset>
 
-            <fieldset className="min-w-0 space-y-4 overflow-hidden rounded-md bg-muted/40 p-3">
-              <legend className="text-sm font-medium">Verify your own number</legend>
-              <p className="text-sm text-muted-foreground">
-                Outbound SMS and calls only. Rent a number for inbound traffic.
-              </p>
-              {callerIdNumbers.length > 0 ? (
-                <ul className="space-y-2" data-testid="onboarding-caller-id-list">
-                  {callerIdNumbers.map((number) => {
-                    const pendingStatus =
-                      !isVerifiedCallerIdNumber(number) &&
-                      number.capabilities &&
-                      typeof number.capabilities === "object" &&
-                      !Array.isArray(number.capabilities) &&
-                      (number.capabilities as Record<string, unknown>)
-                        .verification_status === "pending";
-                    return (
-                      <li
-                        key={number.id ?? number.phone_number}
-                        className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
-                      >
-                        <span className="truncate font-mono">
-                          {number.phone_number ?? "Unknown number"}
-                        </span>
-                        <span className="shrink-0 text-xs text-muted-foreground">
-                          {isVerifiedCallerIdNumber(number)
-                            ? "Verified"
-                            : pendingStatus
-                              ? "Awaiting verification"
-                              : "Caller ID"}
-                        </span>
-                      </li>
-                    );
-                  })}
-                </ul>
-              ) : null}
-              {isReadOnly ? (
+              <fieldset className="min-w-0 space-y-4 overflow-hidden rounded-md bg-muted/40 p-4">
+                <legend className="px-1 text-sm font-medium">Verify your own number</legend>
                 <p className="text-sm text-muted-foreground">
-                  Only workspace owners and admins can verify numbers. Ask an admin to complete this
-                  step.
+                  Outbound SMS and calls only. Rent a number for inbound traffic.
                 </p>
-              ) : (
-                <CallerIdVerificationForm
-                  formId="onboarding-caller-id-form"
-                  actionName="verify_caller_id"
-                  disabled={isVerifying}
-                  isPending={isVerifying}
-                />
-              )}
-            </fieldset>
-          </div>
+                {callerIdNumbers.length > 0 ? (
+                  <ul className="space-y-2" data-testid="onboarding-caller-id-list">
+                    {callerIdNumbers.map((number) => {
+                      const pendingStatus =
+                        !isVerifiedCallerIdNumber(number) &&
+                        number.capabilities &&
+                        typeof number.capabilities === "object" &&
+                        !Array.isArray(number.capabilities) &&
+                        (number.capabilities as Record<string, unknown>)
+                          .verification_status === "pending";
+                      return (
+                        <li
+                          key={number.id ?? number.phone_number}
+                          className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border/60 bg-background px-3 py-2 text-sm"
+                        >
+                          <span className="truncate font-mono">
+                            {number.phone_number ?? "Unknown number"}
+                          </span>
+                          <span className="shrink-0 text-xs text-muted-foreground">
+                            {isVerifiedCallerIdNumber(number)
+                              ? "Verified"
+                              : pendingStatus
+                                ? "Awaiting verification"
+                                : "Caller ID"}
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : null}
+                {isReadOnly ? (
+                  <p className="text-sm text-muted-foreground">
+                    Only workspace owners and admins can verify numbers. Ask an admin to complete this
+                    step.
+                  </p>
+                ) : (
+                  <CallerIdVerificationForm
+                    formId="onboarding-caller-id-form"
+                    actionName="verify_caller_id"
+                    disabled={isVerifying}
+                    isPending={isVerifying}
+                  />
+                )}
+              </fieldset>
+            </div>
+          ) : (
+            <Alert>
+              <AlertDescription>
+                Save a service address above before searching for numbers to rent or verifying a
+                caller ID.
+              </AlertDescription>
+            </Alert>
+          )}
 
+          {/* Routing only after a rented number exists (#1114). */}
           {rentedNumbers.length > 0 && !isReadOnly ? (
             <div className="space-y-2 border-t border-border/60 pt-6">
               <div>

--- a/app/routes/workspaces+/$id/onboarding/OnboardingGoalStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingGoalStep.tsx
@@ -117,31 +117,46 @@ export function OnboardingGoalStep({
                   <span className="mt-0.5 shrink-0">
                     <InfoPopover
                       size={16}
-                      tooltip="Carriers apply different sending limits by number type. Toll-free numbers support higher-volume outreach once verification finishes."
+                      tooltip="Toll-free SMS verification requires your CRA business number (BN). Local numbers skip that verification and send at lower volume."
                     />
                   </span>
                   <p>
-                    For texting at higher volume, a toll-free number is usually the smoother path.
-                    A local number can send texts too, at a lower throughput.
+                    Toll-free is the higher-volume path, and it requires a Canadian business
+                    number (BN) for carrier verification. A local number can send texts at lower
+                    throughput without a BN.
                   </p>
                 </div>
                 {offersTollFree ? (
-                  <div className="flex flex-wrap gap-2">
+                  <div
+                    className="flex flex-wrap gap-2"
+                    role="group"
+                    aria-label="SMS number path"
+                  >
                     <Button
                       type="button"
                       size="sm"
-                      variant={smsNumberPath === "toll_free" ? "default" : "outline"}
+                      variant="outline"
+                      aria-pressed={smsNumberPath === "toll_free"}
                       onClick={() => setSmsNumberPath("toll_free")}
                       disabled={isReadOnly}
+                      className={cn(
+                        smsNumberPath === "toll_free" &&
+                          "border-border bg-secondary font-semibold text-secondary-foreground shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)]",
+                      )}
                     >
-                      Set Up Toll Free
+                      Set Up Toll Free (BN required)
                     </Button>
                     <Button
                       type="button"
                       size="sm"
-                      variant={smsNumberPath === "local" ? "default" : "outline"}
+                      variant="outline"
+                      aria-pressed={smsNumberPath === "local"}
                       onClick={() => setSmsNumberPath("local")}
                       disabled={isReadOnly}
+                      className={cn(
+                        smsNumberPath === "local" &&
+                          "border-border bg-secondary font-semibold text-secondary-foreground shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)]",
+                      )}
                     >
                       Continue with Local Number
                     </Button>
@@ -154,7 +169,8 @@ export function OnboardingGoalStep({
             <fieldset className="space-y-4 border-t border-border/60 pt-4">
               <legend className="text-sm font-medium">Toll-free verification details</legend>
               <p className="text-sm text-muted-foreground">
-                These details help carriers approve higher-volume texting on a toll-free number.
+                Toll-free setup requires your CRA business number (BN). Carriers use it to
+                approve higher-volume texting on a toll-free number.
               </p>
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
@@ -169,7 +185,10 @@ export function OnboardingGoalStep({
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="businessRegistrationNumber">
-                    Business registration number (BN)
+                    Business registration number (BN){" "}
+                    <span className="text-destructive" aria-hidden>
+                      *
+                    </span>
                   </Label>
                   <Input
                     id="businessRegistrationNumber"
@@ -177,7 +196,13 @@ export function OnboardingGoalStep({
                     placeholder="123456789RC0001"
                     defaultValue={profile.businessRegistrationNumber}
                     disabled={isReadOnly}
+                    required
+                    aria-required
                   />
+                  <p className="text-xs text-muted-foreground">
+                    Required to set up toll-free. Use your CRA business number (9 digits + RC +
+                    account), from your CRA documents.
+                  </p>
                 </div>
               </div>
               <div className="flex items-start gap-3">

--- a/app/routes/workspaces+/$id/onboarding/OnboardingGoalStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingGoalStep.tsx
@@ -139,10 +139,6 @@ export function OnboardingGoalStep({
                       aria-pressed={smsNumberPath === "toll_free"}
                       onClick={() => setSmsNumberPath("toll_free")}
                       disabled={isReadOnly}
-                      className={cn(
-                        smsNumberPath === "toll_free" &&
-                          "border-border bg-secondary font-semibold text-secondary-foreground shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)]",
-                      )}
                     >
                       Set Up Toll Free (BN required)
                     </Button>
@@ -153,10 +149,6 @@ export function OnboardingGoalStep({
                       aria-pressed={smsNumberPath === "local"}
                       onClick={() => setSmsNumberPath("local")}
                       disabled={isReadOnly}
-                      className={cn(
-                        smsNumberPath === "local" &&
-                          "border-border bg-secondary font-semibold text-secondary-foreground shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)]",
-                      )}
                     >
                       Continue with Local Number
                     </Button>

--- a/app/routes/workspaces+/$id/onboarding/OnboardingIntroStep.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingIntroStep.tsx
@@ -10,6 +10,7 @@ type OnboardingIntroStepProps = {
   isReadOnly: boolean;
   isSaving: boolean;
   error?: string | null;
+  onContinue?: () => void;
 };
 
 export function OnboardingIntroStep({
@@ -17,6 +18,7 @@ export function OnboardingIntroStep({
   isReadOnly,
   isSaving,
   error,
+  onContinue,
 }: OnboardingIntroStepProps) {
   return (
     <Section variant="flat">
@@ -31,7 +33,11 @@ export function OnboardingIntroStep({
             Workspace name: <span className="font-medium text-foreground">{workspaceName}</span>
           </p>
         ) : (
-          <Form method="post" className="space-y-6">
+          <Form
+            method="post"
+            className="space-y-6"
+            onSubmit={() => onContinue?.()}
+          >
             <input type="hidden" name="_action" value="save_workspace_name" />
             {error ? (
               <Alert variant="destructive" role="alert">

--- a/app/routes/workspaces+/$id/onboarding/OnboardingWizard.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingWizard.tsx
@@ -29,10 +29,6 @@ type OnboardingWizardProps = OnboardingLoaderData & {
   actionData?: OnboardingActionData;
 };
 
-function isBusinessPrefixStep(step: string | null): boolean {
-  return step === "business_identity" || step === "business_program";
-}
-
 function checklistCreateHref(
   workspaceId: string,
   resourcePath: "audiences/new" | "scripts/new" | "campaigns/new",
@@ -67,9 +63,18 @@ export function OnboardingWizard({
   const navigation = useNavigation();
   const isReadOnly = userRole !== "owner" && userRole !== "admin";
   const urlStep = searchParams.get("step");
+  // Intro is only the pre-wizard name screen. Any explicit ?step= (including
+  // path_selection / goal-first) should show the wizard, not the name form.
   const [showIntro, setShowIntro] = useState(
-    () => onboarding.status === "not_started" && !isBusinessPrefixStep(urlStep),
+    () => onboarding.status === "not_started" && !urlStep,
   );
+
+  useEffect(() => {
+    if (onboarding.status !== "not_started" || urlStep) {
+      setShowIntro(false);
+    }
+  }, [onboarding.status, urlStep]);
+
   const goal = onboarding.selectedGoal;
   const visibleSteps = wizardStepsForGoal(goal);
   const activeStep = showIntro
@@ -226,14 +231,14 @@ export function OnboardingWizard({
       {!showIntro && activeStep === "audience" && continueTarget ? (
         <OnboardingChecklistLinkStep
           title="Audience"
-          description="Upload the contacts you want to reach. Every live call, IVR, and SMS campaign uses an audience."
+          description="Upload the contacts you want to reach. Every live call, IVR, and SMS campaign uses a call list."
           complete={audienceCount > 0}
-          completeLabel={`You have ${audienceCount} audience${audienceCount === 1 ? "" : "s"} ready.`}
-          incompleteLabel="Create an audience and upload contacts, then return here to continue."
+          completeLabel={`You have ${audienceCount} call list${audienceCount === 1 ? "" : "s"} ready.`}
+          incompleteLabel="Create a call list and upload contacts, then return here to continue."
           actionHref={checklistCreateHref(workspaceId, "audiences/new", "audience")}
-          actionLabel={audienceCount > 0 ? "Manage audiences" : "Upload audience"}
+          actionLabel={audienceCount > 0 ? "Add another call list" : "Upload call list"}
           secondaryHref={`/workspaces/${workspaceId}/audiences`}
-          secondaryLabel="View audiences"
+          secondaryLabel="View call lists"
           nextStep={continueTarget}
           isReadOnly={isReadOnly}
         />

--- a/app/routes/workspaces+/$id/onboarding/OnboardingWizard.tsx
+++ b/app/routes/workspaces+/$id/onboarding/OnboardingWizard.tsx
@@ -63,17 +63,20 @@ export function OnboardingWizard({
   const navigation = useNavigation();
   const isReadOnly = userRole !== "owner" && userRole !== "admin";
   const urlStep = searchParams.get("step");
-  // Intro is only the pre-wizard name screen. Any explicit ?step= (including
-  // path_selection / goal-first) should show the wizard, not the name form.
-  const [showIntro, setShowIntro] = useState(
-    () => onboarding.status === "not_started" && !urlStep,
-  );
-
-  useEffect(() => {
-    if (onboarding.status !== "not_started" || urlStep) {
-      setShowIntro(false);
-    }
-  }, [onboarding.status, urlStep]);
+  // Intro is the pre-wizard name screen. Explicit ?step= or a session override
+  // wins over status; avoid syncing showIntro from props via an effect.
+  const autoShowIntro = onboarding.status === "not_started" && !urlStep;
+  const [introSession, setIntroSession] = useState<
+    "auto" | "force_show" | "force_hide"
+  >("auto");
+  const showIntro =
+    introSession === "force_hide"
+      ? false
+      : urlStep
+        ? false
+        : introSession === "force_show"
+          ? true
+          : autoShowIntro;
 
   const goal = onboarding.selectedGoal;
   const visibleSteps = wizardStepsForGoal(goal);
@@ -105,7 +108,7 @@ export function OnboardingWizard({
   const continueTarget = activeStep ? nextWizardStep(activeStep, goal) : null;
 
   const goToPreviousIntro = () => {
-    setShowIntro(true);
+    setIntroSession("force_show");
     navigate(`/workspaces/${workspaceId}/onboarding`, { replace: true });
   };
 
@@ -198,6 +201,7 @@ export function OnboardingWizard({
           isReadOnly={isReadOnly}
           isSaving={pending.isSavingWorkspaceName}
           error={actionError}
+          onContinue={() => setIntroSession("force_hide")}
         />
       ) : null}
 

--- a/app/routes/workspaces+/$id/onboarding/constants.ts
+++ b/app/routes/workspaces+/$id/onboarding/constants.ts
@@ -20,10 +20,10 @@ export const WIZARD_STEP_META: Array<{
   label: string;
   shortLabel: string;
 }> = [
+  { id: "path_selection", label: "Your goal", shortLabel: "Goal" },
   { id: "business_identity", label: "Business identity", shortLabel: "Identity" },
   { id: "business_program", label: "Program details", shortLabel: "Program" },
-  { id: "path_selection", label: "Your goal", shortLabel: "Goal" },
-  { id: "audience", label: "Audience", shortLabel: "Audience" },
+  { id: "audience", label: "Call list", shortLabel: "Call list" },
   { id: "first_number", label: "Phone number", shortLabel: "Number" },
   { id: "script", label: "Script", shortLabel: "Script" },
   { id: "campaign_info", label: "Campaign info", shortLabel: "Campaign" },

--- a/docs/remediation/sai-issues-2026-07-28.md
+++ b/docs/remediation/sai-issues-2026-07-28.md
@@ -1,0 +1,58 @@
+# Sai QA issues — 2026-07-28
+
+**Author:** sai-sy  
+**Parent:** [#1103](https://github.com/chester-hill-solutions/callcaster/issues/1103) Onboarding Change Requests  
+**Working branch:** `dev`  
+**Walkthrough date:** 2026-07-28  
+**Status:** Implementation in progress (product issues); #1116 deferred to devops track
+
+---
+
+## Goal
+
+Ship Sai’s 2026-07-28 onboarding pass plus the SMS content save bug, then clear Jul-22 leftovers still assigned. Environments (#1116) is a separate devops track.
+
+---
+
+## Issue ledger
+
+| Issue | Title | Status |
+|------:|-------|--------|
+| [#1115](https://github.com/chester-hill-solutions/callcaster/issues/1115) | SMS Content got cleared after save | **Done** — coalesce nested `body_text` + message save UX |
+| [#1107](https://github.com/chester-hill-solutions/callcaster/issues/1107) | Goal tooltip advances to audience | **Done** — InfoPopover `type="button"` |
+| [#1104](https://github.com/chester-hill-solutions/callcaster/issues/1104) | First step = goal (+ rent-a-number path) | **Done** — goal-first + `rent_number` |
+| [#1105](https://github.com/chester-hill-solutions/callcaster/issues/1105) | Identity bare bones (name + URL) | **Done** |
+| [#1106](https://github.com/chester-hill-solutions/callcaster/issues/1106) / [#1076](https://github.com/chester-hill-solutions/callcaster/issues/1076) | Program details strip / axe | **Done** — SMS-only, two fields |
+| [#1108](https://github.com/chester-hill-solutions/callcaster/issues/1108) | BN guidance for toll-free campaigns | **Done** — campaign create + TFV helper |
+| [#1109](https://github.com/chester-hill-solutions/callcaster/issues/1109) | Audience continue / manage confusing | **Done** — call-list copy + Continue styling |
+| [#1110](https://github.com/chester-hill-solutions/callcaster/issues/1110) | Rent a number issues (parent) | Parent of #1111–1114 |
+| [#1111](https://github.com/chester-hill-solutions/callcaster/issues/1111) | Double H1 on number step | **Done** — demoted address heading |
+| [#1112](https://github.com/chester-hill-solutions/callcaster/issues/1112) | Address form width + edit mode | **Done** |
+| [#1113](https://github.com/chester-hill-solutions/callcaster/issues/1113) | No space between action titles | **Done** — stacked fieldsets + gap |
+| [#1114](https://github.com/chester-hill-solutions/callcaster/issues/1114) | Number step too much at once | **Done** — progressive disclosure |
+| [#1097](https://github.com/chester-hill-solutions/callcaster/issues/1097) | Credits warning on credits page | **Done** — hide banner on `/billing` |
+| [#1095](https://github.com/chester-hill-solutions/callcaster/issues/1095) | Credits upload message too big | **Done** — compact credits step |
+| [#1094](https://github.com/chester-hill-solutions/callcaster/issues/1094) | Too much vertical padding | **Done** — upload dropzone |
+| [#1093](https://github.com/chester-hill-solutions/callcaster/issues/1093) | Upload audiences: 2 back buttons | **Done** — removed parent Back |
+| [#1077](https://github.com/chester-hill-solutions/callcaster/issues/1077) | Better upload UI component | Deferred |
+| [#1116](https://github.com/chester-hill-solutions/callcaster/issues/1116) | Environments (dev/qa/pre-prod/prod) | **Separate devops track** |
+
+---
+
+## Implementation notes
+
+### #1115
+
+`updateCampaign` / `buildUnifiedCampaignFields` prefer non-empty nested `campaignDetails.body_text` / `message_media` over empty top-level placeholders. Message campaigns save directly (no script copy modal) and flatten details into the PATCH payload.
+
+### #1107
+
+`InfoPopover` uses `TooltipTrigger asChild` + `<button type="button">` so it cannot submit the goal form.
+
+### #1104–1106
+
+`wizardStepsForGoal`: `path_selection` → `business_identity` → (`business_program` only for `sms_blast`) → checklist. New goal `rent_number` skips audience/script/campaign. Identity UI is name + website + country; program UI is use-case + samples only.
+
+### #1097
+
+Workspace low-credit banner is suppressed on `/billing`.

--- a/test/campaign-goals.test.ts
+++ b/test/campaign-goals.test.ts
@@ -58,6 +58,7 @@ describe("app/lib/campaign-goals.ts", () => {
       "live_call",
       "ivr",
       "sms_blast",
+      "rent_number",
     ];
 
     expect(
@@ -68,6 +69,7 @@ describe("app/lib/campaign-goals.ts", () => {
       live_call: "live_calling",
       ivr: "automated_phone_menu",
       sms_blast: "text_campaign",
+      rent_number: null,
     });
   });
 

--- a/test/db-campaign.server.test.ts
+++ b/test/db-campaign.server.test.ts
@@ -138,6 +138,46 @@ describe("app/lib/database/campaign.server.ts", () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
+  test("updateCampaign keeps nested body_text when top-level body_text is empty", async () => {
+    const mod = await import("../app/lib/database/campaign.server");
+
+    tdbMocks.campaign.update.mockResolvedValueOnce([
+      {
+        id: 1,
+        type: "message",
+        script_id: null,
+        body_text: "Keep this SMS",
+        message_media: ["https://example.com/a.png"],
+      },
+    ]);
+
+    await mod.updateCampaign({
+      campaignData: {
+        campaign_id: "1",
+        workspace: "w1",
+        title: "T",
+        type: "message",
+        body_text: "",
+        message_media: [],
+        is_active: 1,
+      } as any,
+      campaignDetails: {
+        campaign_id: "1",
+        body_text: "Keep this SMS",
+        message_media: ["https://example.com/a.png"],
+      },
+    });
+
+    expect(tdbMocks.campaign.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          body_text: "Keep this SMS",
+          message_media: ["https://example.com/a.png"],
+        }),
+      }),
+    );
+  });
+
   test("updateCampaign updates unified campaign row", async () => {
     const mod = await import("../app/lib/database/campaign.server");
 

--- a/test/messaging-onboarding-goals.test.ts
+++ b/test/messaging-onboarding-goals.test.ts
@@ -13,6 +13,7 @@ describe("messaging onboarding goals", () => {
       "voice_compliance",
     ]);
     expect(channelsForOnboardingGoal("ivr", "US")).toEqual(["local_number"]);
+    expect(channelsForOnboardingGoal("rent_number", "CA")).toEqual(["local_number"]);
   });
 
   test("maps SMS blast by operating country", () => {
@@ -24,7 +25,7 @@ describe("messaging onboarding goals", () => {
     ]);
   });
 
-  test("builds goal-specific checklist order", () => {
+  test("builds goal-first wizard order with SMS program only for sms_blast", () => {
     expect(checklistStepsForGoal("live_call")).toEqual([
       "audience",
       "first_number",
@@ -33,13 +34,23 @@ describe("messaging onboarding goals", () => {
       "launch_checks",
     ]);
     expect(checklistStepsForGoal("ivr")).toContain("script");
-    expect(wizardStepsForGoal("sms_blast")[0]).toBe("business_identity");
-    expect(wizardStepsForGoal("sms_blast")[1]).toBe("business_program");
-    expect(wizardStepsForGoal("sms_blast")[2]).toBe("path_selection");
+    expect(checklistStepsForGoal("rent_number")).toEqual([
+      "first_number",
+      "credits",
+      "launch_checks",
+    ]);
+    expect(wizardStepsForGoal("sms_blast")[0]).toBe("path_selection");
+    expect(wizardStepsForGoal("sms_blast")[1]).toBe("business_identity");
+    expect(wizardStepsForGoal("sms_blast")[2]).toBe("business_program");
+    expect(wizardStepsForGoal("live_call")).not.toContain("business_program");
+    expect(wizardStepsForGoal("rent_number")[0]).toBe("path_selection");
+    expect(wizardStepsForGoal("rent_number")).not.toContain("audience");
   });
 
   test("advances past first number according to goal", () => {
     expect(nextWizardStep("first_number", "live_call")).toBe("campaign_info");
     expect(nextWizardStep("first_number", "ivr")).toBe("script");
+    expect(nextWizardStep("first_number", "rent_number")).toBe("credits");
+    expect(nextWizardStep("path_selection", "sms_blast")).toBe("business_identity");
   });
 });

--- a/test/messaging-onboarding.server.test.ts
+++ b/test/messaging-onboarding.server.test.ts
@@ -380,6 +380,39 @@ describe("messaging onboarding helpers", () => {
     expect(ivrSteps).toHaveLength(8);
   });
 
+  test("rent_number checklist omits audience/script/campaign and launch ignores them", () => {
+    const rentNumber = mergeWorkspaceMessagingOnboardingState(
+      DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE,
+      {
+        selectedGoal: "rent_number",
+        selectedChannels: ["local_number"],
+        messagingService: {
+          ...DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE.messagingService,
+          serviceSid: "MG123",
+        },
+      },
+    );
+
+    const steps = buildOnboardingStepsForState(rentNumber, {
+      hasFirstNumber: true,
+      audienceCount: 0,
+      campaignCount: 0,
+      creditsBalance: 10,
+    });
+
+    expect(steps.find((step) => step.id === "audience")).toBeUndefined();
+    expect(steps.find((step) => step.id === "script")).toBeUndefined();
+    expect(steps.find((step) => step.id === "campaign_info")).toBeUndefined();
+    expect(steps.map((step) => step.id)).toEqual([
+      "business_profile",
+      "path_selection",
+      "first_number",
+      "credits",
+      "launch_checks",
+    ]);
+    expect(steps.find((step) => step.id === "launch_checks")?.status).toBe("complete");
+  });
+
   test("marks first_number complete when hasFirstNumber is true", () => {
     const state = mergeWorkspaceMessagingOnboardingState(
       DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE,

--- a/test/onboarding-business-profile-validation.test.ts
+++ b/test/onboarding-business-profile-validation.test.ts
@@ -245,7 +245,11 @@ describe("save_business_profile validation", () => {
     expect(mocks.persistWorkspaceOnboardingState).not.toHaveBeenCalled();
   });
 
-  test("advances identity save to business_program", async () => {
+  test("advances identity save to business_program for SMS goals", async () => {
+    mocks.getWorkspaceMessagingOnboardingState.mockResolvedValue(
+      onboardingState({ selectedGoal: "sms_blast" }),
+    );
+
     const outcome = await runOnboardingAction(
       USER_ID,
       WORKSPACE_ID,
@@ -264,6 +268,26 @@ describe("save_business_profile validation", () => {
         updates: expect.objectContaining({ currentStep: "business_program" }),
       }),
     );
+  });
+
+  test("advances identity save to audience when program is not required", async () => {
+    mocks.getWorkspaceMessagingOnboardingState.mockResolvedValue(
+      onboardingState({ selectedGoal: "live_call" }),
+    );
+
+    const outcome = await runOnboardingAction(
+      USER_ID,
+      WORKSPACE_ID,
+      "save_business_profile",
+      identityForm({
+        legalBusinessName: "Northgate Services Inc.",
+        websiteUrl: "https://www.northgateservices.example",
+      }),
+    );
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result).toMatchObject({ kind: "redirect", step: "audience" });
   });
 
   test("identity save preserves previously saved program fields", async () => {
@@ -319,7 +343,11 @@ describe("save_business_profile validation", () => {
     expect(mocks.persistWorkspaceOnboardingState).not.toHaveBeenCalled();
   });
 
-  test("advances program save to path_selection", async () => {
+  test("advances program save to audience for SMS goals", async () => {
+    mocks.getWorkspaceMessagingOnboardingState.mockResolvedValue(
+      onboardingState({ selectedGoal: "sms_blast" }),
+    );
+
     const outcome = await runOnboardingAction(
       USER_ID,
       WORKSPACE_ID,
@@ -332,12 +360,16 @@ describe("save_business_profile validation", () => {
 
     expect(outcome.ok).toBe(true);
     if (!outcome.ok) return;
-    expect(outcome.result).toMatchObject({ kind: "redirect", step: "path_selection" });
+    expect(outcome.result).toMatchObject({ kind: "redirect", step: "audience" });
     const mapped = mapOnboardingHandlerResult(outcome.result, outcome.detail, "ui");
-    expect(mapped).toMatchObject({ kind: "ui_redirect", step: "path_selection" });
+    expect(mapped).toMatchObject({ kind: "ui_redirect", step: "audience" });
   });
 
-  test("full baseline submit without wizardStep still advances to path_selection", async () => {
+  test("full baseline submit without wizardStep advances to audience", async () => {
+    mocks.getWorkspaceMessagingOnboardingState.mockResolvedValue(
+      onboardingState({ selectedGoal: "live_call" }),
+    );
+
     const outcome = await runOnboardingAction(
       USER_ID,
       WORKSPACE_ID,
@@ -347,9 +379,8 @@ describe("save_business_profile validation", () => {
 
     expect(outcome.ok).toBe(true);
     if (!outcome.ok) return;
-    expect(outcome.result).toMatchObject({ kind: "redirect", step: "path_selection" });
+    expect(outcome.result).toMatchObject({ kind: "redirect", step: "audience" });
   });
-
   test("rejects a JSON API submit with blank required fields", async () => {
     const outcome = await runOnboardingAction(USER_ID, WORKSPACE_ID, "save_business_profile", {
       legalBusinessName: "",

--- a/test/onboarding-save-workspace-name.test.ts
+++ b/test/onboarding-save-workspace-name.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 /**
  * The first onboarding page collects the workspace name. Submitting a blank
  * name must stay on that page; a valid name updates the workspace and advances
- * to business_identity.
+ * to path_selection (goal-first onboarding).
  */
 
 const mocks = vi.hoisted(() => ({
@@ -227,7 +227,7 @@ describe("save_workspace_name", () => {
         workspaceId: WORKSPACE_ID,
         updates: expect.objectContaining({
           status: "collecting_business",
-          currentStep: "business_identity",
+          currentStep: "path_selection",
         }),
       }),
     );
@@ -235,7 +235,7 @@ describe("save_workspace_name", () => {
     const mapped = mapOnboardingHandlerResult(outcome.result, outcome.detail, "ui");
     expect(mapped).toEqual({
       kind: "ui_redirect",
-      step: "business_identity",
+      step: "path_selection",
       searchParams: undefined,
     });
   });

--- a/vendor/chester-hill-solutions/shad-cc/dist/chunk-727NWYDA.js
+++ b/vendor/chester-hill-solutions/shad-cc/dist/chunk-727NWYDA.js
@@ -4,15 +4,15 @@ import { Button as Button$1, Link } from 'react-aria-components';
 import { jsx } from 'react/jsx-runtime';
 
 var buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-colors duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-[color,background-color,box-shadow,transform] duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px data-pressed:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:shadow-none",
-        outline: "border-border bg-background hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:bg-transparent dark:hover:bg-accent",
-        secondary: "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost: "hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
-        destructive: "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
+        default: "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:bg-primary/80 active:shadow-none data-pressed:bg-primary/80 data-pressed:shadow-none",
+        outline: "border-border bg-background hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:bg-transparent dark:hover:bg-accent",
+        secondary: "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:bg-secondary/70 active:shadow-none data-pressed:bg-secondary/70 data-pressed:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
+        destructive: "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:bg-destructive/80 active:shadow-none data-pressed:bg-destructive/80 data-pressed:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
         link: "font-sans font-medium text-primary underline-offset-4 hover:underline"
       },
       size: {

--- a/vendor/chester-hill-solutions/shad-cc/dist/chunk-727NWYDA.js
+++ b/vendor/chester-hill-solutions/shad-cc/dist/chunk-727NWYDA.js
@@ -4,15 +4,15 @@ import { Button as Button$1, Link } from 'react-aria-components';
 import { jsx } from 'react/jsx-runtime';
 
 var buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-[color,background-color,box-shadow,transform] duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px data-pressed:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-colors duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:bg-primary/80 active:shadow-none data-pressed:bg-primary/80 data-pressed:shadow-none",
-        outline: "border-border bg-background hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:bg-transparent dark:hover:bg-accent",
-        secondary: "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:bg-secondary/70 active:shadow-none data-pressed:bg-secondary/70 data-pressed:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost: "hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
-        destructive: "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:bg-destructive/80 active:shadow-none data-pressed:bg-destructive/80 data-pressed:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
+        default: "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:shadow-none",
+        outline: "border-border bg-background hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground aria-pressed:bg-secondary aria-pressed:font-semibold aria-pressed:text-secondary-foreground aria-pressed:shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)] dark:bg-transparent dark:hover:bg-accent",
+        secondary: "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground aria-pressed:bg-secondary aria-pressed:font-semibold aria-pressed:shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)]",
+        ghost: "hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
+        destructive: "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
         link: "font-sans font-medium text-primary underline-offset-4 hover:underline"
       },
       size: {

--- a/vendor/chester-hill-solutions/shad-cc/src/components/ui/button.tsx
+++ b/vendor/chester-hill-solutions/shad-cc/src/components/ui/button.tsx
@@ -10,20 +10,20 @@ import {
 import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-colors duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-[color,background-color,box-shadow,transform] duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px data-pressed:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:shadow-none",
+          "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:bg-primary/80 active:shadow-none data-pressed:bg-primary/80 data-pressed:shadow-none",
         outline:
-          "border-border bg-background hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:bg-transparent dark:hover:bg-accent",
+          "border-border bg-background hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:bg-transparent dark:hover:bg-accent",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:bg-secondary/70 active:shadow-none data-pressed:bg-secondary/70 data-pressed:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
+          "hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
+          "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:bg-destructive/80 active:shadow-none data-pressed:bg-destructive/80 data-pressed:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
         link: "font-sans font-medium text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/vendor/chester-hill-solutions/shad-cc/src/components/ui/button.tsx
+++ b/vendor/chester-hill-solutions/shad-cc/src/components/ui/button.tsx
@@ -10,20 +10,20 @@ import {
 import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-[color,background-color,box-shadow,transform] duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px data-pressed:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding font-heading text-sm font-semibold whitespace-nowrap transition-colors duration-150 outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:bg-primary/80 active:shadow-none data-pressed:bg-primary/80 data-pressed:shadow-none",
+          "bg-primary text-primary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-primary/90 active:shadow-none",
         outline:
-          "border-border bg-background hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:bg-transparent dark:hover:bg-accent",
+          "border-border bg-background hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground aria-pressed:bg-secondary aria-pressed:font-semibold aria-pressed:text-secondary-foreground aria-pressed:shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)] dark:bg-transparent dark:hover:bg-accent",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:bg-secondary/70 active:shadow-none data-pressed:bg-secondary/70 data-pressed:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+          "bg-secondary text-secondary-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.08)] hover:bg-secondary/80 active:shadow-none aria-expanded:bg-secondary aria-expanded:text-secondary-foreground aria-pressed:bg-secondary aria-pressed:font-semibold aria-pressed:shadow-[inset_0_1.5px_2px_0_rgb(0_0_0/0.1)]",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground active:bg-accent data-pressed:bg-accent aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
+          "hover:bg-accent hover:text-accent-foreground aria-expanded:bg-accent aria-expanded:text-accent-foreground dark:hover:bg-accent/70",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:bg-destructive/80 active:shadow-none data-pressed:bg-destructive/80 data-pressed:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
+          "bg-destructive text-destructive-foreground shadow-[inset_0_-1.5px_0_0_rgb(0_0_0/0.2)] hover:bg-destructive/90 active:shadow-none focus-visible:border-destructive/40 focus-visible:ring-destructive/20",
         link: "font-sans font-medium text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
## Summary

Sai’s 2026-07-28 onboarding walkthrough under parent [#1103](https://github.com/chester-hill-solutions/callcaster/issues/1103). Ledger and notes: `docs/remediation/sai-issues-2026-07-28.md`.

Also includes a small Button pressed-state fix in vendored `shad-cc` (React Aria `data-pressed`) and selected SMS path buttons that read as pressed/secondary instead of primary red.

## Tickets

### Onboarding flow

- **[#1104](https://github.com/chester-hill-solutions/callcaster/issues/1104)** — First wizard step is goal selection; adds **Just rent a number** (`rent_number`) path that skips audience / script / campaign and goes identity → number → credits → launch.
- **[#1105](https://github.com/chester-hill-solutions/callcaster/issues/1105)** — Business identity is bare bones: workspace name, website URL, and operating country only.
- **[#1106](https://github.com/chester-hill-solutions/callcaster/issues/1106)** / **[#1076](https://github.com/chester-hill-solutions/callcaster/issues/1076)** — Program details only for SMS goals; stripped to use-case + sample messages (axe-friendly, less form chrome).
- **[#1107](https://github.com/chester-hill-solutions/callcaster/issues/1107)** — Goal-step InfoPopover uses `type="button"` so the tooltip trigger cannot submit the form / advance the wizard.

### SMS / campaigns

- **[#1115](https://github.com/chester-hill-solutions/callcaster/issues/1115)** — SMS content no longer clears after save: `updateCampaign` / `buildUnifiedCampaignFields` coalesce nested `campaignDetails.body_text` / `message_media` over empty top-level placeholders; message campaigns save directly and flatten details into the PATCH payload.
- **[#1108](https://github.com/chester-hill-solutions/callcaster/issues/1108)** — BN guidance when creating toll-free / SMS campaigns (campaign create + TFV helper copy).

### Audience / call list

- **[#1109](https://github.com/chester-hill-solutions/callcaster/issues/1109)** — Audience continue / manage confusion: call-list naming and Continue styling.
- **[#1093](https://github.com/chester-hill-solutions/callcaster/issues/1093)** — Audience upload no longer shows two Back buttons (removed parent Back).
- **[#1094](https://github.com/chester-hill-solutions/callcaster/issues/1094)** — Upload dropzone vertical padding reduced.

### Rent a number (#1110 parent)

- **[#1110](https://github.com/chester-hill-solutions/callcaster/issues/1110)** — Parent for number-step issues below.
- **[#1111](https://github.com/chester-hill-solutions/callcaster/issues/1111)** — Double H1 on number step: service address heading demoted under the phone-number step.
- **[#1112](https://github.com/chester-hill-solutions/callcaster/issues/1112)** — Address form width + edit mode: compact summary when complete, Edit to reopen the form.
- **[#1113](https://github.com/chester-hill-solutions/callcaster/issues/1113)** — Space between rental action titles: stacked fieldsets with gap.
- **[#1114](https://github.com/chester-hill-solutions/callcaster/issues/1114)** — Number step progressive disclosure so less is shown at once.

### Credits

- **[#1097](https://github.com/chester-hill-solutions/callcaster/issues/1097)** — Low-credits warning hidden on the `/billing` credits page itself.
- **[#1095](https://github.com/chester-hill-solutions/callcaster/issues/1095)** — Onboarding credits step copy/layout compacted.

### Out of scope (not in this PR)

- **[#1077](https://github.com/chester-hill-solutions/callcaster/issues/1077)** — Better upload UI component — deferred.
- **[#1116](https://github.com/chester-hill-solutions/callcaster/issues/1116)** — Environments (dev/qa/pre-prod/prod) — separate devops track.

## Test plan

- [ ] **#1104** — Onboarding opens on goal; **Just rent a number** skips audience/script/campaign
- [ ] **#1105 / #1106** — SMS blast → identity (name/URL/country) → program (use-case + samples only)
- [ ] **#1107** — InfoPopover on goal/SMS path does not submit or advance the form
- [ ] **SMS path UI** — selected toll-free / local option looks pressed/secondary, not primary red
- [ ] **#1115** — Edit SMS body on a message campaign, save, reload — body persists
- [ ] **#1108** — Toll-free / BN guidance appears on relevant campaign create paths
- [ ] **#1109 / #1093 / #1094** — Call-list copy + Continue; single Back; tighter upload dropzone
- [ ] **#1111–#1114** — Number step: one primary heading, address summary+Edit, spaced actions, progressive disclosure
- [ ] **#1097 / #1095** — Compact credits step; billing page has no duplicate low-credit banner
- [ ] `bun test test/messaging-onboarding-goals.test.ts test/onboarding-business-profile-validation.test.ts test/onboarding-save-workspace-name.test.ts test/db-campaign.server.test.ts`

Closes #1103  
Closes #1104  
Closes #1105  
Closes #1106  
Closes #1107  
Closes #1108  
Closes #1109  
Closes #1110  
Closes #1111  
Closes #1112  
Closes #1113  
Closes #1114  
Closes #1115  
Closes #1093  
Closes #1094  
Closes #1095  
Closes #1097  
Closes #1076