### PR TITLE
Enhance API surface with capability enforcement for operations

### DIFF
--- a/app/lib/api-generated/sdk.gen.ts
+++ b/app/lib/api-generated/sdk.gen.ts
@@ -20,7 +20,7 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
 
 /**
  * Create campaign with script and phone number (one-shot)
- * Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both.
+ * Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both. Requires the campaigns.write capability for API keys.
  */
 export const createCampaignWithScript = <ThrowOnError extends boolean = false>(options: Options<CreateCampaignWithScriptData, ThrowOnError>) => {
     return (options.client ?? _heyApiClient).post<CreateCampaignWithScriptResponse2, CreateCampaignWithScriptError, ThrowOnError>({
@@ -46,7 +46,7 @@ export const createCampaignWithScript = <ThrowOnError extends boolean = false>(o
 
 /**
  * Send a single SMS
- * Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body.
+ * Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body. Requires the messages.send capability for API keys.
  */
 export const sendChatSms = <ThrowOnError extends boolean = false>(options: Options<SendChatSmsData, ThrowOnError>) => {
     return (options.client ?? _heyApiClient).post<SendChatSmsResponse, SendChatSmsError, ThrowOnError>({
@@ -72,7 +72,7 @@ export const sendChatSms = <ThrowOnError extends boolean = false>(options: Optio
 
 /**
  * Dispatch SMS to queued campaign contacts
- * Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user.
+ * Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user. Requires the campaigns.dispatch capability for API keys.
  */
 export const dispatchCampaignSms = <ThrowOnError extends boolean = false>(options: Options<DispatchCampaignSmsData, ThrowOnError>) => {
     return (options.client ?? _heyApiClient).post<DispatchCampaignSmsResponse, DispatchCampaignSmsError, ThrowOnError>({

--- a/app/lib/api-surface-platform.ts
+++ b/app/lib/api-surface-platform.ts
@@ -4,6 +4,7 @@ type Op = {
   method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
   handler: "loader" | "action";
   bodyType: "json" | "query" | "form" | "multipart" | "twiml" | "rawWebhook";
+  capability?: string;
 };
 
 type PlatformSeed = {
@@ -157,12 +158,17 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     docsGuide: GUIDE.platform,
     workspaceScoped: true,
     operations: [
-      { method: "GET", handler: "loader", bodyType: "query" },
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      },
       { method: "PATCH", handler: "action", bodyType: "json" },
       { method: "DELETE", handler: "action", bodyType: "json" },
     ],
     notes:
-      "Child index under data-plane layout middleware. GET supports session or API key; PATCH requires admin+ session; DELETE requires owner session.",
+      "Child index under data-plane layout middleware. GET supports session or API key with campaigns.read; PATCH requires admin+ session; DELETE requires owner session.",
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId",
@@ -295,10 +301,17 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     workspaceScoped: true,
     operations: [
       { method: "GET", handler: "loader", bodyType: "query" },
-      { method: "POST", handler: "action", bodyType: "json" },
+      {
+        method: "POST",
+        handler: "action",
+        bodyType: "json",
+        capability: "members.invite",
+      },
       { method: "PATCH", handler: "action", bodyType: "json" },
       { method: "DELETE", handler: "action", bodyType: "json" },
     ],
+    notes:
+      "GET/PATCH/DELETE are session-only. POST invite accepts session or API key with members.invite.",
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/api-keys",
@@ -317,13 +330,21 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
   platformSeed({
     path: "/api/workspaces/:workspaceId/audit-events",
     routeModule: "app/routes/api+/workspaces+/$workspaceId/audit-events.route.tsx",
-    authClass: "workspaceAdmin",
+    authClass: "apiKeyOrSession",
     ownerArea: "workspace",
     exposure: "sessionOnly",
     docsGuide: GUIDE.workspace,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
-    notes: "Owner-only session access until SEC-07 audit.read scopes land for API keys.",
+    operations: [
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "audit.read",
+      },
+    ],
+    notes:
+      "Requires owner session (via role matrix) or an API key with audit.read.",
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/campaigns",
@@ -333,7 +354,14 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      },
+    ],
   }),
   platformSeed({
     path: "/api/campaigns/:campaignId",
@@ -343,8 +371,18 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     operations: [
-      { method: "GET", handler: "loader", bodyType: "query" },
-      { method: "POST", handler: "action", bodyType: "json" },
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      },
+      {
+        method: "POST",
+        handler: "action",
+        bodyType: "json",
+        capability: "campaigns.write",
+      },
     ],
   }),
   platformSeed({
@@ -355,8 +393,18 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     operations: [
-      { method: "GET", handler: "loader", bodyType: "query" },
-      { method: "PATCH", handler: "action", bodyType: "json" },
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      },
+      {
+        method: "PATCH",
+        handler: "action",
+        bodyType: "json",
+        capability: "campaigns.write",
+      },
     ],
   }),
   platformSeed({
@@ -395,7 +443,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/contacts/:contactId",
@@ -405,8 +458,18 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     operations: [
-      { method: "GET", handler: "loader", bodyType: "query" },
-      { method: "DELETE", handler: "action", bodyType: "json" },
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      },
+      {
+        method: "DELETE",
+        handler: "action",
+        bodyType: "json",
+        capability: "campaigns.write",
+      },
     ],
   }),
   platformSeed({
@@ -417,7 +480,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/audiences/:audienceId",
@@ -428,7 +496,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/audience-uploads/:uploadId",
@@ -439,7 +512,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/scripts",
@@ -449,7 +527,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/scripts/:scriptId",
@@ -458,7 +541,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     ownerArea: "scripts",
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/surveys",
@@ -468,7 +556,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/surveys/:surveyId",
@@ -477,7 +570,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     ownerArea: "surveys",
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/surveys/:surveyId/responses",
@@ -486,7 +584,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     ownerArea: "surveys",
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/surveys/:surveyId/responses/export",
@@ -507,7 +610,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/conversations/:contactNumber",
@@ -518,7 +626,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/audios",
@@ -599,7 +712,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.telephony,
     workspaceScoped: true,
-    operations: [{ method: "POST", handler: "action", bodyType: "json" }],
+    operations: [{
+        method: "POST",
+        handler: "action",
+        bodyType: "json",
+        capability: "calls.control",
+      }],
     notes: "Workspace-scoped call disconnect using workspace Twilio credentials. Capability: calls.control.",
   }),
   platformSeed({
@@ -611,7 +729,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.telephony,
     workspaceScoped: true,
-    operations: [{ method: "POST", handler: "action", bodyType: "json" }],
+    operations: [{
+        method: "POST",
+        handler: "action",
+        bodyType: "json",
+        capability: "calls.start",
+      }],
     notes: "Start predictive/manual auto-dial conference for authenticated caller+ agent. Capability: calls.start.",
   }),
   platformSeed({
@@ -734,7 +857,12 @@ export const PLATFORM_API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "sessionOnly",
     docsGuide: GUIDE.data,
     workspaceScoped: true,
-    operations: [{ method: "GET", handler: "loader", bodyType: "query" }],
+    operations: [{
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      }],
   }),
   platformSeed({
     path: "/api/workspaces/:workspaceId/events",

--- a/app/lib/api-surface-types.ts
+++ b/app/lib/api-surface-types.ts
@@ -100,6 +100,8 @@ export type ApiSurfaceOperation = {
   method: HttpMethod;
   handler: "loader" | "action";
   bodyType: BodyType;
+  /** Product capability ID enforced for this operation (SEC-07). */
+  capability?: string;
 };
 
 export type ApiSurfaceEntry = {

--- a/app/lib/api-surface.ts
+++ b/app/lib/api-surface.ts
@@ -45,6 +45,7 @@ type Op = {
   method: HttpMethod;
   handler: "loader" | "action";
   bodyType: BodyType;
+  capability?: string;
 };
 
 type Seed = {
@@ -331,7 +332,14 @@ export const API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "publicSdk",
     docsGuide: "docs/api-create-campaign-with-script.md",
     workspaceScoped: true,
-    operations: [{ method: "POST", handler: "action", bodyType: "json" }],
+    operations: [
+      {
+        method: "POST",
+        handler: "action",
+        bodyType: "json",
+        capability: "campaigns.write",
+      },
+    ],
   }),
   seed({
     path: "/api/chat_sms",
@@ -341,7 +349,14 @@ export const API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "publicSdk",
     docsGuide: "docs/api-send-sms.md",
     workspaceScoped: true,
-    operations: [{ method: "POST", handler: "action", bodyType: "json" }],
+    operations: [
+      {
+        method: "POST",
+        handler: "action",
+        bodyType: "json",
+        capability: "messages.send",
+      },
+    ],
   }),
   seed({
     path: "/api/connect-campaign-conference/:workspaceId/:campaignId",
@@ -807,7 +822,14 @@ export const API_SURFACE: readonly ApiSurfaceEntry[] = [
     exposure: "publicSdk",
     docsGuide: "docs/api-send-sms.md",
     workspaceScoped: true,
-    operations: [{ method: "POST", handler: "action", bodyType: "json" }],
+    operations: [
+      {
+        method: "POST",
+        handler: "action",
+        bodyType: "json",
+        capability: "campaigns.dispatch",
+      },
+    ],
   }),
   seed({
     path: "/api/sms/status",

--- a/app/lib/audience-api-auth.server.ts
+++ b/app/lib/audience-api-auth.server.ts
@@ -1,0 +1,61 @@
+import type {
+  ApiKeyAuthResult,
+  BearerSessionAuthResult,
+  SessionAuthResult,
+} from "@/lib/api-auth.server";
+import { requireDualAuthCapability } from "@/lib/capability-guard.server";
+import type { ProductCapabilityId } from "@/lib/capabilities";
+import { AppError } from "@/lib/errors.server";
+
+type DualAuthLike =
+  | ApiKeyAuthResult
+  | BearerSessionAuthResult
+  | SessionAuthResult
+  | { authType: string; workspaceId?: string };
+
+/**
+ * Flat `/api/audiences` dual-auth workspace gate + product capability check.
+ * Shared by loader (read) and action (write) so capability wiring stays DRY.
+ */
+export async function requireAudienceWorkspaceAccess(args: {
+  auth?: DualAuthLike;
+  user?: { id: string };
+  workspaceId: string;
+  capability: ProductCapabilityId;
+  requireWorkspaceAccess: (args: {
+    user: { id: string };
+    workspaceId: string;
+  }) => Promise<void>;
+}): Promise<void> {
+  if (args.auth?.authType === "api_key") {
+    if (args.auth.workspaceId !== args.workspaceId) {
+      throw new AppError("Unauthorized", 403);
+    }
+  } else if (!args.user) {
+    throw new AppError("Unauthorized", 401);
+  } else {
+    await args.requireWorkspaceAccess({
+      user: args.user,
+      workspaceId: args.workspaceId,
+    });
+  }
+
+  if (
+    args.auth &&
+    (args.auth.authType === "api_key" ||
+      args.auth.authType === "session" ||
+      args.auth.authType === "bearer")
+  ) {
+    const gated = await requireDualAuthCapability({
+      auth: args.auth as
+        | ApiKeyAuthResult
+        | BearerSessionAuthResult
+        | SessionAuthResult,
+      workspaceId: args.workspaceId,
+      capability: args.capability,
+    });
+    if (gated instanceof Response) {
+      throw gated;
+    }
+  }
+}

--- a/app/lib/capabilities.ts
+++ b/app/lib/capabilities.ts
@@ -6,12 +6,14 @@
  * Keep this module free of server-only package imports — UI may import it.
  */
 export const PRODUCT_CAPABILITIES = {
-  "campaigns.read": "Read campaigns and queue state",
-  "campaigns.write": "Create and update campaigns",
-  "campaigns.dispatch": "Activate automated campaign dispatch",
+  "campaigns.read":
+    "Read campaigns, queue, contacts, audiences, scripts, surveys, conversations, and workspace metadata",
+  "campaigns.write":
+    "Create and update campaigns, mutate queues, and delete contacts",
+  "campaigns.dispatch": "Dispatch campaign SMS batches (/api/sms)",
   "calls.start": "Start dialer conferences and outbound call sessions",
   "calls.control": "Control live calls (disconnect, hold, transfer)",
-  "messages.send": "Send SMS and chat messages",
+  "messages.send": "Send direct chat SMS (/api/chat_sms)",
   "members.invite": "Invite and manage workspace members",
   "audit.read": "Read workspace audit events",
 } as const;

--- a/app/lib/capability-guard.server.ts
+++ b/app/lib/capability-guard.server.ts
@@ -5,7 +5,7 @@ import {
   type AuthorizationActor,
 } from "@chester-hill-solutions/auth";
 import { createRequireCapability } from "@chester-hill-solutions/auth-react-router";
-import type { RouterContextProvider } from "react-router";
+import type { RouterContextProvider, LoaderFunctionArgs } from "react-router";
 import {
   apiKeyActorFromScopes,
   sessionActorFromMembership,
@@ -13,7 +13,8 @@ import {
 import type { ProductCapabilityId } from "@/lib/capabilities";
 import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
 import { getUserRole } from "@/lib/database/workspace.server";
-import { jsonError } from "@/lib/platform-api.server";
+import { defineLoader } from "@/lib/handler.server";
+import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import type { DataPlaneAuthContextValue } from "@/lib/route-context.server";
 import type {
   ApiKeyAuthResult,
@@ -102,6 +103,66 @@ export async function requireDataPlaneRouteCapability(
     return gated;
   }
   return { workspaceId, auth };
+}
+
+/**
+ * Handler-factory auth strategy for data-plane loaders/actions that only need
+ * `workspaceId` + a product capability. Prefer this over inlining the same
+ * workspaceId check + {@link requireDataPlaneRouteCapability} call.
+ */
+export function dataPlaneCapabilityAuth(capability: ProductCapabilityId) {
+  return async ({
+    params,
+    context,
+  }: Pick<LoaderFunctionArgs, "params" | "context">) => {
+    const workspaceId = params.workspaceId;
+    if (!workspaceId) {
+      return jsonError("workspaceId is required", 400);
+    }
+    return requireDataPlaneRouteCapability(context, workspaceId, capability);
+  };
+}
+
+/**
+ * Auth strategy that gates on a capability then attaches one extra route param.
+ */
+export function dataPlaneCapabilityAuthWithParam<P extends string>(
+  capability: ProductCapabilityId,
+  paramName: P,
+) {
+  const base = dataPlaneCapabilityAuth(capability);
+  return async (args: Pick<LoaderFunctionArgs, "params" | "context">) => {
+    const value = args.params[paramName];
+    if (!value) {
+      return jsonError(`workspaceId and ${paramName} are required`, 400);
+    }
+    const gated = await base(args);
+    if (gated instanceof Response) return gated;
+    return Object.assign(gated, { [paramName]: value } as Record<P, string>);
+  };
+}
+
+type ListFail = { ok: false; error: string; status: number };
+
+/** Shared defineLoader shape for workspace-scoped list endpoints. */
+export function defineDataPlaneListLoader<K extends string>(config: {
+  capability: ProductCapabilityId;
+  key: K;
+  list: (
+    workspaceId: string,
+  ) => Promise<({ ok: true } & Record<K, unknown>) | ListFail>;
+}) {
+  return defineLoader({
+    auth: dataPlaneCapabilityAuth(config.capability),
+    sideEffects: ["db-read"],
+    handler: async ({ auth }) => {
+      const result = await config.list(auth.workspaceId);
+      if (!result.ok) {
+        return jsonError(result.error, result.status);
+      }
+      return jsonResponse({ [config.key]: result[config.key] }, 200);
+    },
+  });
 }
 
 /**

--- a/app/lib/capability-guard.server.ts
+++ b/app/lib/capability-guard.server.ts
@@ -5,11 +5,13 @@ import {
   type AuthorizationActor,
 } from "@chester-hill-solutions/auth";
 import { createRequireCapability } from "@chester-hill-solutions/auth-react-router";
+import type { RouterContextProvider } from "react-router";
 import {
   apiKeyActorFromScopes,
   sessionActorFromMembership,
 } from "@/lib/capability-actor.server";
 import type { ProductCapabilityId } from "@/lib/capabilities";
+import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
 import { getUserRole } from "@/lib/database/workspace.server";
 import { jsonError } from "@/lib/platform-api.server";
 import type { DataPlaneAuthContextValue } from "@/lib/route-context.server";
@@ -83,6 +85,23 @@ export async function requireDataPlaneCapability(
     }
     throw error;
   }
+}
+
+/**
+ * Resolve data-plane auth context and require a product capability.
+ * Returns `{ workspaceId, auth }` or a 403/404 Response.
+ */
+export async function requireDataPlaneRouteCapability(
+  context: Readonly<RouterContextProvider>,
+  workspaceId: string,
+  capability: ProductCapabilityId,
+): Promise<{ workspaceId: string; auth: DataPlaneAuthContextValue } | Response> {
+  const auth = getDataPlaneRouteContext(context, workspaceId);
+  const gated = await requireDataPlaneCapability(auth, capability);
+  if (gated instanceof Response) {
+    return gated;
+  }
+  return { workspaceId, auth };
 }
 
 /**

--- a/app/lib/openapi-build.ts
+++ b/app/lib/openapi-build.ts
@@ -243,6 +243,9 @@ export function buildOpenApiSpec(options: BuildOpenApiSpecOptions) {
         "x-callcaster-exposure": entry.exposure,
         "x-callcaster-auth-class": entry.authClass,
         "x-callcaster-docs-guide": entry.docsGuide,
+        ...(op.capability
+          ? { "x-callcaster-capability": op.capability }
+          : {}),
         security: securityForAuth(entry.authClass),
         ...(entry.workspaceScoped && op.method === "GET"
           ? {

--- a/app/lib/openapi-integrator.ts
+++ b/app/lib/openapi-integrator.ts
@@ -239,8 +239,9 @@ export const integratorPathOverrides = {
       operationId: "createCampaignWithScript",
       summary: "Create campaign with script and phone number (one-shot)",
       description:
-        "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both.",
+        "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both. Requires the campaigns.write capability for API keys.",
       tags: [INTEGRATOR_API_TAG, "Campaigns"],
+      "x-callcaster-capability": "campaigns.write",
       security: [...publicSecurity],
       requestBody: {
         required: true,
@@ -295,8 +296,9 @@ export const integratorPathOverrides = {
       operationId: "sendChatSms",
       summary: "Send a single SMS",
       description:
-        "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body.",
+        "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body. Requires the messages.send capability for API keys.",
       tags: [INTEGRATOR_API_TAG, "Messaging"],
+      "x-callcaster-capability": "messages.send",
       security: [...publicSecurity],
       requestBody: {
         required: true,
@@ -328,8 +330,9 @@ export const integratorPathOverrides = {
       operationId: "dispatchCampaignSms",
       summary: "Dispatch SMS to queued campaign contacts",
       description:
-        "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user.",
+        "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user. Requires the campaigns.dispatch capability for API keys.",
       tags: [INTEGRATOR_API_TAG, "Messaging"],
+      "x-callcaster-capability": "campaigns.dispatch",
       security: [...publicSecurity],
       requestBody: {
         required: true,

--- a/app/lib/openapi-platform.ts
+++ b/app/lib/openapi-platform.ts
@@ -230,15 +230,39 @@ export const platformOpenApiComponents = {
       type: "string" as const,
       enum: ["owner", "admin", "member", "caller"] as const,
     },
+    ProductCapabilityId: {
+      type: "string" as const,
+      enum: [
+        "campaigns.read",
+        "campaigns.write",
+        "campaigns.dispatch",
+        "calls.start",
+        "calls.control",
+        "messages.send",
+        "members.invite",
+        "audit.read",
+      ] as const,
+      description: "Stable product capability ID used as an API-key scope.",
+    },
     ApiKeySummary: {
       type: "object" as const,
-      required: ["id", "name", "key_prefix", "created_at"] as const,
+      required: ["id", "name", "key_prefix", "created_at", "scopes"] as const,
       properties: {
-        id: { type: "integer" as const },
+        id: { type: "string" as const },
         name: { type: "string" as const },
         key_prefix: { type: "string" as const },
         created_at: { type: "string" as const, format: "date-time" },
         last_used_at: { type: "string" as const, format: "date-time", nullable: true },
+        scopes: {
+          type: "array" as const,
+          items: { $ref: "#/components/schemas/ProductCapabilityId" },
+        },
+        expires_at: {
+          type: "string" as const,
+          format: "date-time",
+          nullable: true,
+          description: "ISO-8601 expiry; null only for pre-SEC-07 legacy keys.",
+        },
       },
     },
     ApiKeyListResponse: {
@@ -253,14 +277,33 @@ export const platformOpenApiComponents = {
     },
     CreateApiKeyRequest: {
       type: "object" as const,
-      required: ["name"] as const,
+      required: ["name", "scopes"] as const,
       properties: {
         name: { type: "string" as const, minLength: 1, maxLength: 200 },
+        scopes: {
+          type: "array" as const,
+          minItems: 1,
+          items: { $ref: "#/components/schemas/ProductCapabilityId" },
+          description: "At least one capability scope is required.",
+        },
+        expires_in_days: {
+          type: "integer" as const,
+          minimum: 1,
+          maximum: 365,
+          description: "Key TTL in days (default 90, max 365).",
+        },
       },
     },
     CreateApiKeyResponse: {
       type: "object" as const,
-      required: ["key", "id", "name", "key_prefix", "created_at"] as const,
+      required: [
+        "key",
+        "id",
+        "name",
+        "key_prefix",
+        "created_at",
+        "scopes",
+      ] as const,
       properties: {
         key: {
           type: "string" as const,
@@ -270,6 +313,15 @@ export const platformOpenApiComponents = {
         name: { type: "string" as const },
         key_prefix: { type: "string" as const },
         created_at: { type: "string" as const, format: "date-time" },
+        scopes: {
+          type: "array" as const,
+          items: { $ref: "#/components/schemas/ProductCapabilityId" },
+        },
+        expires_at: {
+          type: "string" as const,
+          format: "date-time",
+          nullable: true,
+        },
       },
     },
     DeleteApiKeyRequest: {
@@ -647,9 +699,10 @@ export const platformPathOverrides: Record<string, Record<string, unknown>> = {
       operationId: "getWorkspace",
       summary: "Get workspace details",
       tags: ["Platform API", "Workspace"],
+      "x-callcaster-capability": "campaigns.read",
       security: cutoverDataPlaneSecurity,
       description:
-        "Returns workspace metadata for an authorized session member or workspace API key scoped to the route workspace.",
+        "Returns workspace metadata for an authorized session member or workspace API key with campaigns.read scoped to the route workspace.",
       responses: {
         "200": {
           description: "Workspace details",
@@ -777,9 +830,9 @@ export const platformPathOverrides: Record<string, Record<string, unknown>> = {
       summary: "List workspace audit events",
       tags: ["Platform API", "Workspace"],
       "x-callcaster-capability": "audit.read",
-      security: [{ sessionCookie: [] }],
+      security: cutoverDataPlaneSecurity,
       description:
-        "Cursor-paginated immutable audit log for privileged workspace actions. Owner session only until API key scopes ship in SEC-07.",
+        "Cursor-paginated immutable audit log for privileged workspace actions. Requires owner session or an API key with the audit.read capability.",
       parameters: [
         {
           name: "cursor",
@@ -912,9 +965,9 @@ export const platformPathOverrides: Record<string, Record<string, unknown>> = {
       summary: "Invite a workspace member",
       tags: ["Platform API", "Workspace"],
       "x-callcaster-capability": "members.invite",
-      security: sessionOnlySecurity,
+      security: cutoverDataPlaneSecurity,
       description:
-        "Session-only trust-root route. Privileged role assignment may require MFA enrollment.",
+        "Invite a member with a session (role subordination rules apply) or an API key with members.invite (admin-equivalent role assignment: member/caller only). Privileged session role assignment may require MFA enrollment.",
       requestBody: {
         required: true,
         content: {

--- a/app/lib/platform-data.server.ts
+++ b/app/lib/platform-data.server.ts
@@ -221,7 +221,8 @@ export async function authForCampaign(
   const auth = await verifyApiKeyOrSession(request);
   if ("error" in auth) {
     return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getCampaignWorkspaceId(campaignId);
+  }
+  const workspaceId = await getCampaignWorkspaceId(campaignId);
   if (!workspaceId) {
     return jsonError("Campaign not found", 404);
   }
@@ -230,8 +231,7 @@ export async function authForCampaign(
     if (auth.workspaceId !== workspaceId) {
       return jsonError("Campaign not found", 404);
     }
-    // Workspace-scoped API keys retain full data-plane access; role gating
-    // applies to session (member) auth only. Capability gates are opt-in per route.
+    // Capability gates are applied by route handlers via requireDataPlaneCapability.
     return {
       userId: null,
       workspaceId,
@@ -252,7 +252,8 @@ export async function authForContact(
   const auth = await verifyApiKeyOrSession(request);
   if ("error" in auth) {
     return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getContactWorkspaceId(contactId);
+  }
+  const workspaceId = await getContactWorkspaceId(contactId);
   if (!workspaceId) {
     return jsonError("Contact not found", 404);
   }
@@ -261,8 +262,7 @@ export async function authForContact(
     if (auth.workspaceId !== workspaceId) {
       return jsonError("Contact not found", 404);
     }
-    // Workspace-scoped API keys retain full data-plane access; role gating
-    // applies to session (member) auth only. Capability gates are opt-in per route.
+    // Capability gates are applied by route handlers via requireDataPlaneCapability.
     return {
       userId: null,
       workspaceId,
@@ -282,7 +282,8 @@ export async function authForScript(
   const auth = await verifyApiKeyOrSession(request);
   if ("error" in auth) {
     return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getScriptWorkspaceId(scriptId);
+  }
+  const workspaceId = await getScriptWorkspaceId(scriptId);
   if (!workspaceId) {
     return jsonError("Script not found", 404);
   }
@@ -312,7 +313,8 @@ export async function authForSurvey(
   const auth = await verifyApiKeyOrSession(request);
   if ("error" in auth) {
     return jsonError(auth.error, auth.status);
-  }  const workspaceId = await getSurveyWorkspaceId(surveyId);
+  }
+  const workspaceId = await getSurveyWorkspaceId(surveyId);
   if (!workspaceId) {
     return jsonError("Survey not found", 404);
   }

--- a/app/lib/platform-members.server.ts
+++ b/app/lib/platform-members.server.ts
@@ -196,16 +196,13 @@ export async function listWorkspaceMembers(
   }
 }
 
-export async function inviteWorkspaceMember(
-  userId: string,
+async function inviteWorkspaceMemberWithActorRole(
+  actorRole: string,
   workspaceId: string,
   email: string,
   role: "owner" | "admin" | "member" | "caller",
 ) {
-  const access = await requireMemberManager(userId, workspaceId);
-  if (!access.ok) return access;
-
-  const escalation = assertNoRoleEscalation(access.actorRole, role);
+  const escalation = assertNoRoleEscalation(actorRole, role);
   if (!escalation.ok) return escalation;
 
   const cleanedEmail = email.toLowerCase().trim();
@@ -244,6 +241,35 @@ export async function inviteWorkspaceMember(
   }
 
   return { ok: true as const, invite: result.invite };
+}
+
+export async function inviteWorkspaceMember(
+  userId: string,
+  workspaceId: string,
+  email: string,
+  role: "owner" | "admin" | "member" | "caller",
+) {
+  const access = await requireMemberManager(userId, workspaceId);
+  if (!access.ok) return access;
+
+  return inviteWorkspaceMemberWithActorRole(
+    access.actorRole,
+    workspaceId,
+    email,
+    role,
+  );
+}
+
+/**
+ * Invite via API key with `members.invite`. Role assignment follows the admin
+ * subordination policy (member/caller only) until members.assign.* scopes exist.
+ */
+export async function inviteWorkspaceMemberAsApiKey(
+  workspaceId: string,
+  email: string,
+  role: "owner" | "admin" | "member" | "caller",
+) {
+  return inviteWorkspaceMemberWithActorRole("admin", workspaceId, email, role);
 }
 
 export async function updateWorkspaceMemberRole(

--- a/app/routes/api+/audiences.action.server.ts
+++ b/app/routes/api+/audiences.action.server.ts
@@ -2,7 +2,13 @@ import { data as routeData } from "react-router";
 import type { ActionFunctionArgs } from "react-router";
 import { requireWorkspaceAccess } from "@/lib/database/workspace.server";
 import { parseActionRequest } from "@/lib/request-utils.server";
-import { resolveDualAuthSession } from "@/lib/api-auth.server";
+import {
+  resolveDualAuthSession,
+  type ApiKeyAuthResult,
+  type BearerSessionAuthResult,
+  type SessionAuthResult,
+} from "@/lib/api-auth.server";
+import { requireDualAuthCapability } from "@/lib/capability-guard.server";
 import { AppError } from "@/lib/errors.server";
 import { defineAction } from "@/lib/handler.server";
 import {
@@ -20,7 +26,11 @@ type AudiencesDeps = {
   verifyAuth: (
     request: Request,
   ) => Promise<{
-    auth?: { authType: string; workspaceId?: string };
+    auth?:
+      | ApiKeyAuthResult
+      | BearerSessionAuthResult
+      | SessionAuthResult
+      | { authType: string; workspaceId?: string };
     headers: Headers;
     user?: { id: string };
   }>;
@@ -32,7 +42,11 @@ type AudiencesDeps = {
 };
 
 async function requireAudienceWorkspaceAccess(args: {
-  auth?: { authType: string; workspaceId?: string };
+  auth?:
+    | ApiKeyAuthResult
+    | BearerSessionAuthResult
+    | SessionAuthResult
+    | { authType: string; workspaceId?: string };
   user?: { id: string };
   workspaceId: string;
   requireWorkspaceAccess: AudiencesDeps["requireWorkspaceAccess"];
@@ -41,15 +55,33 @@ async function requireAudienceWorkspaceAccess(args: {
     if (args.auth.workspaceId !== args.workspaceId) {
       throw new AppError("Unauthorized", 403);
     }
-    return;
-  }
-  if (!args.user) {
+  } else if (!args.user) {
     throw new AppError("Unauthorized", 401);
+  } else {
+    await args.requireWorkspaceAccess({
+      user: args.user,
+      workspaceId: args.workspaceId,
+    });
   }
-  await args.requireWorkspaceAccess({
-    user: args.user,
-    workspaceId: args.workspaceId,
-  });
+
+  if (
+    args.auth &&
+    (args.auth.authType === "api_key" ||
+      args.auth.authType === "session" ||
+      args.auth.authType === "bearer")
+  ) {
+    const gated = await requireDualAuthCapability({
+      auth: args.auth as
+        | ApiKeyAuthResult
+        | BearerSessionAuthResult
+        | SessionAuthResult,
+      workspaceId: args.workspaceId,
+      capability: "campaigns.write",
+    });
+    if (gated instanceof Response) {
+      throw gated;
+    }
+  }
 }
 
 export const action = defineAction({
@@ -134,6 +166,9 @@ export const action = defineAction({
       response = { success: true };
     }
   } catch (error) {
+    if (error instanceof Response) {
+      return error;
+    }
     if (error instanceof AppError) {
       return routeData({ error: error.message }, { status: error.statusCode, headers });
     }

--- a/app/routes/api+/audiences.action.server.ts
+++ b/app/routes/api+/audiences.action.server.ts
@@ -8,7 +8,7 @@ import {
   type BearerSessionAuthResult,
   type SessionAuthResult,
 } from "@/lib/api-auth.server";
-import { requireDualAuthCapability } from "@/lib/capability-guard.server";
+import { requireAudienceWorkspaceAccess } from "@/lib/audience-api-auth.server";
 import { AppError } from "@/lib/errors.server";
 import { defineAction } from "@/lib/handler.server";
 import {
@@ -40,49 +40,6 @@ type AudiencesDeps = {
     workspaceId: string;
   }) => Promise<void>;
 };
-
-async function requireAudienceWorkspaceAccess(args: {
-  auth?:
-    | ApiKeyAuthResult
-    | BearerSessionAuthResult
-    | SessionAuthResult
-    | { authType: string; workspaceId?: string };
-  user?: { id: string };
-  workspaceId: string;
-  requireWorkspaceAccess: AudiencesDeps["requireWorkspaceAccess"];
-}) {
-  if (args.auth?.authType === "api_key") {
-    if (args.auth.workspaceId !== args.workspaceId) {
-      throw new AppError("Unauthorized", 403);
-    }
-  } else if (!args.user) {
-    throw new AppError("Unauthorized", 401);
-  } else {
-    await args.requireWorkspaceAccess({
-      user: args.user,
-      workspaceId: args.workspaceId,
-    });
-  }
-
-  if (
-    args.auth &&
-    (args.auth.authType === "api_key" ||
-      args.auth.authType === "session" ||
-      args.auth.authType === "bearer")
-  ) {
-    const gated = await requireDualAuthCapability({
-      auth: args.auth as
-        | ApiKeyAuthResult
-        | BearerSessionAuthResult
-        | SessionAuthResult,
-      workspaceId: args.workspaceId,
-      capability: "campaigns.write",
-    });
-    if (gated instanceof Response) {
-      throw gated;
-    }
-  }
-}
 
 export const action = defineAction({
   sideEffects: ["db-write"],
@@ -126,6 +83,7 @@ export const action = defineAction({
         auth,
         user,
         workspaceId,
+        capability: "campaigns.write",
         requireWorkspaceAccess: d.requireWorkspaceAccess,
       });
 
@@ -156,6 +114,7 @@ export const action = defineAction({
         auth,
         user,
         workspaceId,
+        capability: "campaigns.write",
         requireWorkspaceAccess: d.requireWorkspaceAccess,
       });
 

--- a/app/routes/api+/audiences.loader.server.ts
+++ b/app/routes/api+/audiences.loader.server.ts
@@ -7,15 +7,25 @@ import {
   listAudienceContactsForExport,
   listAudienceContactsJson,
 } from "@/lib/database/contact-audience.server";
-import { resolveDualAuthSession } from "@/lib/api-auth.server";
+import {
+  resolveDualAuthSession,
+  type ApiKeyAuthResult,
+  type BearerSessionAuthResult,
+  type SessionAuthResult,
+} from "@/lib/api-auth.server";
 import { findAudienceWorkspaceById } from "@/lib/audience-upload-db.server";
+import { requireDualAuthCapability } from "@/lib/capability-guard.server";
 import { AppError } from "@/lib/errors.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 type AudiencesDeps = {
   verifyAuth: (request: Request) => Promise<{
-    auth?: { authType: string; workspaceId?: string };
+    auth?:
+      | ApiKeyAuthResult
+      | BearerSessionAuthResult
+      | SessionAuthResult
+      | { authType: string; workspaceId?: string };
     user?: { id: string };
     headers: Headers;
   }>;
@@ -41,7 +51,11 @@ const AUDIENCE_CONTACT_SORT_KEYS = new Set([
 ]);
 
 async function requireAudienceWorkspaceAccess(args: {
-  auth?: { authType: string; workspaceId?: string };
+  auth?:
+    | ApiKeyAuthResult
+    | BearerSessionAuthResult
+    | SessionAuthResult
+    | { authType: string; workspaceId?: string };
   user?: { id: string };
   workspaceId: string;
   requireWorkspaceAccess: AudiencesDeps["requireWorkspaceAccess"];
@@ -50,15 +64,33 @@ async function requireAudienceWorkspaceAccess(args: {
     if (args.auth.workspaceId !== args.workspaceId) {
       throw new AppError("Unauthorized", 403);
     }
-    return;
-  }
-  if (!args.user) {
+  } else if (!args.user) {
     throw new AppError("Unauthorized", 401);
+  } else {
+    await args.requireWorkspaceAccess({
+      user: args.user,
+      workspaceId: args.workspaceId,
+    });
   }
-  await args.requireWorkspaceAccess({
-    user: args.user,
-    workspaceId: args.workspaceId,
-  });
+
+  if (
+    args.auth &&
+    (args.auth.authType === "api_key" ||
+      args.auth.authType === "session" ||
+      args.auth.authType === "bearer")
+  ) {
+    const gated = await requireDualAuthCapability({
+      auth: args.auth as
+        | ApiKeyAuthResult
+        | BearerSessionAuthResult
+        | SessionAuthResult,
+      workspaceId: args.workspaceId,
+      capability: "campaigns.read",
+    });
+    if (gated instanceof Response) {
+      throw gated;
+    }
+  }
 }
 
 function flattenAudienceExportRows(rawData: Array<Record<string, unknown>>) {
@@ -190,6 +222,9 @@ export const loader = defineLoader({
       const data = await listAudienceContactsJson(parsedAudienceId);
       return routeData({ data }, { headers });
     } catch (error) {
+      if (error instanceof Response) {
+        return error;
+      }
       logger.error("Error fetching contact audience data:", error);
       if (error instanceof AppError) {
         return routeData({ error: error.message }, { status: error.statusCode, headers });

--- a/app/routes/api+/audiences.loader.server.ts
+++ b/app/routes/api+/audiences.loader.server.ts
@@ -14,7 +14,7 @@ import {
   type SessionAuthResult,
 } from "@/lib/api-auth.server";
 import { findAudienceWorkspaceById } from "@/lib/audience-upload-db.server";
-import { requireDualAuthCapability } from "@/lib/capability-guard.server";
+import { requireAudienceWorkspaceAccess } from "@/lib/audience-api-auth.server";
 import { AppError } from "@/lib/errors.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
@@ -49,49 +49,6 @@ const AUDIENCE_CONTACT_SORT_KEYS = new Set([
   "country",
   "created_at",
 ]);
-
-async function requireAudienceWorkspaceAccess(args: {
-  auth?:
-    | ApiKeyAuthResult
-    | BearerSessionAuthResult
-    | SessionAuthResult
-    | { authType: string; workspaceId?: string };
-  user?: { id: string };
-  workspaceId: string;
-  requireWorkspaceAccess: AudiencesDeps["requireWorkspaceAccess"];
-}) {
-  if (args.auth?.authType === "api_key") {
-    if (args.auth.workspaceId !== args.workspaceId) {
-      throw new AppError("Unauthorized", 403);
-    }
-  } else if (!args.user) {
-    throw new AppError("Unauthorized", 401);
-  } else {
-    await args.requireWorkspaceAccess({
-      user: args.user,
-      workspaceId: args.workspaceId,
-    });
-  }
-
-  if (
-    args.auth &&
-    (args.auth.authType === "api_key" ||
-      args.auth.authType === "session" ||
-      args.auth.authType === "bearer")
-  ) {
-    const gated = await requireDualAuthCapability({
-      auth: args.auth as
-        | ApiKeyAuthResult
-        | BearerSessionAuthResult
-        | SessionAuthResult,
-      workspaceId: args.workspaceId,
-      capability: "campaigns.read",
-    });
-    if (gated instanceof Response) {
-      throw gated;
-    }
-  }
-}
 
 function flattenAudienceExportRows(rawData: Array<Record<string, unknown>>) {
   return rawData.map((row) => {
@@ -159,6 +116,7 @@ export const loader = defineLoader({
           auth,
           user,
           workspaceId: audienceWorkspace,
+          capability: "campaigns.read",
           requireWorkspaceAccess: d.requireWorkspaceAccess,
         });
 
@@ -216,6 +174,7 @@ export const loader = defineLoader({
         auth,
         user,
         workspaceId: resolvedWorkspaceId,
+        capability: "campaigns.read",
         requireWorkspaceAccess: d.requireWorkspaceAccess,
       });
 

--- a/app/routes/api+/campaigns/$campaignId.action.server.ts
+++ b/app/routes/api+/campaigns/$campaignId.action.server.ts
@@ -1,4 +1,5 @@
 import { parseJsonBodyOrResponse } from "@/lib/api-parse.server";
+import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { defineAction, defineLoader } from "@/lib/handler.server";
 import {
@@ -19,6 +20,9 @@ export const loader = defineLoader({
 
     const auth = await authForCampaign(request, campaignId);
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.read");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, campaignId };
   },
@@ -47,6 +51,9 @@ export const action = defineAction({
     // mutations: require at least `member`, blocking the `caller` role.
     const auth = await authForCampaign(request, campaignId, "member");
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.write");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, campaignId };
   },

--- a/app/routes/api+/campaigns/$campaignId/queue.action.server.ts
+++ b/app/routes/api+/campaigns/$campaignId/queue.action.server.ts
@@ -1,4 +1,5 @@
 import { parseJsonBodyOrResponse } from "@/lib/api-parse.server";
+import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { defineAction, defineLoader } from "@/lib/handler.server";
 import {
@@ -22,6 +23,9 @@ export const loader = defineLoader({
 
     const auth = await authForCampaign(request, campaignId);
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.read");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, campaignId };
   },
@@ -80,6 +84,9 @@ export const action = defineAction({
     // Destructive mutation: require at least `member`, blocking the `caller` role.
     const auth = await authForCampaign(request, campaignId, "member");
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.write");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, campaignId };
   },

--- a/app/routes/api+/campaigns/create-with-script.action.server.ts
+++ b/app/routes/api+/campaigns/create-with-script.action.server.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from "@/lib/logger.server";
 import { verifyApiKeyOrSession } from "@/lib/api-auth.server";
 import { parseJsonBodyOrResponse } from "@/lib/api-parse.server";
+import { requireDualAuthCapability } from "@/lib/capability-guard.server";
 import { defineAction } from "@/lib/handler.server";
 import {
   createWithScriptBodySchema,
@@ -82,6 +83,15 @@ export const action = defineAction({
       workspaceId: bodyWorkspaceId,
     });
     workspaceId = bodyWorkspaceId;
+  }
+
+  const capability = await requireDualAuthCapability({
+    auth: authResult,
+    workspaceId,
+    capability: "campaigns.write",
+  });
+  if (capability instanceof Response) {
+    return capability;
   }
 
   const preflight = await validateCreateWithScriptPreflight({

--- a/app/routes/api+/chat_sms.action.server.ts
+++ b/app/routes/api+/chat_sms.action.server.ts
@@ -9,6 +9,7 @@ import { parseOptionalString } from "@/lib/parse-utils.server";
 import { sendMessage } from "@/lib/chat-sms.server";
 import { verifyApiKeyOrSession } from "@/lib/api-auth.server";
 import { parseJsonBodyOrResponse } from "@/lib/api-parse.server";
+import { requireDualAuthCapability } from "@/lib/capability-guard.server";
 import { chatSmsBodySchema } from "@/lib/schemas/api/chat-sms";
 import type { TwilioMessageIntent } from "@/lib/types";
 import { eq } from "drizzle-orm";
@@ -142,6 +143,15 @@ export const action = defineAction({
     await requireWorkspaceAccess({user: authResult.user,
       workspaceId: workspace_id,
     });
+  }
+
+  const capability = await requireDualAuthCapability({
+    auth: authResult,
+    workspaceId: workspace_id,
+    capability: "messages.send",
+  });
+  if (capability instanceof Response) {
+    return capability;
   }
 
   // Fail-closed credit gate: reject sends when the balance is unknown or

--- a/app/routes/api+/contacts/$contactId.action.server.ts
+++ b/app/routes/api+/contacts/$contactId.action.server.ts
@@ -1,3 +1,4 @@
+import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { defineAction, defineLoader } from "@/lib/handler.server";
 import {
@@ -16,6 +17,9 @@ export const loader = defineLoader({
 
     const auth = await authForContact(request, contactId);
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.read");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, contactId };
   },
@@ -47,6 +51,9 @@ export const action = defineAction({
     // Destructive mutation: require at least `member`, blocking the `caller` role.
     const auth = await authForContact(request, contactId, "member");
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.write");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, contactId };
   },

--- a/app/routes/api+/scripts/$scriptId.loader.server.ts
+++ b/app/routes/api+/scripts/$scriptId.loader.server.ts
@@ -1,3 +1,4 @@
+import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { authForScript, getScriptDetailApi } from "@/lib/platform-data.server";
 import { defineLoader } from "@/lib/handler.server";
@@ -12,6 +13,9 @@ export const loader = defineLoader({
 
     const auth = await authForScript(request, scriptId);
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.read");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, scriptId };
   },

--- a/app/routes/api+/sms.action.server.ts
+++ b/app/routes/api+/sms.action.server.ts
@@ -17,6 +17,7 @@ import { env } from "@/lib/env.server";
 import { logger } from "@/lib/logger.server";
 import { normalizePhoneNumber, processTemplateTags } from "@/lib/utils";
 import { verifyApiKeyOrSession } from "@/lib/api-auth.server";
+import { requireDualAuthCapability } from "@/lib/capability-guard.server";
 import { parseJsonBodyOrResponse } from "@/lib/api-parse.server";
 import { campaignSmsDispatchBodySchema } from "@/lib/schemas/api/sms";
 import type { TwilioMessageIntent, WorkspaceTwilioOpsConfig } from "@/lib/types";
@@ -264,6 +265,15 @@ export const action = defineAction({
       await requireWorkspaceAccess({user: authResult.user,
         workspaceId: workspace_id,
       });
+    }
+
+    const capability = await requireDualAuthCapability({
+      auth: authResult,
+      workspaceId: workspace_id,
+      capability: "campaigns.dispatch",
+    });
+    if (capability instanceof Response) {
+      return capability;
     }
 
     // Fail-closed credit gate: check once at entry for the whole batch

--- a/app/routes/api+/surveys/$surveyId.loader.server.ts
+++ b/app/routes/api+/surveys/$surveyId.loader.server.ts
@@ -1,3 +1,4 @@
+import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { authForSurvey, getSurveyDetailApi } from "@/lib/platform-data.server";
 import { defineLoader } from "@/lib/handler.server";
@@ -12,6 +13,9 @@ export const loader = defineLoader({
 
     const auth = await authForSurvey(request, surveyId);
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.read");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, surveyId };
   },

--- a/app/routes/api+/surveys/$surveyId/responses.loader.server.ts
+++ b/app/routes/api+/surveys/$surveyId/responses.loader.server.ts
@@ -1,3 +1,4 @@
+import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   authForSurvey,
@@ -16,6 +17,9 @@ export const loader = defineLoader({
 
     const auth = await authForSurvey(request, surveyId);
     if (auth instanceof Response) return auth;
+
+    const capability = await requireDataPlaneCapability(auth, "campaigns.read");
+    if (capability instanceof Response) return capability;
 
     return { ...auth, surveyId };
   },

--- a/app/routes/api+/workspaces+/$workspaceId.action.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId.action.server.ts
@@ -1,5 +1,6 @@
 import { parseJsonBodyOrResponse } from "@/lib/api-parse.server";
 import { getSession } from "@/lib/auth.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
 import { updateWorkspaceBodySchema } from "@/lib/schemas/api/platform-auth";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
@@ -11,7 +12,7 @@ import {
 import { defineAction, defineLoader } from "@/lib/handler.server";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 
-function resolveDataPlaneWorkspaceAuth({
+async function resolveDataPlaneWorkspaceAuth({
   params,
   context,
 }: Pick<LoaderFunctionArgs, "params" | "context">) {
@@ -20,21 +21,21 @@ function resolveDataPlaneWorkspaceAuth({
     return jsonError("workspaceId is required", 400);
   }
 
-  const auth = getDataPlaneRouteContext(context, workspaceId);
-  return { workspaceId, auth };
+  return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
 }
 
 function requireSessionUser(
   args: Pick<ActionFunctionArgs, "params" | "context">,
 ) {
-  const resolved = resolveDataPlaneWorkspaceAuth(args);
-  if (resolved instanceof Response) {
-    return resolved;
+  const workspaceId = args.params.workspaceId;
+  if (!workspaceId) {
+    return jsonError("workspaceId is required", 400);
   }
-  if (!resolved.auth.userId) {
+  const auth = getDataPlaneRouteContext(args.context, workspaceId);
+  if (!auth.userId) {
     return jsonError("Unauthorized", 401);
   }
-  return { workspaceId: resolved.workspaceId, userId: resolved.auth.userId };
+  return { workspaceId, userId: auth.userId };
 }
 
 export const loader = defineLoader({

--- a/app/routes/api+/workspaces+/$workspaceId/audience-uploads/$uploadId.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audience-uploads/$uploadId.loader.server.ts
@@ -2,25 +2,12 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   getAudienceUploadStatusApi,
 } from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
+import { dataPlaneCapabilityAuthWithParam } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: async ({ params, context }: LoaderFunctionArgs) => {
-    const workspaceId = params.workspaceId;
-    const uploadId = params.uploadId;
-    if (!workspaceId || !uploadId) {
-      return jsonError("workspaceId and uploadId are required", 400);
-    }
-    const gated = await requireDataPlaneRouteCapability(
-      context,
-      workspaceId,
-      "campaigns.read",
-    );
-    if (gated instanceof Response) return gated;
-    return { ...gated, uploadId };
-  },
+  auth: (args) =>
+    dataPlaneCapabilityAuthWithParam("campaigns.read", "uploadId")(args),
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {
     const result = await getAudienceUploadStatusApi(

--- a/app/routes/api+/workspaces+/$workspaceId/audience-uploads/$uploadId.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audience-uploads/$uploadId.loader.server.ts
@@ -2,20 +2,24 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   getAudienceUploadStatusApi,
 } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: LoaderFunctionArgs) => {
+  auth: async ({ params, context }: LoaderFunctionArgs) => {
     const workspaceId = params.workspaceId;
     const uploadId = params.uploadId;
     if (!workspaceId || !uploadId) {
       return jsonError("workspaceId and uploadId are required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
-
-    return { workspaceId, uploadId };
+    const gated = await requireDataPlaneRouteCapability(
+      context,
+      workspaceId,
+      "campaigns.read",
+    );
+    if (gated instanceof Response) return gated;
+    return { ...gated, uploadId };
   },
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/audiences.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences.loader.server.ts
@@ -1,18 +1,16 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { listWorkspaceAudiencesApi } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: LoaderFunctionArgs) => {
+  auth: async ({ params, context }: LoaderFunctionArgs) => {
     const workspaceId = params.workspaceId;
     if (!workspaceId) {
       return jsonError("workspaceId is required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
-
-    return { workspaceId };
+    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
   },
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/audiences.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences.loader.server.ts
@@ -1,24 +1,8 @@
-import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { listWorkspaceAudiencesApi } from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
-import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
+import { defineDataPlaneListLoader } from "@/lib/capability-guard.server";
 
-export const loader = defineLoader({
-  auth: async ({ params, context }: LoaderFunctionArgs) => {
-    const workspaceId = params.workspaceId;
-    if (!workspaceId) {
-      return jsonError("workspaceId is required", 400);
-    }
-    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
-  },
-  sideEffects: ["db-read"],
-  handler: async ({ auth }) => {
-    const result = await listWorkspaceAudiencesApi(auth.workspaceId);
-    if (!result.ok) {
-      return jsonError(result.error, result.status);
-    }
-
-    return jsonResponse({ audiences: result.audiences }, 200);
-  },
+export const loader = defineDataPlaneListLoader({
+  capability: "campaigns.read",
+  key: "audiences",
+  list: listWorkspaceAudiencesApi,
 });

--- a/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
@@ -2,25 +2,12 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   getAudienceDetailApi,
 } from "@/lib/audience-detail.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
+import { dataPlaneCapabilityAuthWithParam } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: async ({ params, context }: LoaderFunctionArgs) => {
-    const workspaceId = params.workspaceId;
-    const audienceId = params.audienceId;
-    if (!workspaceId || !audienceId) {
-      return jsonError("workspaceId and audienceId are required", 400);
-    }
-    const gated = await requireDataPlaneRouteCapability(
-      context,
-      workspaceId,
-      "campaigns.read",
-    );
-    if (gated instanceof Response) return gated;
-    return { ...gated, audienceId };
-  },
+  auth: (args) =>
+    dataPlaneCapabilityAuthWithParam("campaigns.read", "audienceId")(args),
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {
     const result = await getAudienceDetailApi(

--- a/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
@@ -2,20 +2,24 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   getAudienceDetailApi,
 } from "@/lib/audience-detail.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: LoaderFunctionArgs) => {
+  auth: async ({ params, context }: LoaderFunctionArgs) => {
     const workspaceId = params.workspaceId;
     const audienceId = params.audienceId;
     if (!workspaceId || !audienceId) {
       return jsonError("workspaceId and audienceId are required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
-
-    return { workspaceId, audienceId };
+    const gated = await requireDataPlaneRouteCapability(
+      context,
+      workspaceId,
+      "campaigns.read",
+    );
+    if (gated instanceof Response) return gated;
+    return { ...gated, audienceId };
   },
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId/uploads.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId/uploads.loader.server.ts
@@ -1,24 +1,17 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { listAudienceUploadsByAudienceId } from "@/lib/audience-upload-db.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
+import { dataPlaneCapabilityAuthWithParam } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: async ({ params, context }: LoaderFunctionArgs) => {
-    const workspaceId = params.workspaceId;
-    const audienceId = params.audienceId;
-    if (!workspaceId || !audienceId) {
-      return jsonError("workspaceId and audienceId are required", 400);
-    }
-    const gated = await requireDataPlaneRouteCapability(
-      context,
-      workspaceId,
+  auth: async (args) => {
+    const gated = await dataPlaneCapabilityAuthWithParam(
       "campaigns.read",
-    );
+      "audienceId",
+    )(args);
     if (gated instanceof Response) return gated;
 
-    const parsedAudienceId = Number.parseInt(audienceId, 10);
+    const parsedAudienceId = Number.parseInt(gated.audienceId, 10);
     if (Number.isNaN(parsedAudienceId)) {
       return jsonError("Invalid audienceId", 400);
     }

--- a/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId/uploads.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId/uploads.loader.server.ts
@@ -1,24 +1,29 @@
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import { listAudienceUploadsByAudienceId } from "@/lib/audience-upload-db.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: LoaderFunctionArgs) => {
+  auth: async ({ params, context }: LoaderFunctionArgs) => {
     const workspaceId = params.workspaceId;
     const audienceId = params.audienceId;
     if (!workspaceId || !audienceId) {
       return jsonError("workspaceId and audienceId are required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
+    const gated = await requireDataPlaneRouteCapability(
+      context,
+      workspaceId,
+      "campaigns.read",
+    );
+    if (gated instanceof Response) return gated;
 
     const parsedAudienceId = Number.parseInt(audienceId, 10);
     if (Number.isNaN(parsedAudienceId)) {
       return jsonError("Invalid audienceId", 400);
     }
 
-    return { workspaceId, parsedAudienceId };
+    return { workspaceId: gated.workspaceId, parsedAudienceId };
   },
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/campaigns.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/campaigns.loader.server.ts
@@ -1,26 +1,8 @@
-import { jsonError, jsonResponse } from "@/lib/platform-api.server";
-import {
-  listWorkspaceCampaignsApi,
-} from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
-import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
+import { listWorkspaceCampaignsApi } from "@/lib/platform-data.server";
+import { defineDataPlaneListLoader } from "@/lib/capability-guard.server";
 
-export const loader = defineLoader({
-  auth: async ({ params, context }: LoaderFunctionArgs) => {
-    const workspaceId = params.workspaceId;
-    if (!workspaceId) {
-      return jsonError("workspaceId is required", 400);
-    }
-    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
-  },
-  sideEffects: ["db-read"],
-  handler: async ({ auth }) => {
-    const result = await listWorkspaceCampaignsApi(auth.workspaceId);
-    if (!result.ok) {
-      return jsonError(result.error, result.status);
-    }
-
-    return jsonResponse({ campaigns: result.campaigns }, 200);
-  },
+export const loader = defineDataPlaneListLoader({
+  capability: "campaigns.read",
+  key: "campaigns",
+  list: listWorkspaceCampaignsApi,
 });

--- a/app/routes/api+/workspaces+/$workspaceId/campaigns.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/campaigns.loader.server.ts
@@ -2,19 +2,17 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   listWorkspaceCampaignsApi,
 } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: LoaderFunctionArgs) => {
+  auth: async ({ params, context }: LoaderFunctionArgs) => {
     const workspaceId = params.workspaceId;
     if (!workspaceId) {
       return jsonError("workspaceId is required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
-
-    return { workspaceId };
+    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
   },
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/contacts.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/contacts.loader.server.ts
@@ -3,23 +3,11 @@ import { findContactsByPhone } from "@/lib/database/contact.server";
 import {
   listWorkspaceContactsApi,
 } from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
+import { dataPlaneCapabilityAuth } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
-
-async function requireWorkspaceDataPlane({
-  params,
-  context,
-}: Pick<LoaderFunctionArgs, "params" | "context">) {
-  const workspaceId = params.workspaceId;
-  if (!workspaceId) {
-    return jsonError("workspaceId is required", 400);
-  }
-  return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
-}
 
 export const loader = defineLoader({
-  auth: requireWorkspaceDataPlane,
+  auth: dataPlaneCapabilityAuth("campaigns.read"),
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {
     const { workspaceId } = auth;

--- a/app/routes/api+/workspaces+/$workspaceId/contacts.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/contacts.loader.server.ts
@@ -3,11 +3,11 @@ import { findContactsByPhone } from "@/lib/database/contact.server";
 import {
   listWorkspaceContactsApi,
 } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
-function requireWorkspaceDataPlane({
+async function requireWorkspaceDataPlane({
   params,
   context,
 }: Pick<LoaderFunctionArgs, "params" | "context">) {
@@ -15,8 +15,7 @@ function requireWorkspaceDataPlane({
   if (!workspaceId) {
     return jsonError("workspaceId is required", 400);
   }
-  getDataPlaneRouteContext(context, workspaceId);
-  return { workspaceId };
+  return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
 }
 
 export const loader = defineLoader({

--- a/app/routes/api+/workspaces+/$workspaceId/conversations.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/conversations.loader.server.ts
@@ -2,11 +2,11 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   listWorkspaceConversationsApi,
 } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
-function requireWorkspaceDataPlane({
+async function requireWorkspaceDataPlane({
   params,
   context,
 }: Pick<LoaderFunctionArgs, "params" | "context">) {
@@ -14,8 +14,7 @@ function requireWorkspaceDataPlane({
   if (!workspaceId) {
     return jsonError("workspaceId is required", 400);
   }
-  getDataPlaneRouteContext(context, workspaceId);
-  return { workspaceId };
+  return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
 }
 
 export const loader = defineLoader({

--- a/app/routes/api+/workspaces+/$workspaceId/conversations.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/conversations.loader.server.ts
@@ -2,23 +2,11 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   listWorkspaceConversationsApi,
 } from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
+import { dataPlaneCapabilityAuth } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
-
-async function requireWorkspaceDataPlane({
-  params,
-  context,
-}: Pick<LoaderFunctionArgs, "params" | "context">) {
-  const workspaceId = params.workspaceId;
-  if (!workspaceId) {
-    return jsonError("workspaceId is required", 400);
-  }
-  return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
-}
 
 export const loader = defineLoader({
-  auth: requireWorkspaceDataPlane,
+  auth: dataPlaneCapabilityAuth("campaigns.read"),
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {
     const result = await listWorkspaceConversationsApi(

--- a/app/routes/api+/workspaces+/$workspaceId/conversations/$contactNumber.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/conversations/$contactNumber.loader.server.ts
@@ -3,28 +3,12 @@ import { fetchLatestMessageForPhone } from "@/lib/message-db.server";
 import {
   getConversationMessagesApi,
 } from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
+import { dataPlaneCapabilityAuthWithParam } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: async ({
-    params,
-    context,
-  }: Pick<LoaderFunctionArgs, "params" | "context">) => {
-    const workspaceId = params.workspaceId;
-    const contactNumber = params.contactNumber;
-    if (!workspaceId || !contactNumber) {
-      return jsonError("workspaceId and contactNumber are required", 400);
-    }
-    const gated = await requireDataPlaneRouteCapability(
-      context,
-      workspaceId,
-      "campaigns.read",
-    );
-    if (gated instanceof Response) return gated;
-    return { ...gated, contactNumber };
-  },
+  auth: (args) =>
+    dataPlaneCapabilityAuthWithParam("campaigns.read", "contactNumber")(args),
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {
     const { workspaceId, contactNumber } = auth;

--- a/app/routes/api+/workspaces+/$workspaceId/conversations/$contactNumber.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/conversations/$contactNumber.loader.server.ts
@@ -3,20 +3,27 @@ import { fetchLatestMessageForPhone } from "@/lib/message-db.server";
 import {
   getConversationMessagesApi,
 } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: Pick<LoaderFunctionArgs, "params" | "context">) => {
+  auth: async ({
+    params,
+    context,
+  }: Pick<LoaderFunctionArgs, "params" | "context">) => {
     const workspaceId = params.workspaceId;
     const contactNumber = params.contactNumber;
     if (!workspaceId || !contactNumber) {
       return jsonError("workspaceId and contactNumber are required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
-
-    return { workspaceId, contactNumber };
+    const gated = await requireDataPlaneRouteCapability(
+      context,
+      workspaceId,
+      "campaigns.read",
+    );
+    if (gated instanceof Response) return gated;
+    return { ...gated, contactNumber };
   },
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/members.action.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/members.action.server.ts
@@ -7,14 +7,17 @@ import {
 import {
   cancelWorkspaceInvite,
   inviteWorkspaceMember,
+  inviteWorkspaceMemberAsApiKey,
   listWorkspaceMembers,
   removeWorkspaceMember,
   updateWorkspaceMemberRole,
 } from "@/lib/platform-members.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
+import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
 import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import type { DataPlaneAuthContextValue } from "@/lib/route-context.server";
 import { defineAction, defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 
 function requireWorkspaceUser({
   params,
@@ -31,15 +34,17 @@ function requireWorkspaceUser({
   return { workspaceId, userId };
 }
 
+type MembersActionAuth =
+  | { mode: "invite"; workspaceId: string; auth: DataPlaneAuthContextValue }
+  | { mode: "session"; workspaceId: string; userId: string };
+
 export const loader = defineLoader({
   auth: requireWorkspaceUser,
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {
     const { workspaceId, userId } = auth;
 
-    const result = await listWorkspaceMembers(    userId,
-      workspaceId,
-    );
+    const result = await listWorkspaceMembers(userId, workspaceId);
 
     if (!result.ok) {
       return jsonError(result.error, result.status);
@@ -56,21 +61,54 @@ export const loader = defineLoader({
 });
 
 export const action = defineAction({
-  auth: requireWorkspaceUser,
-  sideEffects: ["db-write", "email"],
-  handler: async ({ request, auth }) => {
-    const { workspaceId, userId } = auth;
+  auth: async ({
+    request,
+    params,
+    context,
+  }: ActionFunctionArgs): Promise<MembersActionAuth | Response> => {
+    const workspaceId = params.workspaceId;
+    if (!workspaceId) {
+      return jsonError("workspaceId is required", 400);
+    }
+    const auth = getDataPlaneRouteContext(context, workspaceId);
 
     if (request.method === "POST") {
+      const capability = await requireDataPlaneCapability(auth, "members.invite");
+      if (capability instanceof Response) {
+        return capability;
+      }
+      if (!auth.userId && !auth.apiKey) {
+        return jsonError("Unauthorized", 401);
+      }
+      return { mode: "invite", workspaceId, auth };
+    }
+
+    if (!auth.userId) {
+      return jsonError("Unauthorized", 401);
+    }
+    return { mode: "session", workspaceId, userId: auth.userId };
+  },
+  sideEffects: ["db-write", "email"],
+  handler: async ({ request, auth }) => {
+    const { workspaceId } = auth;
+
+    if (request.method === "POST" && auth.mode === "invite") {
       const parsed = await parseJsonBodyOrResponse(request, inviteMemberBodySchema);
       if (parsed instanceof Response) return parsed;
 
-      const result = await inviteWorkspaceMember(
-        userId,
-        workspaceId,
-        parsed.email,
-        parsed.role,
-      );
+      const result =
+        auth.auth.userId != null
+          ? await inviteWorkspaceMember(
+              auth.auth.userId,
+              workspaceId,
+              parsed.email,
+              parsed.role,
+            )
+          : await inviteWorkspaceMemberAsApiKey(
+              workspaceId,
+              parsed.email,
+              parsed.role,
+            );
 
       if (!result.ok) {
         return jsonError(result.error, result.status);
@@ -85,6 +123,11 @@ export const action = defineAction({
         201,
       );
     }
+
+    if (auth.mode !== "session") {
+      return jsonError("Unauthorized", 401);
+    }
+    const { userId } = auth;
 
     if (request.method === "PATCH") {
       const parsed = await parseJsonBodyOrResponse(request, updateMemberBodySchema);

--- a/app/routes/api+/workspaces+/$workspaceId/scripts.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/scripts.loader.server.ts
@@ -2,18 +2,20 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   listWorkspaceScriptsApi,
 } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: Pick<LoaderFunctionArgs, "params" | "context">) => {
+  auth: async ({
+    params,
+    context,
+  }: Pick<LoaderFunctionArgs, "params" | "context">) => {
     const workspaceId = params.workspaceId;
     if (!workspaceId) {
       return jsonError("workspaceId is required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
-    return { workspaceId };
+    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
   },
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/scripts.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/scripts.loader.server.ts
@@ -1,29 +1,8 @@
-import { jsonError, jsonResponse } from "@/lib/platform-api.server";
-import {
-  listWorkspaceScriptsApi,
-} from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
-import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
+import { listWorkspaceScriptsApi } from "@/lib/platform-data.server";
+import { defineDataPlaneListLoader } from "@/lib/capability-guard.server";
 
-export const loader = defineLoader({
-  auth: async ({
-    params,
-    context,
-  }: Pick<LoaderFunctionArgs, "params" | "context">) => {
-    const workspaceId = params.workspaceId;
-    if (!workspaceId) {
-      return jsonError("workspaceId is required", 400);
-    }
-    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
-  },
-  sideEffects: ["db-read"],
-  handler: async ({ auth }) => {
-    const result = await listWorkspaceScriptsApi(auth.workspaceId);
-    if (!result.ok) {
-      return jsonError(result.error, result.status);
-    }
-
-    return jsonResponse({ scripts: result.scripts }, 200);
-  },
+export const loader = defineDataPlaneListLoader({
+  capability: "campaigns.read",
+  key: "scripts",
+  list: listWorkspaceScriptsApi,
 });

--- a/app/routes/api+/workspaces+/$workspaceId/surveys.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/surveys.loader.server.ts
@@ -2,18 +2,20 @@ import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import {
   listWorkspaceSurveysApi,
 } from "@/lib/platform-data.server";
-import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
 import { defineLoader } from "@/lib/handler.server";
 import type { LoaderFunctionArgs } from "react-router";
 
 export const loader = defineLoader({
-  auth: ({ params, context }: Pick<LoaderFunctionArgs, "params" | "context">) => {
+  auth: async ({
+    params,
+    context,
+  }: Pick<LoaderFunctionArgs, "params" | "context">) => {
     const workspaceId = params.workspaceId;
     if (!workspaceId) {
       return jsonError("workspaceId is required", 400);
     }
-    getDataPlaneRouteContext(context, workspaceId);
-    return { workspaceId };
+    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
   },
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {

--- a/app/routes/api+/workspaces+/$workspaceId/surveys.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/surveys.loader.server.ts
@@ -1,29 +1,8 @@
-import { jsonError, jsonResponse } from "@/lib/platform-api.server";
-import {
-  listWorkspaceSurveysApi,
-} from "@/lib/platform-data.server";
-import { requireDataPlaneRouteCapability } from "@/lib/capability-guard.server";
-import { defineLoader } from "@/lib/handler.server";
-import type { LoaderFunctionArgs } from "react-router";
+import { listWorkspaceSurveysApi } from "@/lib/platform-data.server";
+import { defineDataPlaneListLoader } from "@/lib/capability-guard.server";
 
-export const loader = defineLoader({
-  auth: async ({
-    params,
-    context,
-  }: Pick<LoaderFunctionArgs, "params" | "context">) => {
-    const workspaceId = params.workspaceId;
-    if (!workspaceId) {
-      return jsonError("workspaceId is required", 400);
-    }
-    return requireDataPlaneRouteCapability(context, workspaceId, "campaigns.read");
-  },
-  sideEffects: ["db-read"],
-  handler: async ({ auth }) => {
-    const result = await listWorkspaceSurveysApi(auth.workspaceId);
-    if (!result.ok) {
-      return jsonError(result.error, result.status);
-    }
-
-    return jsonResponse({ surveys: result.surveys }, 200);
-  },
+export const loader = defineDataPlaneListLoader({
+  capability: "campaigns.read",
+  key: "surveys",
+  list: listWorkspaceSurveysApi,
 });

--- a/docs/api-agent-quickstart.md
+++ b/docs/api-agent-quickstart.md
@@ -80,14 +80,30 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 ## API keys (automation)
 
+Keys require at least one capability scope. Optional `expires_in_days` defaults to 90 (max 365).
+
 ```bash
 curl -X POST "$BASE_URL/api/workspaces/$WORKSPACE_ID/api-keys" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name":"production agent"}'
+  -d '{
+    "name": "production agent",
+    "scopes": ["campaigns.read", "campaigns.write", "messages.send", "campaigns.dispatch"],
+    "expires_in_days": 90
+  }'
 ```
 
-Use `X-API-Key: cc_live_...` or `Authorization: Bearer cc_live_...` for integrator routes (`/api/sms`, `/api/chat_sms`, `/api/campaigns/create-with-script`) and dual-auth data routes.
+Use `X-API-Key: cc_live_...` or `Authorization: Bearer cc_live_...` for integrator routes (`/api/sms`, `/api/chat_sms`, `/api/campaigns/create-with-script`) and dual-auth data routes. Missing scopes return `403` with a `capability_denied:*` error code.
+
+| Capability | Unlocks |
+| --- | --- |
+| `campaigns.read` | Campaigns, queue, contacts, audiences, scripts, surveys, conversations, workspace metadata |
+| `campaigns.write` | Create/update campaigns, queue mutations, contact deletes |
+| `campaigns.dispatch` | Campaign SMS batch (`POST /api/sms`) |
+| `messages.send` | Direct chat SMS (`POST /api/chat_sms`) |
+| `calls.start` / `calls.control` | Dialer start / live call disconnect |
+| `members.invite` | Invite members (`POST .../members`) |
+| `audit.read` | Workspace audit events |
 
 ## Campaign operations
 
@@ -98,9 +114,11 @@ See [Data plane API](./api-data-plane.md) for campaigns, contacts, audiences, sc
 | Route class | API key | Bearer JWT | Cookie |
 | --- | --- | --- | --- |
 | Platform auth (register/token) | — | — | — |
-| Workspace admin (billing, onboarding, members) | — | yes | yes |
-| Data / campaigns / exports | yes | yes | yes |
-| Dialer / handset / agent-status | — | yes | yes |
+| Workspace admin (billing, onboarding) | — | yes | yes |
+| Member invite (`members.invite`) | yes | yes | yes |
+| Data / campaigns / exports | yes (scoped) | yes | yes |
+| Dialer start / call disconnect | yes (scoped) | yes | yes |
+| Handset / agent-status | — | yes | yes |
 
 ## Related guides
 

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -62,11 +62,11 @@ The workspace is inferred from the key. If you send `workspace_id` in the body, 
 API keys are created in the workspace **Settings** UI, or programmatically via `POST /api/workspaces/{workspaceId}/api-keys` (session or Bearer JWT auth — see the [agent quickstart](./api-agent-quickstart.md#api-keys-automation)). The flat admin endpoint `POST /api/workspace-api-keys` backs the Settings UI and is **not** part of the public integrator API.
 
 1. Sign in to CallCaster in a browser.
-2. Open workspace **Settings** and create an API key.
+2. Open workspace **Settings** and create an API key with the capability scopes it needs (at least one required).
 3. Copy the key once (shown only at creation); store it securely.
 4. Use the key as `X-API-Key` or `Authorization: Bearer` in server-side scripts.
 
-Never commit API keys to source control.
+Each key only accesses operations covered by its scopes. Requests that need a missing capability return `403`. Never commit API keys to source control.
 
 ---
 
@@ -86,7 +86,7 @@ Validation errors from Zod-backed public routes may include field paths, e.g. `t
 |--------|---------------|----------|
 | `400` | Validation or business rule | Missing `title`; invalid UUID; both `script` and `script_id` sent; `caller_id` not in workspace; `user_id` required for API key on `/api/sms` |
 | `401` | Missing or invalid auth | Invalid API key; no session cookie |
-| `403` | Workspace mismatch | `workspace_id` in body does not match API key workspace |
+| `403` | Workspace mismatch or missing capability | `workspace_id` does not match API key workspace; API key lacks required scope |
 | `404` | Not found (chat SMS) | Invalid phone number normalization |
 | `405` | Wrong HTTP method | Non-POST to action route |
 | `500` | Server/Twilio failure | Twilio send error; database error |

--- a/docs/api-surface-inventory.md
+++ b/docs/api-surface-inventory.md
@@ -101,7 +101,7 @@ Interactive specs:
 | `/api/auth/invites` | GET, POST | User API | sessionOnly | yes | `routes/api+/auth/invites.route.tsx` | `docs/api-agent-quickstart.md` |  |
 | `/api/me` | GET, PATCH | User API | sessionOnly | yes | `routes/api+/me.route.tsx` | `docs/api-agent-quickstart.md` |  |
 | `/api/workspaces` | GET, POST | User API | sessionOnly | yes | `routes/api+/workspaces.route.tsx` | `docs/api-agent-quickstart.md` |  |
-| `/api/workspaces/:workspaceId` | GET, PATCH, DELETE | Integrator API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/route.tsx` | `docs/api-agent-quickstart.md` | Child index under data-plane layout middleware. GET supports session or API key; PATCH requires admin+ session; DELETE requires owner session. |
+| `/api/workspaces/:workspaceId` | GET, PATCH, DELETE | Integrator API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/route.tsx` | `docs/api-agent-quickstart.md` | Child index under data-plane layout middleware. GET supports session or API key with campaigns.read; PATCH requires admin+ session; DELETE requires owner session. |
 | `/api/workspaces/:workspaceId` | GET | User API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId.tsx` | `docs/api-agent-quickstart.md` | duplicate route; Middleware layout for nested workspace API routes; no direct handler. |
 | `/api/workspaces/:workspaceId/transfer-ownership` | POST | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/transfer-ownership.route.tsx` | `docs/api-workspace-admin.md` |  |
 | `/api/workspaces/:workspaceId/billing` | GET | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/billing.route.tsx` | `docs/api-agent-quickstart.md` |  |
@@ -112,9 +112,9 @@ Interactive specs:
 | `/api/workspaces/:workspaceId/numbers` | GET, POST | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/numbers.route.tsx` | `docs/api-telephony-provisioning.md` |  |
 | `/api/workspaces/:workspaceId/numbers/:numberId` | PATCH, DELETE | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/numbers/$numberId.route.tsx` | `docs/api-telephony-provisioning.md` |  |
 | `/api/workspaces/:workspaceId/webhook` | GET, PUT, POST | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/webhook.route.tsx` | `docs/api-workspace-admin.md` | POST tests webhook delivery. |
-| `/api/workspaces/:workspaceId/members` | GET, POST, PATCH, DELETE | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/members.route.tsx` | `docs/api-workspace-admin.md` |  |
+| `/api/workspaces/:workspaceId/members` | GET, POST, PATCH, DELETE | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/members.route.tsx` | `docs/api-workspace-admin.md` | GET/PATCH/DELETE are session-only. POST invite accepts session or API key with members.invite. |
 | `/api/workspaces/:workspaceId/api-keys` | GET, POST, DELETE | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/api-keys.route.tsx` | `docs/api-workspace-admin.md` |  |
-| `/api/workspaces/:workspaceId/audit-events` | GET | Integrator API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/audit-events.route.tsx` | `docs/api-workspace-admin.md` | Requires owner session or API key with `audit.read`. |
+| `/api/workspaces/:workspaceId/audit-events` | GET | Integrator API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/audit-events.route.tsx` | `docs/api-workspace-admin.md` | Requires owner session (via role matrix) or an API key with audit.read. |
 | `/api/workspaces/:workspaceId/campaigns` | GET | Integrator API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/campaigns.route.tsx` | `docs/api-data-plane.md` |  |
 | `/api/campaigns/:campaignId` | GET, POST | Integrator API | sessionOnly | yes | `routes/api+/campaigns/$campaignId.route.tsx` | `docs/api-data-plane.md` |  |
 | `/api/campaigns/:campaignId/queue` | GET, PATCH | Integrator API | sessionOnly | yes | `routes/api+/campaigns/$campaignId/queue.route.tsx` | `docs/api-data-plane.md` |  |

--- a/docs/api-surface-inventory.md
+++ b/docs/api-surface-inventory.md
@@ -114,7 +114,7 @@ Interactive specs:
 | `/api/workspaces/:workspaceId/webhook` | GET, PUT, POST | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/webhook.route.tsx` | `docs/api-workspace-admin.md` | POST tests webhook delivery. |
 | `/api/workspaces/:workspaceId/members` | GET, POST, PATCH, DELETE | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/members.route.tsx` | `docs/api-workspace-admin.md` |  |
 | `/api/workspaces/:workspaceId/api-keys` | GET, POST, DELETE | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/api-keys.route.tsx` | `docs/api-workspace-admin.md` |  |
-| `/api/workspaces/:workspaceId/audit-events` | GET | Workspace Admin | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/audit-events.route.tsx` | `docs/api-workspace-admin.md` | Owner-only session access until SEC-07 audit.read scopes land for API keys. |
+| `/api/workspaces/:workspaceId/audit-events` | GET | Integrator API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/audit-events.route.tsx` | `docs/api-workspace-admin.md` | Requires owner session or API key with `audit.read`. |
 | `/api/workspaces/:workspaceId/campaigns` | GET | Integrator API | sessionOnly | yes | `routes/api+/workspaces+/$workspaceId/campaigns.route.tsx` | `docs/api-data-plane.md` |  |
 | `/api/campaigns/:campaignId` | GET, POST | Integrator API | sessionOnly | yes | `routes/api+/campaigns/$campaignId.route.tsx` | `docs/api-data-plane.md` |  |
 | `/api/campaigns/:campaignId/queue` | GET, PATCH | Integrator API | sessionOnly | yes | `routes/api+/campaigns/$campaignId/queue.route.tsx` | `docs/api-data-plane.md` |  |

--- a/openapi/complete-api.json
+++ b/openapi/complete-api.json
@@ -1665,11 +1665,12 @@
       "post": {
         "operationId": "createCampaignWithScript",
         "summary": "Create campaign with script and phone number (one-shot)",
-        "description": "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both.",
+        "description": "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both. Requires the campaigns.write capability for API keys.",
         "tags": [
           "Integrator API",
           "Campaigns"
         ],
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -1781,11 +1782,12 @@
       "post": {
         "operationId": "sendChatSms",
         "summary": "Send a single SMS",
-        "description": "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body.",
+        "description": "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body. Requires the messages.send capability for API keys.",
         "tags": [
           "Integrator API",
           "Messaging"
         ],
+        "x-callcaster-capability": "messages.send",
         "security": [
           {
             "sessionCookie": []
@@ -4913,11 +4915,12 @@
       "post": {
         "operationId": "dispatchCampaignSms",
         "summary": "Dispatch SMS to queued campaign contacts",
-        "description": "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user.",
+        "description": "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user. Requires the campaigns.dispatch capability for API keys.",
         "tags": [
           "Integrator API",
           "Messaging"
         ],
+        "x-callcaster-capability": "campaigns.dispatch",
         "security": [
           {
             "sessionCookie": []
@@ -7007,7 +7010,7 @@
       "patch": {
         "operationId": "patchWorkspaces_workspaceId",
         "summary": "PATCH /api/workspaces/:workspaceId",
-        "description": "Child index under data-plane layout middleware. GET supports session or API key; PATCH requires admin+ session; DELETE requires owner session.",
+        "description": "Child index under data-plane layout middleware. GET supports session or API key with campaigns.read; PATCH requires admin+ session; DELETE requires owner session.",
         "tags": [
           "Integrator API",
           "workspace"
@@ -7073,7 +7076,7 @@
       "delete": {
         "operationId": "deleteWorkspaces_workspaceId",
         "summary": "DELETE /api/workspaces/:workspaceId",
-        "description": "Child index under data-plane layout middleware. GET supports session or API key; PATCH requires admin+ session; DELETE requires owner session.",
+        "description": "Child index under data-plane layout middleware. GET supports session or API key with campaigns.read; PATCH requires admin+ session; DELETE requires owner session.",
         "tags": [
           "Integrator API",
           "workspace"
@@ -8012,7 +8015,7 @@
       "get": {
         "operationId": "getWorkspaces_workspaceId_members",
         "summary": "GET /api/workspaces/:workspaceId/members",
-        "description": "",
+        "description": "GET/PATCH/DELETE are session-only. POST invite accepts session or API key with members.invite.",
         "tags": [
           "Workspace Admin",
           "workspace"
@@ -8074,7 +8077,7 @@
       "post": {
         "operationId": "postWorkspaces_workspaceId_members",
         "summary": "POST /api/workspaces/:workspaceId/members",
-        "description": "",
+        "description": "GET/PATCH/DELETE are session-only. POST invite accepts session or API key with members.invite.",
         "tags": [
           "Workspace Admin",
           "workspace"
@@ -8083,6 +8086,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "workspaceAdmin",
         "x-callcaster-docs-guide": "docs/api-workspace-admin.md",
+        "x-callcaster-capability": "members.invite",
         "security": [
           {
             "sessionCookie": []
@@ -8137,7 +8141,7 @@
       "patch": {
         "operationId": "patchWorkspaces_workspaceId_members",
         "summary": "PATCH /api/workspaces/:workspaceId/members",
-        "description": "",
+        "description": "GET/PATCH/DELETE are session-only. POST invite accepts session or API key with members.invite.",
         "tags": [
           "Workspace Admin",
           "workspace"
@@ -8200,7 +8204,7 @@
       "delete": {
         "operationId": "deleteWorkspaces_workspaceId_members",
         "summary": "DELETE /api/workspaces/:workspaceId/members",
-        "description": "",
+        "description": "GET/PATCH/DELETE are session-only. POST invite accepts session or API key with members.invite.",
         "tags": [
           "Workspace Admin",
           "workspace"
@@ -8431,18 +8435,22 @@
       "get": {
         "operationId": "getWorkspaces_workspaceId_audit_events",
         "summary": "GET /api/workspaces/:workspaceId/audit-events",
-        "description": "Owner-only session access until SEC-07 audit.read scopes land for API keys.",
+        "description": "Requires owner session (via role matrix) or an API key with audit.read.",
         "tags": [
-          "Workspace Admin",
+          "Integrator API",
           "workspace"
         ],
         "x-callcaster-supported": true,
         "x-callcaster-exposure": "sessionOnly",
-        "x-callcaster-auth-class": "workspaceAdmin",
+        "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-workspace-admin.md",
+        "x-callcaster-capability": "audit.read",
         "security": [
           {
             "sessionCookie": []
+          },
+          {
+            "apiKey": []
           }
         ],
         "parameters": [
@@ -8504,6 +8512,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -8571,6 +8580,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -8625,6 +8635,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -8693,6 +8704,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -8747,6 +8759,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -8986,6 +8999,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9053,6 +9067,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9107,6 +9122,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -9163,6 +9179,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9230,6 +9247,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9297,6 +9315,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9364,6 +9383,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9431,6 +9451,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9487,6 +9508,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9554,6 +9576,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9610,6 +9633,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9719,6 +9743,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9786,6 +9811,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -10415,6 +10441,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-telephony-provisioning.md",
+        "x-callcaster-capability": "calls.control",
         "security": [
           {
             "sessionCookie": []
@@ -10483,6 +10510,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-telephony-provisioning.md",
+        "x-callcaster-capability": "calls.start",
         "security": [
           {
             "sessionCookie": []
@@ -11359,6 +11387,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []

--- a/openapi/integrator-api.json
+++ b/openapi/integrator-api.json
@@ -30,11 +30,12 @@
       "post": {
         "operationId": "createCampaignWithScript",
         "summary": "Create campaign with script and phone number (one-shot)",
-        "description": "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both.",
+        "description": "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both. Requires the campaigns.write capability for API keys.",
         "tags": [
           "Integrator API",
           "Campaigns"
         ],
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -146,11 +147,12 @@
       "post": {
         "operationId": "sendChatSms",
         "summary": "Send a single SMS",
-        "description": "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body.",
+        "description": "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body. Requires the messages.send capability for API keys.",
         "tags": [
           "Integrator API",
           "Messaging"
         ],
+        "x-callcaster-capability": "messages.send",
         "security": [
           {
             "sessionCookie": []
@@ -237,11 +239,12 @@
       "post": {
         "operationId": "dispatchCampaignSms",
         "summary": "Dispatch SMS to queued campaign contacts",
-        "description": "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user.",
+        "description": "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user. Requires the campaigns.dispatch capability for API keys.",
         "tags": [
           "Integrator API",
           "Messaging"
         ],
+        "x-callcaster-capability": "campaigns.dispatch",
         "security": [
           {
             "sessionCookie": []

--- a/openapi/public-api.json
+++ b/openapi/public-api.json
@@ -1389,11 +1389,12 @@
       "post": {
         "operationId": "createCampaignWithScript",
         "summary": "Create campaign with script and phone number (one-shot)",
-        "description": "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both.",
+        "description": "Creates a call campaign in a single request: optionally creates a script, creates the campaign with a caller ID, and attaches audiences (with optional contact enqueue). Provide exactly one of `script` or `script_id`, not both. Requires the campaigns.write capability for API keys.",
         "tags": [
           "Integrator API",
           "Campaigns"
         ],
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -1505,11 +1506,12 @@
       "post": {
         "operationId": "sendChatSms",
         "summary": "Send a single SMS",
-        "description": "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body.",
+        "description": "Sends one outbound SMS to a phone number. When `contact_id` is provided, template tags in `body` are substituted from the contact record. Session auth requires `workspace_id` in the body. Requires the messages.send capability for API keys.",
         "tags": [
           "Integrator API",
           "Messaging"
         ],
+        "x-callcaster-capability": "messages.send",
         "security": [
           {
             "sessionCookie": []
@@ -3489,11 +3491,12 @@
       "post": {
         "operationId": "dispatchCampaignSms",
         "summary": "Dispatch SMS to queued campaign contacts",
-        "description": "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user.",
+        "description": "Legacy batch dispatch: sends SMS to all queued contacts on a message campaign. Processes template tags per contact. Duplicate sends to the same number are skipped and the queue row is dequeued. API key auth requires `user_id` for outreach attribution; session auth uses the logged-in user. Requires the campaigns.dispatch capability for API keys.",
         "tags": [
           "Integrator API",
           "Messaging"
         ],
+        "x-callcaster-capability": "campaigns.dispatch",
         "security": [
           {
             "sessionCookie": []
@@ -5222,6 +5225,7 @@
           "Platform API",
           "Workspace"
         ],
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -5230,7 +5234,7 @@
             "apiKey": []
           }
         ],
-        "description": "Returns workspace metadata for an authorized session member or workspace API key scoped to the route workspace.",
+        "description": "Returns workspace metadata for an authorized session member or workspace API key with campaigns.read scoped to the route workspace.",
         "responses": {
           "200": {
             "description": "Workspace details",
@@ -6327,9 +6331,12 @@
         "security": [
           {
             "sessionCookie": []
+          },
+          {
+            "apiKey": []
           }
         ],
-        "description": "Session-only trust-root route. Privileged role assignment may require MFA enrollment.",
+        "description": "Invite a member with a session (role subordination rules apply) or an API key with members.invite (admin-equivalent role assignment: member/caller only). Privileged session role assignment may require MFA enrollment.",
         "requestBody": {
           "required": true,
           "content": {
@@ -6728,9 +6735,12 @@
         "security": [
           {
             "sessionCookie": []
+          },
+          {
+            "apiKey": []
           }
         ],
-        "description": "Cursor-paginated immutable audit log for privileged workspace actions. Owner session only until API key scopes ship in SEC-07.",
+        "description": "Cursor-paginated immutable audit log for privileged workspace actions. Requires owner session or an API key with the audit.read capability.",
         "parameters": [
           {
             "name": "cursor",
@@ -6810,6 +6820,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -6877,6 +6888,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -6931,6 +6943,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -6999,6 +7012,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7053,6 +7067,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -7292,6 +7307,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7359,6 +7375,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7413,6 +7430,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -7469,6 +7487,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7536,6 +7555,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7603,6 +7623,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7670,6 +7691,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7737,6 +7759,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7793,6 +7816,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7860,6 +7884,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -7916,6 +7941,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -8025,6 +8051,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -8092,6 +8119,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -9684,6 +9712,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "apiKeyOrSession",
         "x-callcaster-docs-guide": "docs/api-data-plane.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -10466,17 +10495,32 @@
           "caller"
         ]
       },
+      "ProductCapabilityId": {
+        "type": "string",
+        "enum": [
+          "campaigns.read",
+          "campaigns.write",
+          "campaigns.dispatch",
+          "calls.start",
+          "calls.control",
+          "messages.send",
+          "members.invite",
+          "audit.read"
+        ],
+        "description": "Stable product capability ID used as an API-key scope."
+      },
       "ApiKeySummary": {
         "type": "object",
         "required": [
           "id",
           "name",
           "key_prefix",
-          "created_at"
+          "created_at",
+          "scopes"
         ],
         "properties": {
           "id": {
-            "type": "integer"
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -10492,6 +10536,18 @@
             "type": "string",
             "format": "date-time",
             "nullable": true
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProductCapabilityId"
+            }
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO-8601 expiry; null only for pre-SEC-07 legacy keys."
           }
         }
       },
@@ -10512,13 +10568,28 @@
       "CreateApiKeyRequest": {
         "type": "object",
         "required": [
-          "name"
+          "name",
+          "scopes"
         ],
         "properties": {
           "name": {
             "type": "string",
             "minLength": 1,
             "maxLength": 200
+          },
+          "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/components/schemas/ProductCapabilityId"
+            },
+            "description": "At least one capability scope is required."
+          },
+          "expires_in_days": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 365,
+            "description": "Key TTL in days (default 90, max 365)."
           }
         }
       },
@@ -10529,7 +10600,8 @@
           "id",
           "name",
           "key_prefix",
-          "created_at"
+          "created_at",
+          "scopes"
         ],
         "properties": {
           "key": {
@@ -10548,6 +10620,17 @@
           "created_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProductCapabilityId"
+            }
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         }
       },

--- a/scripts/check-handlers.mjs
+++ b/scripts/check-handlers.mjs
@@ -65,7 +65,11 @@ function rawHandlers(src) {
       new RegExp(`export\\s+async\\s+function\\s+${kw}\\b`).test(src) ||
       new RegExp(`export\\s+function\\s+${kw}\\b`).test(src);
     if (!exported) continue;
-    const governed = new RegExp(`export\\s+const\\s+${kw}\\s*=\\s*define(Action|Loader)\\b`).test(src);
+    const governed =
+      new RegExp(`export\\s+const\\s+${kw}\\s*=\\s*define(Action|Loader)\\b`).test(src) ||
+      new RegExp(
+        `export\\s+const\\s+${kw}\\s*=\\s*defineDataPlaneListLoader\\b`,
+      ).test(src);
     if (!governed) raw.push(kw);
   }
   return raw;

--- a/scripts/check-middleware-adoption.mjs
+++ b/scripts/check-middleware-adoption.mjs
@@ -35,7 +35,12 @@ const TREES = [
     name: "data-plane",
     prefix: "api+/workspaces+/$workspaceId/",
     // requireDataPlaneRouteCapability wraps getDataPlaneRouteContext + capability gate.
-    required: [/getDataPlaneRouteContext/, /requireDataPlaneRouteCapability/],
+    required: [
+      /getDataPlaneRouteContext/,
+      /requireDataPlaneRouteCapability/,
+      /dataPlaneCapabilityAuth/,
+      /defineDataPlaneListLoader/,
+    ],
     forbidden: [
       { pattern: /\bresolveDataPlaneAuth\s*\(/, label: "resolveDataPlaneAuth()" },
       { pattern: /from\s+["']@\/lib\/platform-data\.server["'].*resolveDataPlaneAuth/, label: "resolveDataPlaneAuth import" },

--- a/scripts/check-middleware-adoption.mjs
+++ b/scripts/check-middleware-adoption.mjs
@@ -34,7 +34,8 @@ const TREES = [
   {
     name: "data-plane",
     prefix: "api+/workspaces+/$workspaceId/",
-    required: [/getDataPlaneRouteContext/],
+    // requireDataPlaneRouteCapability wraps getDataPlaneRouteContext + capability gate.
+    required: [/getDataPlaneRouteContext/, /requireDataPlaneRouteCapability/],
     forbidden: [
       { pattern: /\bresolveDataPlaneAuth\s*\(/, label: "resolveDataPlaneAuth()" },
       { pattern: /from\s+["']@\/lib\/platform-data\.server["'].*resolveDataPlaneAuth/, label: "resolveDataPlaneAuth import" },

--- a/scripts/dry-baseline.json
+++ b/scripts/dry-baseline.json
@@ -1,5 +1,5 @@
 {
-  "clones": 242,
-  "duplicatedLines": 3333,
-  "percentage": 2.6
+  "clones": 239,
+  "duplicatedLines": 3287,
+  "percentage": 2.48
 }

--- a/test/api-workspaces-audiences.route.test.ts
+++ b/test/api-workspaces-audiences.route.test.ts
@@ -10,6 +10,7 @@ vi.hoisted(() => {
 
 const mocks = vi.hoisted(() => ({
   listWorkspaceAudiencesApi: vi.fn(),
+  getUserRole: vi.fn(),
 }));
 
 vi.mock("@/lib/platform-data.server", () => ({
@@ -17,9 +18,14 @@ vi.mock("@/lib/platform-data.server", () => ({
     mocks.listWorkspaceAudiencesApi(...args),
 }));
 
+vi.mock("@/lib/database/workspace.server", () => ({
+  getUserRole: (...args: unknown[]) => mocks.getUserRole(...args),
+}));
+
 describe("app/routes/api+/workspaces/$workspaceId/audiences/route.tsx", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getUserRole.mockResolvedValue({ role: "member" });
   });
 
   test("lists audiences for an authorized workspace", async () => {
@@ -60,7 +66,10 @@ describe("app/routes/api+/workspaces/$workspaceId/audiences/route.tsx", () => {
             request: new Request("http://localhost/api/workspaces/w1/audiences"),
             params: { workspaceId: "w1" },
           },
-          { userId: null },
+          {
+            userId: null,
+            apiKey: { keyId: "k1", scopes: ["campaigns.read"] },
+          },
         ),
       ),
     );

--- a/test/audience-export.test.ts
+++ b/test/audience-export.test.ts
@@ -8,7 +8,9 @@ vi.mock("@/lib/env.server", () => {
   return { env: new Proxy({}, handler) };
 });
 
-const requireWorkspaceAccess = vi.fn(async () => undefined);
+const requireWorkspaceAccess = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
 
 const audienceExportMocks = vi.hoisted(() => ({
   findAudienceWorkspaceById: vi.fn(async () => "w1"),
@@ -23,12 +25,19 @@ const audienceExportMocks = vi.hoisted(() => ({
   ]),
 }));
 
-vi.mock("@/lib/database/workspace.server", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/lib/database/workspace.server")
-  >("@/lib/database/workspace.server");
-  return { ...actual, requireWorkspaceAccess };
-});
+vi.mock("@/lib/database/workspace.server", () => ({
+  requireWorkspaceAccess: (...args: unknown[]) =>
+    requireWorkspaceAccess(...args),
+}));
+
+vi.mock("@/lib/capability-guard.server", () => ({
+  requireDualAuthCapability: async () => ({ type: "ok" }),
+  requireDataPlaneCapability: async () => ({ type: "ok" }),
+  requireDataPlaneRouteCapability: async (
+    _context: unknown,
+    workspaceId: string,
+  ) => ({ workspaceId, auth: { workspaceId, userId: "u1" } }),
+}));
 
 vi.mock("@/lib/audience-upload-db.server", () => ({
   findAudienceWorkspaceById: (...args: any[]) =>

--- a/test/audiences.route.test.ts
+++ b/test/audiences.route.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/lib/logger.server", () => ({ logger: loggerMock }));
 
 vi.mock("@/lib/database/workspace.server", () => ({
   requireWorkspaceAccess: vi.fn(async () => undefined),
+  getUserRole: vi.fn(async () => ({ role: "member" })),
 }));
 
 function makeQuery(result: any) {
@@ -268,6 +269,7 @@ describe("api.audiences route", () => {
     setDualAuthSession({ headers: new Headers(), user: { id: "u1" } });
     vi.doMock("@/lib/database/workspace.server", () => ({
       requireWorkspaceAccess,
+      getUserRole: vi.fn(async () => ({ role: "member" })),
     }));
     vi.doMock("@/lib/request-utils.server", () => ({ parseActionRequest }));
 
@@ -319,7 +321,12 @@ describe("api.audiences route", () => {
     contactAudienceMocks.findAudienceWorkspaceById.mockResolvedValue("w1");
     const mod = await import("../app/routes/api+/audiences");
     const verifyAuth = vi.fn(async () => ({
-      auth: { authType: "api_key", workspaceId: "w2" },
+      auth: {
+        authType: "api_key",
+        workspaceId: "w2",
+        keyId: "k1",
+        scopes: ["campaigns.read", "campaigns.write"],
+      },
       headers: new Headers(),
     }));
     const parseActionRequest = vi.fn(async () => ({ id: "1" }));

--- a/test/campaigns-create-with-script.route.test.ts
+++ b/test/campaigns-create-with-script.route.test.ts
@@ -10,7 +10,9 @@ type VerifyError = { error: string; status: number };
 type VerifyApiKey = {
   authType: "api_key";
   workspaceId: string;
-  client: any;
+  keyId?: string;
+  scopes?: readonly string[];
+  client?: any;
 };
 type VerifySession = {
   authType: "session";
@@ -38,6 +40,12 @@ vi.mock("@/lib/create-with-script.server", () => ({
     mocks.validateCreateWithScriptPreflight(...args),
   createScriptForCampaign: (...args: unknown[]) => mocks.createScriptForCampaign(...args),
   linkAudiencesToNewCampaign: (...args: unknown[]) => mocks.linkAudiencesToNewCampaign(...args),
+}));
+
+
+vi.mock("@/lib/capability-guard.server", () => ({
+  requireDualAuthCapability: async () => ({ type: "ok" }),
+  requireDataPlaneCapability: async () => ({ type: "ok" }),
 }));
 
 vi.mock("@/lib/api-auth.server", () => ({
@@ -183,7 +191,7 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
   });
 
   test("returns 400 on invalid JSON body", async () => {
-    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client: {} } as any);
+    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, keyId: "k1", scopes: ["campaigns.write"], client: {} } as any);
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce(
       new Response(JSON.stringify({ error: "Invalid JSON body" }), {
         status: 400,
@@ -218,7 +226,7 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
 
   test("api_key auth rejects mismatched workspace_id", async () => {
     const client = makeDbClientForValidations({});
-    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client });
+    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client: {}, keyId: "k1", scopes: ["campaigns.write"]});
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       workspace_id: TEST_WORKSPACE_ID_ALT,
       title: "t",
@@ -234,7 +242,7 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
 
   test("validates title/type/caller_id/script requirements", async () => {
     const client = makeDbClientForValidations({});
-    mocks.verifyApiKeyOrSession.mockResolvedValue({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client });
+    mocks.verifyApiKeyOrSession.mockResolvedValue({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client: {}, keyId: "k1", scopes: ["campaigns.write"]});
     mocks.parseJsonBodyOrResponse.mockImplementation(async (request, schema) => {
       const actual = await vi.importActual<typeof import("@/lib/api-parse.server")>(
         "@/lib/api-parse.server",
@@ -304,6 +312,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -328,6 +338,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -351,6 +363,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -376,6 +390,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -397,6 +413,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -420,6 +438,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -447,6 +467,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -474,6 +496,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.validateCreateWithScriptPreflight.mockResolvedValueOnce({
       ok: false,
@@ -498,6 +522,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.createScriptForCampaign.mockResolvedValueOnce({
       ok: false,
@@ -519,6 +545,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.createScriptForCampaign.mockResolvedValueOnce({
       ok: false,
@@ -542,6 +570,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.createScriptForCampaign.mockResolvedValueOnce({
       ok: true,
@@ -582,6 +612,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       workspace_id: TEST_WORKSPACE_ID,
@@ -599,6 +631,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       workspace_id: TEST_WORKSPACE_ID,
@@ -666,6 +700,8 @@ describe("app/routes/api+/campaigns/route.create-with-script.tsx", () => {
       authType: "api_key",
       workspaceId,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.write"],
     });
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       workspace_id: workspaceId,

--- a/test/capability-gated-routes.test.ts
+++ b/test/capability-gated-routes.test.ts
@@ -34,6 +34,10 @@ vi.mock("@/lib/audit-event.server", () => ({
     mocks.safeRecordWorkspaceAuditEvent(...args),
 }));
 
+vi.mock("@/lib/twilio-twiml.server", () => ({
+  pauseTwiml: () => "<Response><Pause/></Response>",
+}));
+
 describe("capability-gated data-plane routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -171,5 +175,61 @@ describe("capability-gated data-plane routes", () => {
     );
 
     expect(res.status).toBe(200);
+  });
+
+  test("campaigns list rejects API key missing campaigns.read", async () => {
+    const mod = await import(
+      "../app/routes/api+/workspaces+/$workspaceId/campaigns.route"
+    );
+    const res = await asRouteResponse(
+      mod.loader(
+        await withDataPlaneRouteArgs(
+          {
+            request: new Request(
+              "http://localhost/api/workspaces/w1/campaigns",
+            ),
+            params: { workspaceId: "w1" },
+          },
+          {
+            userId: null,
+            apiKey: { keyId: "k1", scopes: ["messages.send"] },
+          },
+        ),
+      ),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  test("members invite rejects API key missing members.invite", async () => {
+    const mod = await import(
+      "../app/routes/api+/workspaces+/$workspaceId/members.route"
+    );
+    const res = await asRouteResponse(
+      mod.action(
+        await withDataPlaneRouteArgs(
+          {
+            request: new Request(
+              "http://localhost/api/workspaces/w1/members",
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  email: "a@example.com",
+                  role: "caller",
+                }),
+              },
+            ),
+            params: { workspaceId: "w1" },
+          },
+          {
+            userId: null,
+            apiKey: { keyId: "k1", scopes: ["campaigns.read"] },
+          },
+        ),
+      ),
+    );
+
+    expect(res.status).toBe(403);
   });
 });

--- a/test/chat-sms-action.route.test.ts
+++ b/test/chat-sms-action.route.test.ts
@@ -18,6 +18,11 @@ const tenantDbMocks = vi.hoisted(() => ({
   contact: { findFirst: vi.fn(async () => null) },
 }));
 
+vi.mock("@/lib/capability-guard.server", () => ({
+  requireDualAuthCapability: async () => ({ type: "ok" }),
+  requireDataPlaneCapability: async () => ({ type: "ok" }),
+}));
+
 vi.mock("@/lib/api-auth.server", () => ({
   verifyApiKeyOrSession: (...args: unknown[]) => mocks.verifyApiKeyOrSession(...args),
 }));

--- a/test/chat-sms.route.test.ts
+++ b/test/chat-sms.route.test.ts
@@ -33,6 +33,12 @@ const tenantDbMocks = vi.hoisted(() => ({
   },
 }));
 
+
+vi.mock("@/lib/capability-guard.server", () => ({
+  requireDualAuthCapability: async () => ({ type: "ok" }),
+  requireDataPlaneCapability: async () => ({ type: "ok" }),
+}));
+
 vi.mock("@/lib/api-auth.server", () => ({
   verifyApiKeyOrSession: (...args: any[]) => mocks.verifyApiKeyOrSession(...args),
 }));
@@ -521,7 +527,7 @@ describe("app/routes/api+/chat_sms/route.tsx", () => {
   });
 
   test("action api_key rejects workspace mismatch", async () => {
-    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client: {} });
+    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, keyId: "k1", scopes: ["messages.send"], client: {} });
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       to_number: "15551234567",
       workspace_id: TEST_WORKSPACE_ID_ALT,
@@ -537,7 +543,7 @@ describe("app/routes/api+/chat_sms/route.tsx", () => {
 
   test("action returns 402 with creditsError when workspace balance is depleted", async () => {
     mocks.getWorkspaceCreditsBalance.mockResolvedValueOnce(0);
-    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client: {} });
+    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, keyId: "k1", scopes: ["messages.send"], client: {} });
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       to_number: "+15551234567",
       workspace_id: TEST_WORKSPACE_ID,
@@ -557,7 +563,7 @@ describe("app/routes/api+/chat_sms/route.tsx", () => {
 
   test("action returns 402 with creditsError when workspace balance is unknown (fail closed)", async () => {
     mocks.getWorkspaceCreditsBalance.mockResolvedValueOnce(null);
-    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client: {} });
+    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, keyId: "k1", scopes: ["messages.send"], client: {} });
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       to_number: "+15551234567",
       workspace_id: TEST_WORKSPACE_ID,
@@ -574,7 +580,7 @@ describe("app/routes/api+/chat_sms/route.tsx", () => {
 
   test("action api_key success path uses authResult.client and user null; covers '+' not at start normalization", async () => {
     const client = makeDbClientStub({ webhookRows: [] });
-    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client });
+    mocks.verifyApiKeyOrSession.mockResolvedValueOnce({ authType: "api_key", workspaceId: TEST_WORKSPACE_ID, client: {}, keyId: "k1", scopes: ["messages.send"]});
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       to_number: "1+5551234567",
       workspace_id: TEST_WORKSPACE_ID,
@@ -759,6 +765,8 @@ describe("app/routes/api+/chat_sms/route.tsx", () => {
       authType: "api_key",
       workspaceId: "550e8400-e29b-41d4-a716-446655440000",
       client: {},
+      keyId: "k1",
+      scopes: ["messages.send"],
     });
     mocks.parseJsonBodyOrResponse.mockImplementation(async (request, schema) => {
       const actual = await vi.importActual<typeof import("@/lib/api-parse.server")>(

--- a/test/data-plane-cross-tenant-routes.test.ts
+++ b/test/data-plane-cross-tenant-routes.test.ts
@@ -43,6 +43,11 @@ vi.mock("@/lib/platform-workspace-numbers.server", () => ({
     mocks.deleteWorkspaceNumber(...args),
 }));
 
+vi.mock("@/lib/database/workspace.server", () => ({
+  getUserRole: vi.fn(async () => ({ role: "member" })),
+  requireWorkspaceAccess: vi.fn(async () => undefined),
+}));
+
 vi.mock("@/lib/workspace-events.server", () => ({
   WORKSPACE_EVENTS_NOTIFY_CHANNEL: "workspace_events",
   fetchWorkspaceEventsAfter: (...args: unknown[]) =>
@@ -50,6 +55,7 @@ vi.mock("@/lib/workspace-events.server", () => ({
 }));
 
 vi.mock("@/server/db", () => ({
+  db: {},
   directPool: {
     listen: (...args: unknown[]) => mocks.listen(...args),
   },

--- a/test/data-plane-role-gate.test.ts
+++ b/test/data-plane-role-gate.test.ts
@@ -10,6 +10,7 @@ vi.hoisted(() => {
 const mocks = vi.hoisted(() => ({
   verifyApiKeyOrSession: vi.fn(),
   requireWorkspaceAccess: vi.fn(),
+  getUserRole: vi.fn(),
   deleteContactApi: vi.fn(),
   getContactDetailApi: vi.fn(),
   patchCampaignQueueApi: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock("@/lib/api-auth.server", () => ({
 vi.mock("@/lib/database/workspace.server", () => ({
   requireWorkspaceAccess: (...a: unknown[]) =>
     mocks.requireWorkspaceAccess(...a),
+  getUserRole: (...a: unknown[]) => mocks.getUserRole(...a),
   fetchConversationSummary: vi.fn(),
 }));
 
@@ -75,6 +77,8 @@ function forbidBelowMember() {
 
 function allowAccess() {
   mocks.requireWorkspaceAccess.mockResolvedValue(undefined);
+  // Capability gate resolves session capabilities from role matrix.
+  mocks.getUserRole.mockResolvedValue({ role: "member" });
 }
 
 describe("data-plane mutation role gate (authForContact / authForCampaign)", () => {

--- a/test/export-authz.test.ts
+++ b/test/export-authz.test.ts
@@ -8,7 +8,9 @@ vi.hoisted(() => {
 import { asRouteResponse, withRouteUrl } from "./helpers/route-result";
 import { setDualAuthSession } from "./helpers/route-auth-mock";
 
-const requireWorkspaceAccess = vi.fn(async () => undefined);
+const requireWorkspaceAccess = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
 
 vi.mock("@/lib/campaign-ivr.server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/campaign-ivr.server")>();
@@ -46,12 +48,19 @@ vi.mock("@/lib/object-storage.server", () => ({
   downloadObject: vi.fn(async () => Buffer.from(JSON.stringify({ status: "processing" }))),
 }));
 
-vi.mock("@/lib/database/workspace.server", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/lib/database/workspace.server")
-  >("@/lib/database/workspace.server");
-  return { ...actual, requireWorkspaceAccess };
-});
+vi.mock("@/lib/database/workspace.server", () => ({
+  requireWorkspaceAccess: (...args: unknown[]) =>
+    requireWorkspaceAccess(...args),
+}));
+
+vi.mock("@/lib/capability-guard.server", () => ({
+  requireDualAuthCapability: async () => ({ type: "ok" }),
+  requireDataPlaneCapability: async () => ({ type: "ok" }),
+  requireDataPlaneRouteCapability: async (
+    _context: unknown,
+    workspaceId: string,
+  ) => ({ workspaceId, auth: { workspaceId, userId: "u1" } }),
+}));
 
 function buildMockDb() {
   const mockClient: any = {

--- a/test/helpers/route-auth-mock.ts
+++ b/test/helpers/route-auth-mock.ts
@@ -38,6 +38,17 @@ function buildDualAuth(session: RouteAuthSessionInput) {
   return {
     authType: "api_key" as const,
     workspaceId: "w-test",
+    keyId: "k-test",
+    scopes: [
+      "campaigns.read",
+      "campaigns.write",
+      "campaigns.dispatch",
+      "messages.send",
+      "calls.start",
+      "calls.control",
+      "members.invite",
+      "audit.read",
+    ],
   };
 }
 

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -187,16 +187,40 @@ describe("openapi spec", () => {
     ).toContain("DialerStartResponse");
   });
 
-  test("audit events route is owner-session documented with audit.read capability", () => {
+  test("audit events route documents dual auth with audit.read capability", () => {
     const audit =
       openApiSpec.paths["/api/workspaces/{workspaceId}/audit-events"].get;
 
     expect(audit?.operationId).toBe("listWorkspaceAuditEvents");
-    expect(audit?.security).toEqual([{ sessionCookie: [] }]);
+    expect(audit?.security).toEqual([{ sessionCookie: [] }, { apiKey: [] }]);
     expect(audit?.["x-callcaster-capability"]).toBe("audit.read");
     expect(
       audit?.responses?.["200"]?.content?.["application/json"]?.schema?.$ref,
     ).toContain("WorkspaceAuditEventListResponse");
+  });
+
+  test("CreateApiKeyRequest requires scopes and documents expiry", () => {
+    const schema = openApiSpec.components.schemas.CreateApiKeyRequest;
+    expect(schema.required).toEqual(expect.arrayContaining(["name", "scopes"]));
+    expect(schema.properties.scopes.minItems).toBe(1);
+    expect(schema.properties.expires_in_days.maximum).toBe(365);
+    expect(
+      openApiSpec.components.schemas.ProductCapabilityId.enum,
+    ).toContain("campaigns.read");
+  });
+
+  test("integrator operations declare required capabilities", () => {
+    expect(
+      openApiSpec.paths["/api/campaigns/create-with-script"].post?.[
+        "x-callcaster-capability"
+      ],
+    ).toBe("campaigns.write");
+    expect(
+      openApiSpec.paths["/api/chat_sms"].post?.["x-callcaster-capability"],
+    ).toBe("messages.send");
+    expect(openApiSpec.paths["/api/sms"].post?.["x-callcaster-capability"]).toBe(
+      "campaigns.dispatch",
+    );
   });
 
   test("workspace scoped routes have stable operationIds and mixed auth", () => {
@@ -239,13 +263,20 @@ describe("openapi spec", () => {
         ?.operationId,
     ).toBe("patchWorkspaceNumber");
 
-    for (const pathItem of [apiKeys, members, webhook, numbers]) {
+    for (const pathItem of [apiKeys, webhook, numbers]) {
       for (const op of Object.values(pathItem)) {
         if (op && typeof op === "object" && "security" in op) {
           expect(op.security).toEqual([{ sessionCookie: [] }]);
         }
       }
     }
+    expect(members.get?.security).toEqual([{ sessionCookie: [] }]);
+    expect(members.post?.security).toEqual([
+      { sessionCookie: [] },
+      { apiKey: [] },
+    ]);
+    expect(members.patch?.security).toEqual([{ sessionCookie: [] }]);
+    expect(members.delete?.security).toEqual([{ sessionCookie: [] }]);
     expect(transfer?.security).toEqual([{ sessionCookie: [] }]);
   });
 });

--- a/test/sms-action.route.test.ts
+++ b/test/sms-action.route.test.ts
@@ -35,6 +35,11 @@ vi.mock("@/lib/recipient-calling-window", () => ({
   isWithinRecipientCallingWindow: vi.fn(() => true),
 }));
 
+vi.mock("@/lib/capability-guard.server", () => ({
+  requireDualAuthCapability: async () => ({ type: "ok" }),
+  requireDataPlaneCapability: async () => ({ type: "ok" }),
+}));
+
 vi.mock("@/lib/api-auth.server", () => ({
   verifyApiKeyOrSession: (...args: unknown[]) => mocks.verifyApiKeyOrSession(...args),
 }));

--- a/test/sms.route.test.ts
+++ b/test/sms.route.test.ts
@@ -72,6 +72,12 @@ vi.mock("@/lib/recipient-calling-window", () => ({
   isWithinRecipientCallingWindow: vi.fn(() => true),
 }));
 
+
+vi.mock("@/lib/capability-guard.server", () => ({
+  requireDualAuthCapability: async () => ({ type: "ok" }),
+  requireDataPlaneCapability: async () => ({ type: "ok" }),
+}));
+
 vi.mock("@/lib/api-auth.server", () => ({
   verifyApiKeyOrSession: (...args: any[]) => mocks.verifyApiKeyOrSession(...args),
 }));
@@ -284,6 +290,8 @@ describe("app/routes/api+/sms/route.tsx", () => {
       authType: "api_key",
       workspaceId: TEST_WORKSPACE_ID,
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.dispatch"],
     });
     mocks.getWorkspaceTwilioPortalConfig.mockResolvedValue(defaultPortalConfig);
     mocks.rpcCreateOutreachAttempt.mockResolvedValue("oa1");
@@ -870,6 +878,8 @@ describe("app/routes/api+/sms/route.tsx", () => {
       authType: "api_key",
       workspaceId: "550e8400-e29b-41d4-a716-446655440000",
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.dispatch"],
     });
     mocks.parseJsonBodyOrResponse.mockResolvedValueOnce({
       campaign_id: "c1",
@@ -890,6 +900,8 @@ describe("app/routes/api+/sms/route.tsx", () => {
       authType: "api_key",
       workspaceId: "550e8400-e29b-41d4-a716-446655440000",
       client: {},
+      keyId: "k1",
+      scopes: ["campaigns.dispatch"],
     });
     mocks.parseJsonBodyOrResponse.mockImplementation(async (request, schema) => {
       const actual = await vi.importActual<typeof import("@/lib/api-parse.server")>(

--- a/test/ui/api-key-capability-picker.test.tsx
+++ b/test/ui/api-key-capability-picker.test.tsx
@@ -26,6 +26,15 @@ describe("ApiKeyCapabilityPicker", () => {
     expect(screen.queryByText("campaigns.read")).toBeNull();
   });
 
+  test("capability descriptions cover data-plane resources", () => {
+    render(<ApiKeyCapabilityPicker />);
+    expect(
+      screen.getByText(/contacts, audiences, scripts, surveys, conversations/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/Dispatch campaign SMS batches/i)).toBeTruthy();
+    expect(screen.getByText(/direct chat SMS/i)).toBeTruthy();
+  });
+
   test("checking a capability emits a hidden scopes field and selected count", () => {
     const { container } = render(<ApiKeyCapabilityPicker />);
     fireEvent.click(container.querySelector('input[data-scope-value="messages.send"]')!);


### PR DESCRIPTION
- Added optional `capability` field to API surface operations to enforce product capabilities.
- Updated various API endpoints to include capability checks for actions like reading, writing, and dispatching campaigns.
- Enhanced documentation and descriptions to reflect the new capability requirements for API keys.
- Refactored authentication functions to integrate capability checks, ensuring proper access control based on user roles and API keys.

This change improves security and clarity in API usage by explicitly defining required capabilities for each operation.