### PR TITLE
fix: harden manual dialing against multi-agent races

### DIFF
--- a/app/hooks/call/useCallScreen.ts
+++ b/app/hooks/call/useCallScreen.ts
@@ -210,7 +210,7 @@ export function useCallScreen() {
   useDialFailureRecovery({
     fetcherState: fetcher.state,
     fetcherData: fetcher.data,
-    send: send as unknown as (action: { type: string }) => void,
+    send,
     showError: (message) => toast.error(message),
   });
 

--- a/app/hooks/call/useCallScreen.ts
+++ b/app/hooks/call/useCallScreen.ts
@@ -29,6 +29,7 @@ import {
 } from "@/hooks/call/useCampaignDialActions";
 import { usePredictiveCallSync } from "@/hooks/call/usePredictiveCallSync";
 import { useNextRecipientSync } from "@/hooks/call/useNextRecipientSync";
+import { useDialFailureRecovery } from "@/hooks/call/useDialFailureRecovery";
 import { getCallSid } from "@/lib/twilio/twilio-call-params";
 import { KEYPAD_KEYS } from "@/lib/dtmf";
 import type {
@@ -199,12 +200,19 @@ export function useCallScreen() {
     },
   );
 
-  const fetcher = useFetcher<{ creditsError?: boolean }>();
+  const fetcher = useFetcher<{ creditsError?: boolean; error?: string }>();
   const submit = fetcher.submit;
   const creditsError =
     fetcher.data?.creditsError ||
     conferenceCreditsError ||
     (credits ?? 0) <= 0;
+
+  useDialFailureRecovery({
+    fetcherState: fetcher.state,
+    fetcherData: fetcher.data,
+    send: send as unknown as (action: { type: string }) => void,
+    showError: (message) => toast.error(message),
+  });
 
   const { startCall } = handleCall({ submit });
   const { handleConferenceEnd } = handleConference({

--- a/app/hooks/call/useDialFailureRecovery.ts
+++ b/app/hooks/call/useDialFailureRecovery.ts
@@ -3,7 +3,12 @@ import { useEffect } from "react";
 type UseDialFailureRecoveryOptions = {
   fetcherState: string;
   fetcherData: { error?: string; creditsError?: boolean } | undefined;
-  send: (action: { type: string }) => void;
+  // Narrowed to just the action this hook ever dispatches (rather than the
+  // wider `{ type: string }` + `as unknown as` cast other call-screen hooks
+  // use) — useCallState's send is `(action: CallAction) => void`, and a
+  // function typed to accept the whole CallAction union is assignable here
+  // without a cast under parameter contravariance.
+  send: (action: { type: "FAIL" }) => void;
   showError: (message: string) => void;
 };
 

--- a/app/hooks/call/useDialFailureRecovery.ts
+++ b/app/hooks/call/useDialFailureRecovery.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+
+type UseDialFailureRecoveryOptions = {
+  fetcherState: string;
+  fetcherData: { error?: string; creditsError?: boolean } | undefined;
+  send: (action: { type: string }) => void;
+  showError: (message: string) => void;
+};
+
+/**
+ * Recover the call FSM when the /api/dial submit is rejected (409 claim
+ * refusal, 402 credits, 5xx). START_DIALING fires before the POST settles,
+ * so a rejected dial otherwise left the status bar stuck on "Dialing…" with
+ * nothing to hang up.
+ */
+export function useDialFailureRecovery({
+  fetcherState,
+  fetcherData,
+  send,
+  showError,
+}: UseDialFailureRecoveryOptions) {
+  /**
+   * @effect Dispatch FAIL to the call FSM when a settled dial fetcher
+   * carries an error or creditsError, and toast the error message if one was
+   * given.
+   * @effect-deps fetcherState, fetcherData, send, showError (fires once per
+   * settled fetcher response carrying a rejection)
+   * @effect-side-effects none directly (FSM dispatch + toast)
+   * @effect-why-not-loader Reacts to a mutation result to fix client FSM
+   * state; not request/response data for render.
+   */
+  useEffect(() => {
+    if (fetcherState !== "idle" || !fetcherData) return;
+    const { error, creditsError } = fetcherData;
+    if (error || creditsError) {
+      send({ type: "FAIL" });
+      if (error) showError(error);
+    }
+  }, [fetcherState, fetcherData, send, showError]);
+}

--- a/app/lib/db-rpc.server.ts
+++ b/app/lib/db-rpc.server.ts
@@ -153,6 +153,40 @@ export async function rpcCreateOutreachAttempt(
   return id;
 }
 
+export type DialClaimResult =
+  | "claimed"
+  | "unavailable"
+  | "claimed_by_other"
+  | "not_queued"
+  | "active_call";
+
+/**
+ * Atomically claim a specific queue row before dialing it (manual dial path).
+ * Anything but "claimed" means the dial must not proceed — see
+ * client/migrations/20260805120000_atomic_manual_dial_claims.sql for the
+ * exact semantics of each refusal code.
+ */
+export async function rpcClaimQueueEntryForDial(
+  executor: RpcExecutor,
+  args: {
+    queueId: number;
+    campaignId: number;
+    workspaceId: string;
+    userId: string;
+  },
+): Promise<DialClaimResult> {
+  const result = await queryScalar<string>(
+    executor,
+    sql`select claim_queue_entry_for_dial(
+      ${args.queueId}::bigint,
+      ${args.campaignId}::bigint,
+      ${args.workspaceId}::uuid,
+      ${args.userId}::uuid
+    ) as result`,
+  );
+  return (result ?? "unavailable") as DialClaimResult;
+}
+
 export async function rpcDequeueContact(
   executor: RpcExecutor,
   args: {

--- a/app/routes/api+/dial.action.server.ts
+++ b/app/routes/api+/dial.action.server.ts
@@ -5,6 +5,7 @@ import {
   requireWorkspaceAccess,
 } from "@/lib/database/workspace.server";
 import { parseActionRequest } from "@/lib/request-utils.server";
+import { rpcClaimQueueEntryForDial } from "@/lib/db-rpc.server";
 import { getWorkspaceCreditsBalance } from "@/lib/workspace-credits.server";
 import { hasInsufficientCreditsForOutbound } from "../../../shared/credit-floor";
 import { createTenantDb } from "@/server/tenant-db";
@@ -76,7 +77,36 @@ export const action = defineAction({
     if (hasInsufficientCreditsForOutbound(credits)) {
         return routeData({ creditsError: true }, { status: 402 });
     }
+    // NOTE: this credit gate is check-then-act — N concurrent dials can all
+    // read the same pre-debit balance (the debit lands at call completion).
+    // Overdraw is bounded by concurrency × per-call cost; an atomic pre-dial
+    // hold via apply_ledger_entry_and_sync_credits is the follow-up if that
+    // bound ever matters.
     const tdb = createTenantDb(workspace_id);
+
+    // Atomically claim the queue row before placing a real call. This is the
+    // server-side guard the client's callState check cannot provide: without
+    // it a double-click, a second tab, or two agents holding the same
+    // unclaimed row each dialed a real person. Refusals are 409s the call
+    // screen surfaces as a failed dial rather than a stuck "Dialing…".
+    const claim = await rpcClaimQueueEntryForDial(tdb, {
+        queueId: Number(queue_id),
+        campaignId: Number(campaign_id),
+        workspaceId: workspace_id,
+        userId: user.id,
+    });
+    if (claim !== "claimed") {
+        const messages: Record<string, string> = {
+            claimed_by_other: "This contact is being dialed by another agent.",
+            active_call: "This contact already has a call in progress.",
+            not_queued: "This contact is no longer queued.",
+            unavailable: "This contact is not available to dial.",
+        };
+        return routeData(
+            { error: messages[claim] ?? messages.unavailable, claim },
+            { status: 409 },
+        );
+    }
     const [callerIdRecord, onboarding] = await Promise.all([
         tdb.workspace_number.findFirst({
             where: eq(workspaceNumberTable.phone_number, caller_id),

--- a/app/routes/api+/hangup.action.server.ts
+++ b/app/routes/api+/hangup.action.server.ts
@@ -3,7 +3,9 @@ import {
   requireWorkspaceAccess,
 } from "@/lib/database/workspace.server";
 import { parseActionRequest } from "@/lib/request-utils.server";
-import { findCallBySid, updateOutreachDispositionByContactId } from "@/lib/telephony-db.server";
+import { findCallBySid, updateOutreachAttemptForWorkspace } from "@/lib/telephony-db.server";
+import { campaign as campaignTable } from "@/db/schema";
+import { eq } from "drizzle-orm";
 import { data as routeData } from "react-router";
 import { logger } from "@/lib/logger.server";
 import { requireJsonAuth } from "@/lib/api-auth.server";
@@ -45,17 +47,35 @@ export const action = defineAction({
             }
         }
         if (call.contact_id) {
+            // Household fan-out follows the campaign's setting; it was
+            // hardcoded true, dequeuing whole households on campaigns that
+            // never asked for household grouping.
+            const campaign = call.campaign_id
+                ? await tdb.campaign.findFirst({
+                      where: eq(campaignTable.id, call.campaign_id),
+                      columns: { group_household_queue: true },
+                  })
+                : null;
             await rpcDequeueContact(tdb, {
                 contactId: call.contact_id,
-                groupOnHousehold: true,
+                groupOnHousehold: campaign?.group_household_queue ?? false,
                 dequeuedById: user.id,
                 dequeuedReasonText: "Call completed",
             });
-            await updateOutreachDispositionByContactId(
-                workspaceId,
-                call.contact_id,
-                "completed",
-            );
+            // Scope the disposition to THIS call's attempt. The old
+            // updateOutreachDispositionByContactId rewrote every attempt for
+            // the contact across all campaigns to "completed", destroying
+            // do_not_call/voicemail history. The workspace-scoped update also
+            // applies the terminal-transition guard, so a real disposition
+            // already on the attempt is never downgraded.
+            if (call.outreach_attempt_id) {
+                await updateOutreachAttemptForWorkspace(
+                    workspaceId,
+                    call.outreach_attempt_id,
+                    { disposition: "completed" },
+                    { tdb },
+                );
+            }
         }
         return routeData({ success: true });
 

--- a/client/migrations/20260805120000_atomic_manual_dial_claims.sql
+++ b/client/migrations/20260805120000_atomic_manual_dial_claims.sql
@@ -1,0 +1,215 @@
+-- Atomic claiming for the manual-dial (dial_type 'call') path.
+--
+-- The 2026-08-05 call-screen audit found the manual path has none of the
+-- claim discipline the predictive path gained in 20260731120000:
+--
+-- 1) select_and_update_campaign_contacts (the "fetchMore" RPC, fired from
+--    every "Save and Next") was check-then-act: the CTE selected `queued`
+--    rows with no lock, and the UPDATE re-checked only `cq.id = bc.queue_id`
+--    — which still holds after a concurrent claimer wins EvalPlanQual — and
+--    RETURNING came from the CTE, so BOTH concurrent callers received the
+--    same contacts. Two agents ended up dialing the same person. Fixed the
+--    same way claim_next_queue_contact fixed the auto-dialer: FOR UPDATE
+--    SKIP LOCKED on the candidate rows (in a plain first CTE — FOR UPDATE
+--    is not allowed alongside window functions, so ranking happens in a
+--    second CTE over the locked rows), a queue_state re-check in the UPDATE
+--    predicate, and RETURNING from the updated table.
+--
+-- 2) claim_queue_entry_for_dial is new: /api/dial had no claim at all — it
+--    dialed whatever queue_id the client sent. A double-click, two tabs, or
+--    two agents holding the same unclaimed row each placed a REAL outbound
+--    call to a real person. The claim locks the specific row (FOR UPDATE;
+--    no SKIP LOCKED here — a locked row means someone else is mid-claim and
+--    the caller must know, not silently move on), verifies workspace and
+--    campaign ownership, rejects rows claimed by another agent, and refuses
+--    to claim while the same contact already has a live call on this
+--    campaign. Distinct return codes let the route give the agent a precise
+--    reason.
+--
+-- Contract notes:
+-- * Like claim_next_queue_contact, opt_out filtering stays in the caller.
+-- * 'unavailable' covers both "row is locked by a concurrent claim" and
+--   "row does not exist / wrong campaign / wrong workspace" — the caller
+--   treats every non-'claimed' result as a refusal to dial.
+
+CREATE OR REPLACE FUNCTION public.select_and_update_campaign_contacts(
+  p_campaign_id integer,
+  p_initial_limit integer
+)
+RETURNS TABLE(queue_id integer, contact_id integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_user_id uuid;
+BEGIN
+    v_user_id := auth.uid();
+
+    IF v_user_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    WITH locked_rows AS (
+        -- Plain SELECT so FOR UPDATE is legal; SKIP LOCKED makes concurrent
+        -- fetchMore calls take disjoint rows instead of colliding.
+        SELECT
+            cq.id AS queue_id,
+            cq.contact_id,
+            cq.attempts,
+            cq.queue_order,
+            c.id AS c_id,
+            c.address
+        FROM
+            campaign_queue cq
+            JOIN contact c ON c.id = cq.contact_id
+        WHERE
+            cq.campaign_id = p_campaign_id
+            -- NULL is treated as unclaimed, matching claim_next_queue_contact.
+            AND (cq.queue_state IS NULL OR cq.queue_state = 'queued')
+            AND c.phone IS NOT NULL
+            AND c.phone != ''
+        -- Same ordering the ranking below uses. Without this ORDER BY + LIMIT,
+        -- FOR UPDATE locks EVERY unclaimed row in the campaign on every call —
+        -- verified against a live Postgres: two concurrent calls with
+        -- p_initial_limit 3 against an unbounded lock left the second caller
+        -- with ZERO rows every time, because the first call's lock covered
+        -- every candidate, not just the 3 it claimed, blocking everything
+        -- until commit. That serializes every agent's "Save and Next" on one
+        -- campaign — the opposite of this fix's goal. The multiplier bounds
+        -- the lock to a superset large enough to satisfy household bundling
+        -- in the common case; re-verified at 100 unclaimed rows (the real
+        -- caller — callscreenActions.ts fetchMore — never requests more than
+        -- 10) that two concurrent calls land on disjoint rows. Trade-off,
+        -- also verified: when the REMAINING unclaimed queue is smaller than
+        -- the bound (a nearly-drained campaign), this still locks all of it
+        -- for the call's duration — milliseconds in production, not the
+        -- multi-second sleep used to make the race observable above. A
+        -- pathologically large single household can also yield fewer than
+        -- p_initial_limit contacts in one call; both are far safer failure
+        -- modes than the duplicate-assignment this migration fixes.
+        ORDER BY cq.attempts ASC, cq.queue_order ASC, c.id ASC
+        LIMIT GREATEST(p_initial_limit, 1) * 25
+        FOR UPDATE OF cq SKIP LOCKED
+    ),
+    base_contacts AS (
+        SELECT
+            lr.queue_id::INTEGER AS queue_id,
+            lr.c_id::INTEGER AS contact_id,
+            CASE
+                WHEN lr.address IS NULL OR lr.address = '' THEN 'NO_ADDRESS_' || lr.c_id::TEXT
+                ELSE lr.address
+            END AS effective_address,
+            ROW_NUMBER() OVER (
+                ORDER BY lr.attempts ASC, lr.queue_order ASC, lr.c_id
+            ) AS overall_rank,
+            CASE
+                WHEN lr.address IS NULL OR lr.address = '' THEN 1
+                ELSE 0
+            END as is_no_address
+        FROM locked_rows lr
+    ),
+    address_groups AS (
+        SELECT
+            effective_address,
+            MIN(overall_rank) as first_rank,
+            COUNT(*) as address_count,
+            MAX(is_no_address) as is_no_address
+        FROM base_contacts
+        GROUP BY effective_address
+    ),
+    running_totals AS (
+        SELECT
+            effective_address,
+            first_rank,
+            address_count,
+            is_no_address,
+            SUM(CASE WHEN is_no_address = 1 THEN 1 ELSE address_count END) OVER (
+                ORDER BY first_rank
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) as running_total
+        FROM address_groups
+    )
+    UPDATE campaign_queue cq
+    SET queue_state = 'assigned',
+        assigned_to_user_id = v_user_id,
+        provider_status = NULL,
+        attempts = COALESCE(cq.attempts, 0) + 1,
+        last_attempt_at = now()
+    FROM base_contacts bc
+    JOIN running_totals rt ON bc.effective_address = rt.effective_address
+    WHERE cq.id = bc.queue_id
+    -- Rows are locked by locked_rows, so this re-check is belt-and-braces
+    -- against any future edit that weakens the lock.
+    AND (cq.queue_state IS NULL OR cq.queue_state = 'queued')
+    AND (
+        -- No address: take only if this row itself is within the limit.
+        (rt.is_no_address = 1 AND bc.overall_rank <= p_initial_limit)
+        OR
+        -- Real address: take the whole household if it starts within the limit.
+        (rt.is_no_address = 0 AND rt.running_total <= p_initial_limit)
+    )
+    RETURNING cq.id::INTEGER, cq.contact_id::INTEGER;
+
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.claim_queue_entry_for_dial(
+    p_queue_id bigint,
+    p_campaign_id bigint,
+    p_workspace uuid,
+    p_user_id uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+    v_row public.campaign_queue%ROWTYPE;
+BEGIN
+    -- NOWAIT-style semantics via a targeted lock: if another dial holds this
+    -- exact row we surface 'unavailable' rather than dialing the same person.
+    SELECT * INTO v_row
+      FROM public.campaign_queue cq
+     WHERE cq.id = p_queue_id
+       AND cq.campaign_id = p_campaign_id
+       AND cq.workspace = p_workspace
+       FOR UPDATE SKIP LOCKED;
+
+    IF v_row.id IS NULL THEN
+        RETURN 'unavailable';
+    END IF;
+
+    IF v_row.assigned_to_user_id IS NOT NULL AND v_row.assigned_to_user_id <> p_user_id THEN
+        RETURN 'claimed_by_other';
+    END IF;
+
+    IF v_row.queue_state IS NOT NULL AND v_row.queue_state NOT IN ('queued', 'assigned') THEN
+        RETURN 'not_queued';
+    END IF;
+
+    -- Same-agent double-click / second-tab guard: refuse while this contact
+    -- already has a live call on this campaign. The window check bounds the
+    -- lookup so an ancient stuck row cannot block dialing forever.
+    IF EXISTS (
+        SELECT 1
+          FROM public.call c
+         WHERE c.contact_id = v_row.contact_id
+           AND c.campaign_id = p_campaign_id
+           AND c.workspace = p_workspace
+           -- c.status is the call_status enum; cast to text before comparing
+           -- so this only depends on the enum's known labels (never NULL).
+           AND c.status::text IN ('queued', 'initiated', 'ringing', 'in-progress')
+           AND c.date_created::timestamptz > now() - interval '2 hours'
+    ) THEN
+        RETURN 'active_call';
+    END IF;
+
+    UPDATE public.campaign_queue
+       SET assigned_to_user_id = p_user_id,
+           queue_state = COALESCE(queue_state, 'queued')
+     WHERE id = v_row.id;
+
+    RETURN 'claimed';
+END;
+$function$;

--- a/docs/effects-inventory.md
+++ b/docs/effects-inventory.md
@@ -5,7 +5,7 @@
 > the state it depends on, and the side effects it performs. See
 > [effects-strictness.md](./effects-strictness.md).
 
-**113** documented / **113** total effects (0 grandfathered, ratcheting to 0).
+**114** documented / **114** total effects (0 grandfathered, ratcheting to 0).
 
 | File | Purpose | Depends on | Side effects | Why not a loader/fetcher |
 | --- | --- | --- | --- | --- |
@@ -52,6 +52,7 @@
 | `app/hooks/call/useCallScreen.ts` | Let the physical/OS keyboard send DTMF digits during an active | [] — intentionally mount-once; the handler always calls | dom (window "keypress" event listener), removed on | DOM event subscription, not request/response data. |
 | `app/hooks/call/useCallState.ts` | Tick the call FSM's duration counter (dispatch TICK) once per | state, send (starts/stops the interval based on FSM state; | timer (setInterval), cleared on state change/unmount | Wall-clock elapsed time is live client timer state, |
 | `app/hooks/call/useCampaignCallFlow.ts` | Reset provider call state back to idle when the active call SID | callSid (only fires when the tracked SID changes to null) | none (plain setState) | Call lifecycle state is ephemeral client state, |
+| `app/hooks/call/useDialFailureRecovery.ts` | Dispatch FAIL to the call FSM when a settled dial fetcher | fetcherState, fetcherData, send, showError (fires once per | none directly (FSM dispatch + toast) | Reacts to a mutation result to fix client FSM |
 | `app/hooks/call/useNextRecipientSync.ts` | When the queue-provided next recipient advances, sync the | nextRecipient, send, setCallDuration, setQuestionContact | none (dispatches to state setters/reducer passed in; | nextRecipient is already realtime/loader-sourced |
 | `app/hooks/call/usePhoneVerification.ts` | Reset handset selection to computer when the previously chosen | selectedDevice, verifiedNumbers | setSelectedDevice, setPhoneConnectionStatus, | Device selection is live client state reconciled |
 | `app/hooks/call/usePhoneVerification.ts` | Surface call-in verification results from the verify fetcher: | verifyFetcher.data | toast + setVerificationPhoneNumber, setIsAddingNumber | Reacts to fetcher submission outcomes after the user |

--- a/scripts/db/bootstrap-fresh-db.mjs
+++ b/scripts/db/bootstrap-fresh-db.mjs
@@ -101,6 +101,7 @@ const steps = [
   "client/migrations/20260803120000_fix_queue_rpcs_on_queue_state.sql",
   "client/migrations/20260803130000_claim_next_queue_contact_attempt_count.sql",
   "client/migrations/20260803140000_workspace_number_rental_warned_cycle.sql",
+  "client/migrations/20260805120000_atomic_manual_dial_claims.sql",
 ];
 
 /**

--- a/scripts/e2e/bootstrap-compose-db.mjs
+++ b/scripts/e2e/bootstrap-compose-db.mjs
@@ -59,6 +59,7 @@ const steps = [
   "client/migrations/20260803120000_fix_queue_rpcs_on_queue_state.sql",
   "client/migrations/20260803130000_claim_next_queue_contact_attempt_count.sql",
   "client/migrations/20260803140000_workspace_number_rental_warned_cycle.sql",
+  "client/migrations/20260805120000_atomic_manual_dial_claims.sql",
 ];
 
 /**

--- a/test/atomic-manual-dial-claims.integration.test.ts
+++ b/test/atomic-manual-dial-claims.integration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+
+/**
+ * Documents + guards the SQL fixed by
+ * client/migrations/20260805120000_atomic_manual_dial_claims.sql.
+ *
+ * Both functions were manually verified against a live Postgres 18
+ * instance (docker-compose.dev.yml) during review:
+ *   - select_and_update_campaign_contacts: two concurrent calls with
+ *     limit 3 against a 100-row unclaimed queue landed on disjoint rows
+ *     (0 overlap, 6 distinct contacts claimed) instead of the pre-fix
+ *     behavior where two agents could receive the same contacts.
+ *   - claim_queue_entry_for_dial: claimed once, refused a second agent
+ *     ('claimed_by_other'), allowed the same agent to re-claim (idempotent
+ *     redial), refused a wrong campaign/workspace ('unavailable'), and
+ *     refused while the contact had a live call on the campaign
+ *     ('active_call').
+ *
+ * This repo has no automated live-Postgres test tier (see
+ * campaign-queue-throughput.integration.test.ts for the established
+ * pattern), so this guards the properties that made those two bugs real —
+ * an accidental revert of FOR UPDATE, SKIP LOCKED, or the lock-bound LIMIT
+ * would reintroduce a duplicate-dial or queue-wide-serialization bug
+ * without any other automated test catching it.
+ */
+describe("atomic manual-dial-claims SQL harness", () => {
+  test("select_and_update_campaign_contacts locks a bounded, ordered candidate set", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const sql = await readFile(
+      resolve(
+        process.cwd(),
+        "client/migrations/20260805120000_atomic_manual_dial_claims.sql",
+      ),
+      "utf8",
+    );
+
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION public.select_and_update_campaign_contacts");
+    expect(sql).toContain("FOR UPDATE OF cq SKIP LOCKED");
+    // The lock must be bounded (ORDER BY + LIMIT) rather than covering every
+    // unclaimed row in the campaign — an unbounded lock serializes every
+    // concurrent "Save and Next" on one campaign (verified live; see header).
+    expect(sql).toMatch(/ORDER BY cq\.attempts[\s\S]*?LIMIT[\s\S]*?FOR UPDATE OF cq SKIP LOCKED/);
+    // Re-check inside the UPDATE predicate, not just the lock (belt-and-braces).
+    expect(sql).toContain("AND (cq.queue_state IS NULL OR cq.queue_state = 'queued')");
+
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION public.claim_queue_entry_for_dial");
+    expect(sql).toContain("FOR UPDATE SKIP LOCKED");
+    for (const code of ["claimed", "unavailable", "claimed_by_other", "not_queued", "active_call"]) {
+      expect(sql).toContain(`'${code}'`);
+    }
+    // The active-call guard must compare the enum by casting to text, not by
+    // COALESCE-ing it with a string literal — that failed type resolution
+    // against a live call_status enum column (verified live; see header).
+    expect(sql).toContain("c.status::text IN");
+    expect(sql).not.toMatch(/COALESCE\(c\.status/);
+  });
+});

--- a/test/db-rpc-claim-queue-entry.test.ts
+++ b/test/db-rpc-claim-queue-entry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from "vitest";
+import { rpcClaimQueueEntryForDial } from "../app/lib/db-rpc.server";
+import type { SQL } from "drizzle-orm";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+/** Extract the literal SQL text from a drizzle SQL object's queryChunks. */
+function sqlText(query: SQL): string {
+  const chunks = (query as unknown as { queryChunks: Array<{ constructor: { name: string }; value: unknown }> }).queryChunks;
+  return chunks
+    .filter((c) => c.constructor.name === "StringChunk")
+    .map((c) => String(c.value))
+    .join("");
+}
+
+describe("rpcClaimQueueEntryForDial", () => {
+  test("calls claim_queue_entry_for_dial with the given ids and returns the scalar result", async () => {
+    const execute = vi.fn(async (_query: SQL) => [{ result: "claimed" }]);
+    const result = await rpcClaimQueueEntryForDial(
+      { execute },
+      { queueId: 3, campaignId: 1, workspaceId: "w1", userId: "u1" },
+    );
+    expect(result).toBe("claimed");
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(sqlText(execute.mock.calls[0][0])).toContain("claim_queue_entry_for_dial");
+  });
+
+  test.each(["unavailable", "claimed_by_other", "not_queued", "active_call"])(
+    "passes through the %s refusal code",
+    async (code) => {
+      const execute = vi.fn(async () => [{ result: code }]);
+      const result = await rpcClaimQueueEntryForDial(
+        { execute },
+        { queueId: 1, campaignId: 1, workspaceId: "w1", userId: "u1" },
+      );
+      expect(result).toBe(code);
+    },
+  );
+
+  test("defaults to 'unavailable' when the function returns no row", async () => {
+    const execute = vi.fn(async () => []);
+    const result = await rpcClaimQueueEntryForDial(
+      { execute },
+      { queueId: 1, campaignId: 1, workspaceId: "w1", userId: "u1" },
+    );
+    expect(result).toBe("unavailable");
+  });
+});

--- a/test/dial.route.test.ts
+++ b/test/dial.route.test.ts
@@ -31,6 +31,10 @@ const autoDialState = vi.hoisted(() => ({
   saveCallError: null as Error | null,
 }));
 
+const dbRpcState = vi.hoisted(() => ({
+  claimQueueEntryForDial: vi.fn(async () => "claimed" as string),
+}));
+
 vi.mock("../app/lib/client.server", () => ({
   getSession: (...args: any[]) => mocks.getSession(...args),
   verifyAuth: (...args: any[]) => mocks.verifyAuth(...args),
@@ -75,6 +79,9 @@ vi.mock("@/lib/auto-dial.server", () => ({
     }
   }),
 }));
+vi.mock("@/lib/db-rpc.server", () => ({
+  rpcClaimQueueEntryForDial: (...args: any[]) => dbRpcState.claimQueueEntryForDial(...args),
+}));
 
 vi.mock("twilio", () => {
   class VoiceResponse {
@@ -103,6 +110,8 @@ describe("app/routes/api+/dial/tsx.route", () => {
     autoDialState.createOutreachAttempt.mockReset();
     autoDialState.createOutreachAttempt.mockResolvedValue(77);
     autoDialState.saveCallError = null;
+    dbRpcState.claimQueueEntryForDial.mockReset();
+    dbRpcState.claimQueueEntryForDial.mockResolvedValue("claimed");
     creditsState.credits = 10;
     creditsState.throwError = null;
     tenantDbState.callerIdRecord = { type: "rented", phone_number: "+1555" };
@@ -209,6 +218,61 @@ describe("app/routes/api+/dial/tsx.route", () => {
       "w1",
       "u1",
     );
+  });
+
+  test("claims the queue row with workspace/campaign/queue/session-user before dialing", async () => {
+    mocks.getSession.mockReturnValueOnce({ headers: new Headers() });
+    mocks.parseActionRequest.mockResolvedValueOnce({
+      to_number: "+15555550100",
+      user_id: "someone-else",
+      campaign_id: "1",
+      contact_id: "2",
+      workspace_id: "w1",
+      queue_id: "3",
+      caller_id: "+1555",
+    });
+    queueJsonAuthSession({ user: { id: "u1" } });
+    mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce({ calls: { create: async () => ({ sid: "CA1", from: "+1555" }) } });
+
+    const mod = await import("../app/routes/api+/dial");
+    await asRouteResponse(mod.action({ request: new Request("http://localhost/api/dial", { method: "POST" }) } as any));
+
+    expect(dbRpcState.claimQueueEntryForDial).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        queueId: 3,
+        campaignId: 1,
+        workspaceId: "w1",
+        userId: "u1",
+      }),
+    );
+  });
+
+  test.each([
+    ["claimed_by_other", "This contact is being dialed by another agent."],
+    ["active_call", "This contact already has a call in progress."],
+    ["not_queued", "This contact is no longer queued."],
+    ["unavailable", "This contact is not available to dial."],
+  ])("refuses to dial and returns 409 when the claim result is %s", async (claim, message) => {
+    dbRpcState.claimQueueEntryForDial.mockResolvedValueOnce(claim);
+    mocks.getSession.mockReturnValueOnce({ headers: new Headers() });
+    mocks.parseActionRequest.mockResolvedValueOnce({
+      to_number: "+15555550100",
+      user_id: "u1",
+      campaign_id: "1",
+      contact_id: "2",
+      workspace_id: "w1",
+      queue_id: "3",
+      caller_id: "+1555",
+    });
+    queueJsonAuthSession({ user: { id: "u1" } });
+
+    const mod = await import("../app/routes/api+/dial");
+    const res = await asRouteResponse(mod.action({ request: new Request("http://localhost/api/dial", { method: "POST" }) } as any));
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({ error: message, claim });
+    expect(mocks.createWorkspaceTwilioInstance).not.toHaveBeenCalled();
   });
 
   test("rejects an unverified selected device before calling Twilio", async () => {

--- a/test/hangup.route.test.ts
+++ b/test/hangup.route.test.ts
@@ -29,21 +29,40 @@ vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
 
 vi.mock("@/lib/telephony-db.server", () => ({
   findCallBySid: vi.fn(),
-  updateOutreachDispositionByContactId: vi.fn(),
+  updateOutreachAttemptForWorkspace: vi.fn(),
 }));
 
 vi.mock("@/lib/db-rpc.server", () => ({
   rpcDequeueContact: vi.fn(),
 }));
 
-import { findCallBySid, updateOutreachDispositionByContactId } from "@/lib/telephony-db.server";
+const tenantDbMocks = vi.hoisted(() => ({
+  campaignFindFirst: vi.fn(),
+}));
+vi.mock("@/server/tenant-db", () => ({
+  createTenantDb: () => ({
+    campaign: {
+      findFirst: (...args: any[]) => tenantDbMocks.campaignFindFirst(...args),
+    },
+  }),
+}));
+
+import { findCallBySid, updateOutreachAttemptForWorkspace } from "@/lib/telephony-db.server";
 import { rpcDequeueContact } from "@/lib/db-rpc.server";
 
-function mockCall(overrides?: Partial<{ workspace: string; contact_id: number | null; conference_id: string | null }>) {
+function mockCall(overrides?: Partial<{
+  workspace: string;
+  contact_id: number | null;
+  conference_id: string | null;
+  campaign_id: number | null;
+  outreach_attempt_id: number | null;
+}>) {
   vi.mocked(findCallBySid).mockResolvedValueOnce({
     workspace: "w1",
     contact_id: 2,
     conference_id: "u1~00000000-0000-0000-0000-000000000000",
+    campaign_id: 5,
+    outreach_attempt_id: 9,
     ...overrides,
   } as any);
 }
@@ -56,11 +75,13 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     mocks.requireWorkspaceAccess.mockReset();
     mocks.logger.error.mockReset();
     vi.mocked(findCallBySid).mockReset();
-    vi.mocked(updateOutreachDispositionByContactId).mockReset();
+    vi.mocked(updateOutreachAttemptForWorkspace).mockReset();
     vi.mocked(rpcDequeueContact).mockReset();
+    tenantDbMocks.campaignFindFirst.mockReset();
+    tenantDbMocks.campaignFindFirst.mockResolvedValue({ group_household_queue: false });
   });
 
-  test("hangs up, dequeues, and updates outreach", async () => {
+  test("hangs up, dequeues, and updates the call's own outreach attempt", async () => {
     queueJsonAuthSession({ user: { id: "u1" } });
     mocks.parseActionRequest.mockResolvedValueOnce({
       workspaceId: "w1",
@@ -74,7 +95,46 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     const res = await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
     await expect(res.json()).resolves.toEqual({ success: true });
     expect(rpcDequeueContact).toHaveBeenCalled();
-    expect(updateOutreachDispositionByContactId).toHaveBeenCalledWith("w1", 2, "completed");
+    // Scoped to the specific attempt (9), not every attempt for contact 2.
+    expect(updateOutreachAttemptForWorkspace).toHaveBeenCalledWith(
+      "w1",
+      9,
+      { disposition: "completed" },
+      { tdb: expect.anything() },
+    );
+  });
+
+  test("household fan-out follows campaign.group_household_queue instead of always true", async () => {
+    queueJsonAuthSession({ user: { id: "u1" } });
+    mocks.parseActionRequest.mockResolvedValueOnce({ workspaceId: "w1", callSid: "CA1" });
+    mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce({
+      calls: () => ({ update: async () => ({}) }),
+    });
+    mockCall();
+    tenantDbMocks.campaignFindFirst.mockResolvedValueOnce({ group_household_queue: true });
+
+    const mod = await import("../app/routes/api+/hangup");
+    await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
+
+    expect(rpcDequeueContact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ groupOnHousehold: true }),
+    );
+  });
+
+  test("does not update outreach when the call has no attempt id", async () => {
+    queueJsonAuthSession({ user: { id: "u1" } });
+    mocks.parseActionRequest.mockResolvedValueOnce({ workspaceId: "w1", callSid: "CA1" });
+    mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce({
+      calls: () => ({ update: async () => ({}) }),
+    });
+    mockCall({ outreach_attempt_id: null });
+
+    const mod = await import("../app/routes/api+/hangup");
+    const res = await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
+    expect(res.status).toBe(200);
+    expect(rpcDequeueContact).toHaveBeenCalled();
+    expect(updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
   });
 
   test("returns 200 when Twilio returns 21220 (call already ended)", async () => {
@@ -140,7 +200,7 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ success: true });
     expect(rpcDequeueContact).not.toHaveBeenCalled();
-    expect(updateOutreachDispositionByContactId).not.toHaveBeenCalled();
+    expect(updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
   });
 
   test("outreach update error is thrown and returns 500", async () => {
@@ -148,7 +208,7 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     mocks.parseActionRequest.mockResolvedValueOnce({ workspaceId: "w1", callSid: "CA1" });
     mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce({ calls: () => ({ update: async () => ({}) }) });
     mockCall();
-    vi.mocked(updateOutreachDispositionByContactId).mockRejectedValueOnce(new Error("outreach"));
+    vi.mocked(updateOutreachAttemptForWorkspace).mockRejectedValueOnce(new Error("outreach"));
     const mod = await import("../app/routes/api+/hangup");
     const res = await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
     expect(res.status).toBe(500);

--- a/test/ui/hooks-call-screen.test.tsx
+++ b/test/ui/hooks-call-screen.test.tsx
@@ -123,7 +123,7 @@ describe("useCallScreen", () => {
     );
 
     Object.assign(fetcher, { submit: vi.fn(), state: "idle", data: undefined });
-    Object.assign(queueFetcher, { submit: vi.fn(), state: "idle" });
+    Object.assign(queueFetcher, { submit: vi.fn(), state: "idle", data: undefined });
     Object.assign(verifyFetcher, {
       load: vi.fn(),
       data: {

--- a/test/ui/use-dial-failure-recovery.test.ts
+++ b/test/ui/use-dial-failure-recovery.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useDialFailureRecovery } from "@/hooks/call/useDialFailureRecovery";
+
+type HookProps = Parameters<typeof useDialFailureRecovery>[0];
+
+function baseProps(overrides: Partial<HookProps> = {}): HookProps {
+  return {
+    fetcherState: "idle",
+    fetcherData: undefined,
+    send: vi.fn(),
+    showError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("useDialFailureRecovery", () => {
+  test("does nothing while the fetcher has no settled data", () => {
+    const send = vi.fn();
+    renderHook((props: HookProps) => useDialFailureRecovery(props), {
+      initialProps: baseProps({ fetcherState: "submitting", send }),
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("does nothing on a settled success response", () => {
+    const send = vi.fn();
+    renderHook((props: HookProps) => useDialFailureRecovery(props), {
+      initialProps: baseProps({
+        fetcherState: "idle",
+        fetcherData: {},
+        send,
+      }),
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  // Regression: START_DIALING fires before the /api/dial POST settles (see
+  // useCampaignDialActions), so a rejected dial — e.g. the atomic-claim 409
+  // — otherwise left the status bar stuck on "Dialing…" with nothing to
+  // hang up.
+  test("dispatches FAIL and shows the message on a claim/credits/5xx error", () => {
+    const send = vi.fn();
+    const showError = vi.fn();
+    renderHook((props: HookProps) => useDialFailureRecovery(props), {
+      initialProps: baseProps({
+        fetcherState: "idle",
+        fetcherData: { error: "This contact is being dialed by another agent." },
+        send,
+        showError,
+      }),
+    });
+    expect(send).toHaveBeenCalledWith({ type: "FAIL" });
+    expect(showError).toHaveBeenCalledWith(
+      "This contact is being dialed by another agent.",
+    );
+  });
+
+  test("dispatches FAIL without a toast on a bare creditsError", () => {
+    const send = vi.fn();
+    const showError = vi.fn();
+    renderHook((props: HookProps) => useDialFailureRecovery(props), {
+      initialProps: baseProps({
+        fetcherState: "idle",
+        fetcherData: { creditsError: true },
+        send,
+        showError,
+      }),
+    });
+    expect(send).toHaveBeenCalledWith({ type: "FAIL" });
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  test("only fires once per settled rejection, not on every re-render", () => {
+    const send = vi.fn();
+    const props = baseProps({
+      fetcherState: "idle",
+      fetcherData: { error: "boom" },
+      send,
+    });
+    const { rerender } = renderHook(
+      (p: HookProps) => useDialFailureRecovery(p),
+      { initialProps: props },
+    );
+    expect(send).toHaveBeenCalledTimes(1);
+    rerender(props);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #1145

## Summary

Closes the last item from the 2026-08-05 call-screen security/reliability audit: the manual (`dial_type: "call"`) dialing path had no claim discipline, unlike the predictive path. Two agents (or a double-click / second tab) could dial the same contact simultaneously.

- **New migration** (`client/migrations/20260805120000_atomic_manual_dial_claims.sql`):
  - `select_and_update_campaign_contacts` (the "fetchMore" RPC, fired on every "Save and Next") now locks its candidate rows with `FOR UPDATE SKIP LOCKED`, bounded to an ordered window rather than the whole remaining queue.
  - New `claim_queue_entry_for_dial` atomically claims a specific queue row before `/api/dial` places a real Twilio call, refusing with a specific reason (`claimed_by_other` / `active_call` / `not_queued` / `unavailable`) instead of letting the call through.
  - **Verified live** against Postgres 18 (docker-compose): two concurrent `select_and_update_campaign_contacts` calls at realistic scale (100-row queue, limit 3 — the real caller never requests more than 10) landed on disjoint rows, zero overlap. Also caught and fixed two bugs only a live DB could surface: an enum/`COALESCE` type-resolution failure in the active-call guard, and an unbounded lock that (before bounding) serialized every agent's fetchMore on one campaign.
- `/api/dial` claims before calling Twilio; a rejected claim returns 409 with the reason. New `useDialFailureRecovery` hook dispatches `FAIL` to the call FSM on that (or a credits/5xx) rejection — previously a rejected dial left the status bar stuck on "Dialing…" with nothing to hang up.
- `/api/hangup` no longer rewrites **every** outreach attempt for a contact across every campaign to `completed` (it was destroying `do_not_call`/voicemail history) — scoped to the call's own attempt, through the transition-guarded update path. Household dequeue now follows `campaign.group_household_queue` instead of being hardcoded `true`.
- Documented (not fixed): the credit gate is check-then-act; concurrent dials can overdraw by up to `concurrency × per-call cost`. Noted as a follow-up if that bound matters in practice.

## Related work already on `dev`

This PR is the last of four waves from the same audit; the first three already landed directly on `dev`:
- `bfb5a621` — call-screen questionnaire/disposition saves were 400ing (data loss)
- `d63773f7` — stop rebuilding the Twilio Device on every loader revalidation
- `43c57af1` — make `/api/auto-dial/status` replay-safe (was placing duplicate outbound calls on Twilio retries)

Together these close #1141 and #1142 (both closed with root-cause writeups), and partially address #1125 (comment left, not closed — that issue bundles a still-open UX question).

## Test plan
- [x] `npm run test:node` — 2434 passed, 0 failed
- [x] `npm run test:ui` — 608 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run check:effects` — 114 documented, 0 grandfathered
- [x] `npm run check:db-rpcs` — all 32 app-invoked functions created by a migration
- [x] New migration applied cleanly against live Postgres 18 and manually exercised (claim/refusal paths, concurrent-claim disjointness) — see migration file comments and `test/atomic-manual-dial-claims.integration.test.ts` for the verified properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)
