### PR TITLE
fix: prevent outbound call from disconnecting immediately due to unstable callback identities

### DIFF
--- a/app/hooks/call/useCallHandling.ts
+++ b/app/hooks/call/useCallHandling.ts
@@ -507,13 +507,25 @@ export function useCallHandling({
     applyAgentLegMute(currentActive, isMicMutedRef.current);
   }, []);
 
+  const onStatusChangeRef = useRef(onStatusChange);
+  const onErrorRef = useRef(onError);
+  const onDeviceBusyChangeRef = useRef(onDeviceBusyChange);
+  const updateCallStateRef = useRef(updateCallState);
+  const updateActiveCallRef = useRef(updateActiveCall);
+
+  onStatusChangeRef.current = onStatusChange;
+  onErrorRef.current = onError;
+  onDeviceBusyChangeRef.current = onDeviceBusyChange;
+  updateCallStateRef.current = updateCallState;
+  updateActiveCallRef.current = updateActiveCall;
+
   /**
    * @effect Attach Twilio Call SDK event listeners (accept/audio/disconnect/
    * error) to the current active call and drive local call-state and
    * held-call transitions when it accepts, ends, or errors.
-   * @effect-deps activeCall, updateCallState, updateActiveCall, onStatusChange,
-   * onError, onDeviceBusyChange (re-subscribes whenever the active call
-   * instance changes; the callbacks are invoked from the listeners)
+   * @effect-deps activeCall (re-subscribes only when the active call instance
+   * changes; callback identities are read via refs so unstable callers cannot
+   * cause spurious detach/reattach cycles)
    * @effect-side-effects subscription (Twilio Call event listeners), cleaned
    * up whenever activeCall changes or on unmount.
    * @effect-why-not-loader Subscribes to imperative SDK call-object events;
@@ -523,7 +535,7 @@ export function useCallHandling({
     if (!activeCall) return;
 
     const handleAccept = () => {
-      updateCallState("connected");
+      updateCallStateRef.current("connected");
     };
 
     const handleAudio = (e: unknown) => {
@@ -541,22 +553,22 @@ export function useCallHandling({
         isMicMutedRef.current = false;
         isOnLocalHoldRef.current = false;
         applyAgentLegMute(next, false);
-        updateActiveCall(next);
-        onStatusChange?.("connected");
-        updateCallState("connected");
+        updateActiveCallRef.current(next);
+        onStatusChangeRef.current?.("connected");
+        updateCallStateRef.current("connected");
       } else {
-        updateActiveCall(null);
-        onStatusChange?.("Registered");
-        updateCallState("completed");
-        onDeviceBusyChange?.(false);
+        updateActiveCallRef.current(null);
+        onStatusChangeRef.current?.("Registered");
+        updateCallStateRef.current("completed");
+        onDeviceBusyChangeRef.current?.(false);
       }
     };
 
     const handleError = (err: unknown) => {
       const error = err instanceof Error ? err : new Error("Call error");
-      onDeviceBusyChange?.(false);
-      onError?.(error);
-      updateCallState("failed");
+      onDeviceBusyChangeRef.current?.(false);
+      onErrorRef.current?.(error);
+      updateCallStateRef.current("failed");
       logger.error("Call error:", error);
     };
 
@@ -568,14 +580,7 @@ export function useCallHandling({
     ];
 
     return () => cleanups.forEach((fn) => fn());
-  }, [
-    activeCall,
-    updateCallState,
-    updateActiveCall,
-    onStatusChange,
-    onError,
-    onDeviceBusyChange,
-  ]);
+  }, [activeCall]);
 
   /**
    * @effect Attach a disconnect listener to each currently held call so a held

--- a/app/hooks/call/useSoftphoneController.ts
+++ b/app/hooks/call/useSoftphoneController.ts
@@ -48,12 +48,16 @@ export function useSoftphoneController({
     onDeviceBusyChange: noop,
   });
 
+  const handleCallError = useCallback(
+    (err: Error) => onError(err?.message ?? "Call error"),
+    [onError],
+  );
+
   const callHandling = useCallHandling({
     device: connection.device,
     workspaceId,
     onStatusChange: noop,
-    // Same defensive guard as handleConnectionError above.
-    onError: (err) => onError(err?.message ?? "Call error"),
+    onError: handleCallError,
     onDeviceBusyChange: noop,
   });
 

--- a/app/hooks/call/useTwilioDevice.ts
+++ b/app/hooks/call/useTwilioDevice.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Call, Device } from "@twilio/voice-sdk";
 import { useCallDuration } from "./useCallDuration";
 import { useTwilioConnection } from "./useTwilioConnection";
@@ -53,41 +53,43 @@ export function useTwilioDevice(
   const [error, setError] = useState<Error | null>(null);
   const receiveIncomingRef = useRef<(call: Call) => void>(() => {});
 
+  const onStatusChange = useCallback((newStatus: string) => {
+    setStatus(newStatus);
+  }, []);
+
+  const onDeviceError = useCallback((err: Error) => {
+    setError(err);
+  }, []);
+
+  const onDeviceBusy = useCallback((isBusy: boolean) => {
+    setIsBusy(isBusy);
+  }, []);
+
+  const onCallState = useCallback((newCallState: string) => {
+    switch (newCallState) {
+      case "dialing": send({ type: "START_DIALING" }); break;
+      case "connected": send({ type: "CONNECT" }); break;
+      case "completed": send({ type: "HANG_UP" }); break;
+      case "failed": send({ type: "FAIL" }); break;
+    }
+  }, [send]);
+
   const connection = useTwilioConnection({
     token,
     onIncomingCall: (call) => receiveIncomingRef.current(call),
-    onStatusChange: (newStatus) => {
-      setStatus(newStatus);
-    },
-    onError: (err) => {
-      setError(err);
-    },
-    onDeviceBusyChange: (isBusy) => {
-      setIsBusy(isBusy);
-    },
+    onStatusChange,
+    onError: onDeviceError,
+    onDeviceBusyChange: onDeviceBusy,
   });
 
   const callHandling = useCallHandling({
     device: connection.device,
     workspaceId,
     autoAcceptIncoming: true,
-    onCallStateChange: (newCallState) => {
-      switch (newCallState) {
-        case "dialing": send({ type: "START_DIALING" }); break;
-        case "connected": send({ type: "CONNECT" }); break;
-        case "completed": send({ type: "HANG_UP" }); break;
-        case "failed": send({ type: "FAIL" }); break;
-      }
-    },
-    onStatusChange: (newStatus) => {
-      setStatus(newStatus);
-    },
-    onError: (err) => {
-      setError(err);
-    },
-    onDeviceBusyChange: (isBusy) => {
-      setIsBusy(isBusy);
-    },
+    onCallStateChange: onCallState,
+    onStatusChange,
+    onError: onDeviceError,
+    onDeviceBusyChange: onDeviceBusy,
   });
 
   /**
@@ -106,28 +108,39 @@ export function useTwilioDevice(
 
   const { callDuration, setCallDuration } = useCallDuration(callHandling.callState);
 
+  const activeCallRef = useRef(callHandling.activeCall);
+  const hangUpRef = useRef(callHandling.hangUp);
+  const callStateRef = useRef(callHandling.callState);
+  const deviceRef = useRef(connection.device);
+
+  activeCallRef.current = callHandling.activeCall;
+  hangUpRef.current = callHandling.hangUp;
+  callStateRef.current = callHandling.callState;
+  deviceRef.current = connection.device;
+
   /**
    * @effect Hang up the active call and disconnect the Twilio device when
    * the component unmounts, so calls do not stay live and consume credits
    * after the agent navigates away.
-   * @effect-deps callHandling.hangUp, callHandling.activeCall, callHandling.callState, connection.device
+   * @effect-deps [] — mount-once cleanup-only; reads latest values via refs
+   * kept fresh on every render so the unmount teardown always acts on the
+   * current call/device regardless of stale closures.
    * @effect-side-effects hung up / disconnecting SDK calls + device
    * @effect-why-not-loader Teardown of imperative SDK resources on unmount.
    */
   useEffect(() => {
-    const hangUp = callHandling.hangUp;
-    const device = connection.device;
-    const hasActiveCall = Boolean(callHandling.activeCall);
-    const isActive = callHandling.callState === "connected" || callHandling.callState === "dialing";
     return () => {
+      const hasActiveCall = Boolean(activeCallRef.current);
+      const isActive =
+        callStateRef.current === "connected" || callStateRef.current === "dialing";
       if (hasActiveCall || isActive) {
-        hangUp().catch(() => {
+        hangUpRef.current?.().catch(() => {
           logger.debug("Call hung up during unmount cleanup");
         });
       }
-      device?.disconnectAll();
+      deviceRef.current?.disconnectAll();
     };
-  }, [callHandling.hangUp, callHandling.activeCall, callHandling.callState, connection.device]);
+  }, []);
 
   return {
     device: connection.device,


### PR DESCRIPTION
## Root cause

The unmount cleanup effect in `useTwilioDevice` was re-running on **every render** — not just unmount — because `callHandling.hangUp` had a fresh identity each render.

**Chain:** inline arrow callbacks (`onCallStateChange`, `onStatusChange`, `onError`, `onDeviceBusyChange`) → unstable `updateCallState` → unstable `hangUp` → effect deps change → cleanup fires `hangUp()` on the still-alive call → call disconnects immediately.

Network trace showed two `POST /api/hangup` from `useCallHandling` chunk and `disconnect.mp3` confirming the SDK-level disconnect.

## Fixes

1. **`useTwilioDevice.ts`** — Wrap all 4 callback props in `useCallback`; switch unmount cleanup from state-deps to refs (matching `useSoftphoneController` pattern)

2. **`useCallHandling.ts`** — Convert activeCall listener effect to ref-based callback access so it only depends on `[activeCall]`, immune to unstable callers

3. **`useSoftphoneController.ts`** — Wrap inline `onError` in `useCallback`

## Verification

- Typecheck: clean
- Lint: clean
- 580/580 UI tests pass