### PR TITLE
fix: persist child-leg callbacks and warn on duplicate contact phone

### DIFF
--- a/app/lib/telephony-db.server.ts
+++ b/app/lib/telephony-db.server.ts
@@ -243,7 +243,8 @@ export async function upsertCallBySid(
 ): Promise<CallRow | null> {
   const existingWorkspace = values.workspace ?? null;
   if (existingWorkspace) {
-    return updateCallBySid(existingWorkspace, values.sid, values as Partial<CallRow>);
+    const updated = await updateCallBySid(existingWorkspace, values.sid, values as Partial<CallRow>);
+    if (updated) return updated;
   }
 
   const [row] = await db

--- a/app/routes/workspaces+/$id/contacts/$contactId.action.server.ts
+++ b/app/routes/workspaces+/$id/contacts/$contactId.action.server.ts
@@ -1,5 +1,5 @@
 import { data as routeData } from "react-router";
-import { updateContact } from "@/lib/database/contact.server";
+import { findContactsByPhone, updateContact } from "@/lib/database/contact.server";
 import { requireWorkspaceAccess } from "@/lib/database/workspace.server";
 import { logger } from "@/lib/logger.server";
 import { createTenantDb } from "@/server/tenant-db";
@@ -72,6 +72,17 @@ export const action = defineAction({
     const tdb = createTenantDb(workspace_id);
 
     if (selected_id === "new") {
+      let duplicateWarning: string | undefined;
+      if (normalizedPhone) {
+        const existing = await findContactsByPhone(workspace_id, normalizedPhone, tdb);
+        if (existing.length > 0) {
+          const names = existing.map(
+            (c) => [c.firstname, c.surname].filter(Boolean).join(" ") || `id: ${c.id}`,
+          );
+          duplicateWarning = `A contact with phone ${normalizedPhone} already exists: ${names.join(", ")}`;
+        }
+      }
+
       const { workspace: _workspace, id: _id, ...insertValues } = contactData;
       const [newContact] = await tdb.contact.insert(insertValues);
 
@@ -79,7 +90,11 @@ export const action = defineAction({
         throw new Error("Failed to create contact");
       }
 
-      return routeData({ success: true, contact: newContact });
+      return routeData({
+        success: true,
+        contact: newContact,
+        ...(duplicateWarning ? { warning: duplicateWarning } : {}),
+      });
     }
 
     const contactId = Number(selected_id);

--- a/app/routes/workspaces+/$id/contacts/$contactId.route.tsx
+++ b/app/routes/workspaces+/$id/contacts/$contactId.route.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useRef, useState } from "react";
-import { useLoaderData, useSubmit } from "react-router";
-import { toast } from "sonner";
+import { useActionData, useLoaderData, useSubmit } from "react-router";
 
 import ContactDetails from "@/components/contact/ContactDetails";
 import type { ContactDetailsHandle } from "@/components/contact/ContactDetails";
 import { Button } from "@/components/ui/button";
 import { PageShell } from "@/components/ui/page-shell";
+import { useActionFeedback } from "@/hooks/utils/useActionFeedback";
 
 import type { ContactIdLoaderData } from "./$contactId.loader.server";
+
+type ActionResponse = { success?: boolean; warning?: string; error?: string };
 
 export { loader } from "./$contactId.loader.server";
 export { action } from "./$contactId.action.server";
@@ -16,26 +18,31 @@ export { RouteErrorBoundary as ErrorBoundary } from "@/components/shared/RouteEr
 export default function ContactScreen() {
   const { contact, selected_id, userRole, audiences } =
     useLoaderData<ContactIdLoaderData>();
+  const actionData = useActionData<ActionResponse>();
   const submit = useSubmit();
   const detailsRef = useRef<ContactDetailsHandle>(null);
 
   const [isSaving, setIsSaving] = useState(false);
   const [hasChanges, setHasChanges] = useState(false);
 
+  useActionFeedback(actionData, {
+    successMessage:
+      selected_id === "new"
+        ? "Contact created successfully"
+        : "Contact saved successfully",
+    errorMessage: "Couldn't save the contact. Please try again.",
+    getWarning: (data) => data?.warning,
+  });
+
   const handleSave = useCallback((): void => {
-    try {
-      setIsSaving(true);
-      const values = detailsRef.current?.getFormValues() ?? {};
-      const formData = new FormData();
-      for (const [key, value] of Object.entries(values)) {
-        formData.set(key, value ?? "");
-      }
-      submit(formData, { method: "post" });
-    } catch {
-      toast.error("Couldn't save the contact. Please try again.");
-    } finally {
-      setIsSaving(false);
+    setIsSaving(true);
+    const values = detailsRef.current?.getFormValues() ?? {};
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(values)) {
+      formData.set(key, value ?? "");
     }
+    submit(formData, { method: "post" });
+    setIsSaving(false);
   }, [submit]);
 
   const handleReset = useCallback((): void => {


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. Call status not updating (#1125)

**Root cause:** `upsertCallBySid` in `telephony-db.server.ts` routed to `updateCallBySid` when workspace was known, but never fell through to INSERT when the UPDATE matched 0 rows. Twilio child-leg callbacks (ringing, answered, completed) were silently dropped because the child SID didn't exist in the DB yet.

**Fix:** When `updateCallBySid` returns null (0 rows affected), fall through to the INSERT path. This persists child-leg callbacks, fires SSE events, and updates the UI in real-time when the far end disconnects.

### 2. Duplicate contact phone warning

When creating a new contact ("Save as new contact"), the action now checks if the phone number already exists in the workspace and returns a `warning` field. The route uses `useActionFeedback` to display it as a toast.

Also replaced raw `toast.error` in the save handler with `useActionFeedback` for consistent success/error/warning feedback.

## Changes

| File | Change |
|------|--------|
| `app/lib/telephony-db.server.ts` | `upsertCallBySid` fall through to INSERT when UPDATE misses |
| `app/routes/workspaces+/$id/contacts/$contactId.action.server.ts` | Duplicate phone detection on new contact creation |
| `app/routes/workspaces+/$id/contacts/$contactId.route.tsx` | Use `useActionFeedback` instead of raw `toast.error`