### PR TITLE
fix: close webhook signature downgrade and cross-tenant RPC gaps

### DIFF
--- a/app/lib/auto-dial.server.ts
+++ b/app/lib/auto-dial.server.ts
@@ -301,6 +301,7 @@ export async function runAutoDialerTurn(
             });
             await rpcDequeueContact(tdb, {
               contactId: contactRecord.contact_id,
+              workspaceId: workspace_id,
               groupOnHousehold: false,
               dequeuedById: user_id,
               dequeuedReasonText:
@@ -318,6 +319,7 @@ export async function runAutoDialerTurn(
 
       await rpcDequeueContact(tdb, {
         contactId: contactRecord.contact_id,
+        workspaceId: workspace_id,
         groupOnHousehold: true,
         dequeuedById: user_id,
         dequeuedReasonText: "Predictive Dialer called contact",

--- a/app/lib/db-rpc.server.ts
+++ b/app/lib/db-rpc.server.ts
@@ -157,6 +157,7 @@ export async function rpcDequeueContact(
   executor: RpcExecutor,
   args: {
     contactId: number;
+    workspaceId: string;
     groupOnHousehold: boolean;
     dequeuedById?: string | null;
     dequeuedReasonText?: string | null;
@@ -167,13 +168,23 @@ export async function rpcDequeueContact(
     const [sourceContact] = await db
       .select({ household_id: contactTable.household_id })
       .from(contactTable)
-      .where(eq(contactTable.id, args.contactId))
+      .where(
+        and(
+          eq(contactTable.id, args.contactId),
+          eq(contactTable.workspace, args.workspaceId),
+        ),
+      )
       .limit(1);
     if (sourceContact?.household_id != null) {
       const householdContacts = await db
         .select({ id: contactTable.id })
         .from(contactTable)
-        .where(eq(contactTable.household_id, sourceContact.household_id));
+        .where(
+          and(
+            eq(contactTable.household_id, sourceContact.household_id),
+            eq(contactTable.workspace, args.workspaceId),
+          ),
+        );
       for (const row of householdContacts) {
         contactIds.add(row.id);
       }
@@ -186,6 +197,7 @@ export async function rpcDequeueContact(
     .where(
       and(
         inArray(campaignQueueTable.contact_id, [...contactIds]),
+        eq(campaignQueueTable.workspace, args.workspaceId),
         isNull(campaignQueueTable.dequeued_at),
         or(
           isNull(campaignQueueTable.queue_state),
@@ -199,6 +211,7 @@ export async function rpcDequeueContact(
     sql`select dequeue_contact(
       ${args.contactId}::bigint,
       ${args.groupOnHousehold},
+      ${args.workspaceId}::uuid,
       ${args.dequeuedById ?? null}::uuid,
       ${args.dequeuedReasonText ?? null}
     )`,

--- a/app/lib/telephony-db.server.ts
+++ b/app/lib/telephony-db.server.ts
@@ -301,12 +301,18 @@ export async function findCampaignTypeByCampaignId(
 }
 
 export async function findCallSidByParentCallSid(
+  workspaceId: string,
   parentCallSid: string,
 ): Promise<string | null> {
   const rows = await db
     .select({ sid: callTable.sid })
     .from(callTable)
-    .where(eq(callTable.parent_call_sid, parentCallSid))
+    .where(
+      and(
+        eq(callTable.parent_call_sid, parentCallSid),
+        eq(callTable.workspace, workspaceId),
+      ),
+    )
     .limit(1);
   return rows[0]?.sid ?? null;
 }

--- a/app/routes/api+/acd-router.action.server.ts
+++ b/app/routes/api+/acd-router.action.server.ts
@@ -1,6 +1,9 @@
 import { handleAcdRouterRequest } from "@/lib/acd/acd-router.server";
 import { logger } from "@/lib/logger.server";
-import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
+import {
+  requireTwilioSignature,
+  twilioWebhookForbiddenHangup,
+} from "@/lib/twilio-webhook.server";
 import { defineAction } from "@/lib/handler.server";
 import Twilio from "twilio";
 
@@ -22,7 +25,12 @@ export const action = defineAction({
     try {
       const formData = await request.clone().formData();
       const callSid = String(formData.get("CallSid") ?? "");
-      const forbidden = await requireTwilioSignature(request, callSid ? { callSid } : {});
+      // A genuine Twilio voice callback to this URL always carries CallSid.
+      // Omitting the option here (rather than requiring it) would silently
+      // downgrade validation to the main-account token instead of this
+      // call's workspace token — fail closed instead.
+      if (!callSid) return twilioWebhookForbiddenHangup();
+      const forbidden = await requireTwilioSignature(request, { callSid });
       return forbidden ?? null;
     } catch (error) {
       logger.error("Unhandled error in api.acd-router", {

--- a/app/routes/api+/acd-router/agent-bridge.action.server.ts
+++ b/app/routes/api+/acd-router/agent-bridge.action.server.ts
@@ -1,12 +1,20 @@
 import { handleAcdRouterRequest } from "@/lib/acd/acd-router.server";
-import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
+import {
+  requireTwilioSignature,
+  twilioWebhookForbiddenHangup,
+} from "@/lib/twilio-webhook.server";
 import { defineAction } from "@/lib/handler.server";
 
 export const action = defineAction({
   auth: async ({ request }) => {
     const formData = await request.clone().formData();
     const callSid = String(formData.get("CallSid") ?? "");
-    const forbidden = await requireTwilioSignature(request, callSid ? { callSid } : {});
+    // A genuine Twilio voice callback to this URL always carries CallSid.
+    // Omitting the option here (rather than requiring it) would silently
+    // downgrade validation to the main-account token instead of this
+    // call's workspace token — fail closed instead.
+    if (!callSid) return twilioWebhookForbiddenHangup();
+    const forbidden = await requireTwilioSignature(request, { callSid });
     return forbidden ?? null;
   },
   sideEffects: ["db-write", "twilio"],

--- a/app/routes/api+/acd-router/agent-status.action.server.ts
+++ b/app/routes/api+/acd-router/agent-status.action.server.ts
@@ -1,5 +1,8 @@
 import { handleAcdRouterRequest } from "@/lib/acd/acd-router.server";
-import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
+import {
+  requireTwilioSignature,
+  twilioWebhookForbiddenHangup,
+} from "@/lib/twilio-webhook.server";
 import { defineAction } from "@/lib/handler.server";
 import type { ActionFunctionArgs } from "react-router";
 
@@ -7,7 +10,12 @@ export const action = defineAction({
   auth: async ({ request }: ActionFunctionArgs) => {
     const formData = await request.clone().formData();
     const callSid = String(formData.get("CallSid") ?? "");
-    const forbidden = await requireTwilioSignature(request, callSid ? { callSid } : {});
+    // A genuine Twilio voice callback to this URL always carries CallSid.
+    // Omitting the option here (rather than requiring it) would silently
+    // downgrade validation to the main-account token instead of this
+    // call's workspace token — fail closed instead.
+    if (!callSid) return twilioWebhookForbiddenHangup();
+    const forbidden = await requireTwilioSignature(request, { callSid });
     if (forbidden) return forbidden;
     return undefined;
   },

--- a/app/routes/api+/acd-router/complete.action.server.ts
+++ b/app/routes/api+/acd-router/complete.action.server.ts
@@ -1,12 +1,20 @@
 import { handleAcdRouterRequest } from "@/lib/acd/acd-router.server";
-import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
+import {
+  requireTwilioSignature,
+  twilioWebhookForbiddenHangup,
+} from "@/lib/twilio-webhook.server";
 import { defineAction } from "@/lib/handler.server";
 
 export const action = defineAction({
   auth: async ({ request }) => {
     const formData = await request.clone().formData();
     const callSid = String(formData.get("CallSid") ?? "");
-    const forbidden = await requireTwilioSignature(request, callSid ? { callSid } : {});
+    // A genuine Twilio voice callback to this URL always carries CallSid.
+    // Omitting the option here (rather than requiring it) would silently
+    // downgrade validation to the main-account token instead of this
+    // call's workspace token — fail closed instead.
+    if (!callSid) return twilioWebhookForbiddenHangup();
+    const forbidden = await requireTwilioSignature(request, { callSid });
     return forbidden ?? null;
   },
   sideEffects: ["db-write", "twilio"],

--- a/app/routes/api+/audiodrop.action.server.ts
+++ b/app/routes/api+/audiodrop.action.server.ts
@@ -59,7 +59,10 @@ export const action = defineAction({
     const twilio = await d.createWorkspaceTwilioInstance({
       workspace_id: workspaceId,
     });
-    const childCallSid = await d.findCallSidByParentCallSid(callId as string);
+    const childCallSid = await d.findCallSidByParentCallSid(
+      workspaceId,
+      callId as string,
+    );
     if (!childCallSid) {
       throw { call: new Error("Call not found") };
     }

--- a/app/routes/api+/auto-dial/$roomId.action.server.ts
+++ b/app/routes/api+/auto-dial/$roomId.action.server.ts
@@ -69,6 +69,7 @@ const dequeueContact = async (
         const tdb = createTenantDb(workspace);
         return await rpcDequeueContact(tdb, {
             contactId: Number(contactId),
+            workspaceId: workspace,
             groupOnHousehold,
             dequeuedById: userId,
             dequeuedReasonText: "Auto-dial completed",

--- a/app/routes/api+/auto-dial/status.action.server.ts
+++ b/app/routes/api+/auto-dial/status.action.server.ts
@@ -158,6 +158,7 @@ const handleCallStatus = async (
     const tdb = createTenantDb(workspace);
     await rpcDequeueContact(tdb, {
       contactId: outreachStatus.contact_id,
+      workspaceId: workspace,
       groupOnHousehold: true,
       // A conference name is `${userId}~${uuid}`, and this argument is bound
       // as ::uuid — passing the raw name raised 22P02 on every terminal call,

--- a/app/routes/api+/dial/$number.action.server.ts
+++ b/app/routes/api+/dial/$number.action.server.ts
@@ -2,7 +2,10 @@ import { env } from "@/lib/env.server";
 import { logger } from "@/lib/logger.server";
 import { appendLiveTranscriptionStreamTwiml } from "@/lib/media-stream-twiml.server";
 import { findCallBySid } from "@/lib/telephony-db.server";
-import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
+import {
+    requireTwilioSignature,
+    twilioWebhookForbiddenHangup,
+} from "@/lib/twilio-webhook.server";
 import { getWorkspaceById } from "@/lib/workspace-members-db.server";
 import { defineAction } from "@/lib/handler.server";
 import Twilio from 'twilio';
@@ -23,7 +26,12 @@ export const action = defineAction({
     auth: async ({ request }) => {
         const formData = await request.clone().formData();
         const callSid = String(formData.get("CallSid") ?? "");
-        const forbidden = await requireTwilioSignature(request, callSid ? { callSid } : {});
+        // Twilio always supplies CallSid when fetching a call's TwiML action
+        // URL. Omitting the option here (rather than requiring it) would
+        // silently downgrade validation to the main-account token instead of
+        // this call's workspace token — fail closed instead.
+        if (!callSid) return twilioWebhookForbiddenHangup();
+        const forbidden = await requireTwilioSignature(request, { callSid });
         return forbidden ?? null;
     },
     sideEffects: ["twilio"],

--- a/app/routes/api+/hangup.action.server.ts
+++ b/app/routes/api+/hangup.action.server.ts
@@ -47,6 +47,7 @@ export const action = defineAction({
         if (call.contact_id) {
             await rpcDequeueContact(tdb, {
                 contactId: call.contact_id,
+                workspaceId,
                 groupOnHousehold: true,
                 dequeuedById: user.id,
                 dequeuedReasonText: "Call completed",

--- a/app/routes/api+/queues.action.server.ts
+++ b/app/routes/api+/queues.action.server.ts
@@ -40,6 +40,7 @@ export const action = defineAction({
 
       await rpcDequeueContact(tdb, {
         contactId: Number(contact_id),
+        workspaceId,
         groupOnHousehold: household,
         dequeuedById: auth.user.id,
         dequeuedReasonText: "Manually dequeued by user",

--- a/client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql
+++ b/client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql
@@ -1,0 +1,89 @@
+-- Close two cross-tenant write gaps found in the 2026-08-05 call-screen audit
+-- and re-verified 2026-08-07: both functions write via a client-supplied id
+-- with no workspace predicate, reachable from /api/dial (contact_id, queue_id),
+-- /api/hangup (contact_id), and /api/questions (queue_id) — none of which
+-- validate that the id belongs to the calling workspace before passing it
+-- through.
+--
+-- dequeue_contact: filtered only on contact_id. A member of workspace A who
+-- can produce ANY contact_id (their own dial/hangup flow accepts one from the
+-- client) could dequeue workspace B's contact — and, worse, group_on_household
+-- joined contact.household_id with no workspace filter at all, so a
+-- household_id collision across workspaces (not supposed to happen, but
+-- nothing enforced it) would fan out the dequeue further.
+--
+-- create_outreach_attempt: the outreach_attempt INSERT is correctly tagged
+-- with wks_id, but the campaign_queue attempts-counter UPDATE was filtered
+-- only on queue_id — bumping another workspace's queue row's attempt count
+-- from a request attributed to this workspace's outreach_attempt.
+--
+-- Both fixes add a required workspace parameter and filter every write (and,
+-- for dequeue_contact, every read used to decide what to write) by it. Call
+-- sites are updated in the same commit: app/lib/db-rpc.server.ts and its six
+-- (dequeue) / six (create) callers.
+
+DROP FUNCTION IF EXISTS public.dequeue_contact(bigint, boolean, uuid, text);
+
+CREATE OR REPLACE FUNCTION public.dequeue_contact(
+  passed_contact_id bigint,
+  group_on_household boolean,
+  p_workspace uuid,
+  dequeued_by_id uuid DEFAULT NULL::uuid,
+  dequeued_reason_text text DEFAULT NULL::text
+)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+begin
+  update public.campaign_queue
+  set
+    queue_state = 'dequeued',
+    assigned_to_user_id = null,
+    provider_status = null,
+    dequeued_by = dequeued_by_id,
+    dequeued_at = now(),
+    dequeued_reason = dequeued_reason_text
+  where contact_id = passed_contact_id
+    and workspace = p_workspace
+    and (queue_state is null or queue_state = 'queued');
+
+  if group_on_household then
+    update public.campaign_queue cq
+    set
+      queue_state = 'dequeued',
+      assigned_to_user_id = null,
+      provider_status = null,
+      dequeued_by = dequeued_by_id,
+      dequeued_at = now(),
+      dequeued_reason = dequeued_reason_text
+    from public.contact c1
+    join public.contact c2 on c1.household_id is not null and c1.household_id = c2.household_id
+    where
+      c1.id = passed_contact_id
+      and c1.workspace = p_workspace
+      and c2.workspace = p_workspace
+      and cq.contact_id = c2.id
+      and cq.workspace = p_workspace
+      and (cq.queue_state is null or cq.queue_state = 'queued');
+  end if;
+end;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.create_outreach_attempt(con_id bigint, cam_id bigint, usr_id uuid, wks_id uuid, queue_id bigint) RETURNS bigint
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  new_outreach_attempt_id bigint;
+BEGIN
+  INSERT INTO outreach_attempt (contact_id, campaign_id, user_id, workspace)
+  VALUES (con_id, cam_id, usr_id, wks_id)
+  RETURNING id INTO new_outreach_attempt_id;
+
+  UPDATE campaign_queue
+  SET attempts = attempts + 1
+  WHERE id = queue_id
+    AND workspace = wks_id;
+
+  RETURN new_outreach_attempt_id;
+END;
+$$;

--- a/scripts/db/bootstrap-fresh-db.mjs
+++ b/scripts/db/bootstrap-fresh-db.mjs
@@ -101,6 +101,7 @@ const steps = [
   "client/migrations/20260803120000_fix_queue_rpcs_on_queue_state.sql",
   "client/migrations/20260803130000_claim_next_queue_contact_attempt_count.sql",
   "client/migrations/20260803140000_workspace_number_rental_warned_cycle.sql",
+  "client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql",
 ];
 
 /**

--- a/scripts/e2e/bootstrap-compose-db.mjs
+++ b/scripts/e2e/bootstrap-compose-db.mjs
@@ -59,6 +59,7 @@ const steps = [
   "client/migrations/20260803120000_fix_queue_rpcs_on_queue_state.sql",
   "client/migrations/20260803130000_claim_next_queue_contact_attempt_count.sql",
   "client/migrations/20260803140000_workspace_number_rental_warned_cycle.sql",
+  "client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql",
 ];
 
 /**

--- a/test/acd-router-route.test.ts
+++ b/test/acd-router-route.test.ts
@@ -10,6 +10,11 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/twilio-webhook.server", () => ({
   requireTwilioSignature: (...args: unknown[]) => mocks.requireTwilioSignature(...args),
+  twilioWebhookForbiddenHangup: () =>
+    new Response("<Response><Say>hangup</Say></Response>", {
+      status: 403,
+      headers: { "Content-Type": "text/xml" },
+    }),
 }));
 vi.mock("@/lib/acd/acd-router.server", () => ({
   handleAcdRouterRequest: (...args: unknown[]) => mocks.handleAcdRouterRequest(...args),
@@ -50,6 +55,24 @@ describe("app/routes/api+/acd-router", () => {
       }),
     );
     mocks.logger.error.mockReset();
+  });
+
+  // Regression: this route used to build the signature-check option as
+  // `callSid ? { callSid } : {}` — omitting CallSid silently downgraded
+  // validation to the main-account token instead of failing. A genuine
+  // Twilio callback to this URL always carries CallSid.
+  test("rejects with 403 hangup when CallSid is missing, without calling requireTwilioSignature", async () => {
+    const mod = await import("../app/routes/api+/acd-router.route");
+    const res = await asRouteResponse(
+      mod.action({
+        request: new Request("http://localhost/api/acd-router", {
+          method: "POST",
+          body: new FormData(),
+        }),
+      } as never),
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.requireTwilioSignature).not.toHaveBeenCalled();
   });
 
   test("returns 403 when Twilio signature validation fails", async () => {

--- a/test/acd-router-subroutes.test.ts
+++ b/test/acd-router-subroutes.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { asRouteResponse } from "./helpers/route-result";
+
+// Covers the three acd-router sub-routes that had zero route-level test
+// coverage of their auth callback (test/acd-router.test.ts only exercises
+// handleAcdRouterRequest directly, not these route files' `action`).
+// Regression under test: all three used to build the signature-check option
+// as `callSid ? { callSid } : {}` — omitting CallSid silently downgraded
+// validation to the main-account token instead of failing. A genuine Twilio
+// voice callback to these URLs always carries CallSid.
+
+const mocks = vi.hoisted(() => ({
+  requireTwilioSignature: vi.fn(),
+  handleAcdRouterRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/twilio-webhook.server", () => ({
+  requireTwilioSignature: (...args: unknown[]) => mocks.requireTwilioSignature(...args),
+  twilioWebhookForbiddenHangup: () =>
+    new Response("<Response><Say/><Hangup/></Response>", {
+      status: 403,
+      headers: { "Content-Type": "text/xml" },
+    }),
+}));
+vi.mock("@/lib/acd/acd-router.server", () => ({
+  handleAcdRouterRequest: (...args: unknown[]) => mocks.handleAcdRouterRequest(...args),
+}));
+
+function requestWithCallSid(url: string, callSid: string | null) {
+  const fd = new FormData();
+  if (callSid) fd.set("CallSid", callSid);
+  return new Request(url, { method: "POST", body: fd });
+}
+
+const routes: Array<{ name: string; path: string; url: string; arg: string }> = [
+  {
+    name: "agent-status",
+    path: "../app/routes/api+/acd-router/agent-status.route",
+    url: "http://localhost/api/acd-router/agent-status",
+    arg: "agent-status",
+  },
+  {
+    name: "agent-bridge",
+    path: "../app/routes/api+/acd-router/agent-bridge.route",
+    url: "http://localhost/api/acd-router/agent-bridge",
+    arg: "agent-bridge",
+  },
+  {
+    name: "complete",
+    path: "../app/routes/api+/acd-router/complete.route",
+    url: "http://localhost/api/acd-router/complete",
+    arg: "complete",
+  },
+];
+
+describe.each(routes)("app/routes/api+/acd-router/$name", ({ name, path, url, arg }) => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.requireTwilioSignature.mockReset();
+    mocks.requireTwilioSignature.mockResolvedValue(null);
+    mocks.handleAcdRouterRequest.mockReset();
+    mocks.handleAcdRouterRequest.mockResolvedValue(
+      new Response("<Response><Say>ok</Say></Response>", {
+        headers: { "Content-Type": "text/xml" },
+      }),
+    );
+  });
+
+  test(`${name}: rejects with 403 hangup when CallSid is missing, without calling requireTwilioSignature`, async () => {
+    const mod = await import(path);
+    const res = await asRouteResponse(
+      mod.action({ request: requestWithCallSid(url, null) } as never),
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.requireTwilioSignature).not.toHaveBeenCalled();
+    expect(mocks.handleAcdRouterRequest).not.toHaveBeenCalled();
+  });
+
+  test(`${name}: validates against the resolved CallSid and delegates on success`, async () => {
+    const mod = await import(path);
+    const res = await asRouteResponse(
+      mod.action({ request: requestWithCallSid(url, "CA1") } as never),
+    );
+    expect(mocks.requireTwilioSignature).toHaveBeenCalledWith(
+      expect.anything(),
+      { callSid: "CA1" },
+    );
+    expect(mocks.handleAcdRouterRequest).toHaveBeenCalledWith(expect.anything(), arg);
+    expect(res.headers.get("Content-Type")).toBe("text/xml");
+    expect(await res.text()).toContain("ok");
+  });
+
+  test(`${name}: returns 403 when Twilio signature validation fails`, async () => {
+    mocks.requireTwilioSignature.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Invalid Twilio signature" }), { status: 403 }),
+    );
+    const mod = await import(path);
+    const res = await asRouteResponse(
+      mod.action({ request: requestWithCallSid(url, "CA1") } as never),
+    );
+    expect(res.status).toBe(403);
+    expect(mocks.handleAcdRouterRequest).not.toHaveBeenCalled();
+  });
+});

--- a/test/audiodrop.test.ts
+++ b/test/audiodrop.test.ts
@@ -59,6 +59,11 @@ describe("api.audiodrop action", () => {
       deps: { verifyAuth: vi.fn(async () => ({ user: { id: "u1" }, headers: new Headers() })), createWorkspaceTwilioInstance },
     } as any));
     expect(res).toMatchObject({ success: false, error: { call: expect.any(Error) } });
+    // Regression: findCallSidByParentCallSid used to be a global,
+    // untenanted lookup by callId alone — any workspace could resolve
+    // another workspace's child call SID. It must now be scoped by the
+    // workspace the caller passed access-control checks for.
+    expect(telephonyMocks.findCallSidByParentCallSid).toHaveBeenCalledWith("w1", "c1");
   });
 
   test("returns failure when campaign lookup errors", async () => {

--- a/test/dial-number.route.test.ts
+++ b/test/dial-number.route.test.ts
@@ -16,8 +16,24 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("@/lib/env.server", () => ({ env: mocks.env }));
 vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
+const requireTwilioSignatureMock = vi.fn(async () => null);
 vi.mock("@/lib/twilio-webhook.server", () => ({
-  requireTwilioSignature: vi.fn(async () => null),
+  requireTwilioSignature: (...args: unknown[]) => requireTwilioSignatureMock(...args),
+  twilioWebhookForbiddenHangup: () =>
+    new Response("<Response><Say/><Hangup/></Response>", {
+      status: 403,
+      headers: { "Content-Type": "text/xml" },
+    }),
+}));
+// The handler's live-transcription-enrichment block only ever ran when a
+// test set CallSid — which none did until the CallSid-required auth fix
+// below made it mandatory. findCallBySid was never mocked because that
+// branch was never reached. Resolve null: matches "no call row found",
+// which is exactly the shape the pre-fix tests implicitly exercised (no
+// live-transcription TwiML appended, a plain dial).
+const findCallBySidMock = vi.fn(async () => null);
+vi.mock("@/lib/telephony-db.server", () => ({
+  findCallBySid: (...args: unknown[]) => findCallBySidMock(...args),
 }));
 
 vi.mock("twilio", () => {
@@ -56,12 +72,33 @@ describe("app/routes/api+/dial/route.$number.tsx", () => {
     vi.resetModules();
     mocks.logger.error.mockReset();
     mocks.dialNumberThrows = false;
+    requireTwilioSignatureMock.mockClear();
+    requireTwilioSignatureMock.mockResolvedValue(null);
+    findCallBySidMock.mockClear();
+    findCallBySidMock.mockResolvedValue(null);
+  });
+
+  // Regression: this route used to build the signature-check option as
+  // `callSid ? { callSid } : {}` — omitting CallSid silently downgraded
+  // validation to the main-account token instead of failing. Twilio always
+  // supplies CallSid when fetching a call's TwiML action URL.
+  test("rejects with 403 hangup when CallSid is missing, without calling requireTwilioSignature", async () => {
+    const mod = await import("../app/routes/api+/dial/$number.route");
+    const fd = new FormData();
+    fd.set("From", "+1555");
+    const res = await asRouteResponse(mod.action({
+      request: new Request("http://localhost/api/dial/+1555", { method: "POST", body: fd }),
+      params: { number: "+15550001111" },
+    } as any));
+    expect(res.status).toBe(403);
+    expect(requireTwilioSignatureMock).not.toHaveBeenCalled();
   });
 
   test("returns xml with dial using absolute status callback", async () => {
     const mod = await import("../app/routes/api+/dial/$number.route");
     const fd = new FormData();
     fd.set("From", "+1555");
+    fd.set("CallSid", "CA1");
     const res = await asRouteResponse(mod.action({
       request: new Request("http://localhost/api/dial/+1555", { method: "POST", body: fd }),
       params: { number: "+15550001111" },
@@ -78,6 +115,7 @@ describe("app/routes/api+/dial/route.$number.tsx", () => {
     const mod = await import("../app/routes/api+/dial/$number.route");
     const fd = new FormData();
     fd.set("From", "+1555");
+    fd.set("CallSid", "CA1");
     const res = await asRouteResponse(mod.action({
         request: new Request("http://localhost/api/dial/+1555", { method: "POST", body: fd }),
         params: { number: "+15550001111" },

--- a/test/scope-dequeue-and-outreach-attempt.integration.test.ts
+++ b/test/scope-dequeue-and-outreach-attempt.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+/**
+ * Documents + guards the SQL fixed by
+ * client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql.
+ *
+ * Both functions manually verified against a live Postgres 18 instance
+ * (docker-compose.dev.yml) during review:
+ *   - dequeue_contact: with a queue row seeded in workspace 2, calling
+ *     dequeue_contact(9102, false, workspace1_uuid, ...) — a workspace-1
+ *     caller passing workspace 2's contact_id — left workspace 2's row
+ *     completely untouched (queue_state and dequeued_at both stayed null).
+ *     The same call with the matching workspace correctly dequeued it.
+ *   - create_outreach_attempt: with a queue row seeded in workspace 2,
+ *     calling create_outreach_attempt(..., wks_id: workspace1_uuid,
+ *     queue_id: 9102) — attributing the outreach_attempt to workspace 1
+ *     while pointing queue_id at workspace 2's row — created the
+ *     outreach_attempt (correctly tagged to workspace 1) but left workspace
+ *     2's campaign_queue.attempts at 0. The same call with a same-workspace
+ *     queue_id correctly bumped attempts.
+ *
+ * This repo has no automated live-Postgres test tier (see
+ * campaign-queue-throughput.integration.test.ts for the established
+ * pattern), so this guards the property that made the bug real — an
+ * accidental revert of either workspace predicate would reintroduce a
+ * cross-tenant write without any other automated test catching it.
+ */
+describe("scope dequeue_contact / create_outreach_attempt by workspace SQL harness", () => {
+  test("dequeue_contact filters every write (and the household lookup) by workspace", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const sql = await readFile(
+      resolve(
+        process.cwd(),
+        "client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql",
+      ),
+      "utf8",
+    );
+
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION public.dequeue_contact(");
+    expect(sql).toContain("p_workspace uuid");
+    // The non-household UPDATE.
+    expect(sql).toMatch(
+      /where contact_id = passed_contact_id\s*\n\s*and workspace = p_workspace/,
+    );
+    // The household UPDATE: both joined contacts AND the queue row itself
+    // must be workspace-checked, not just one side of the join.
+    expect(sql).toContain("c1.workspace = p_workspace");
+    expect(sql).toContain("c2.workspace = p_workspace");
+    expect(sql).toContain("cq.workspace = p_workspace");
+
+    expect(sql).toContain("CREATE OR REPLACE FUNCTION public.create_outreach_attempt(");
+    expect(sql).toMatch(
+      /UPDATE campaign_queue\s*\n\s*SET attempts = attempts \+ 1\s*\n\s*WHERE id = queue_id\s*\n\s*AND workspace = wks_id/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #1150

## Summary

Re-verified against `dev` on 2026-08-07 from the 2026-08-05 call-screen audit. Two related classes of tenant-isolation gap.

### 1. Webhook signature validation could silently downgrade to the main-account token

`requireTwilioSignature` validates against a workspace's subaccount token when a tenant-identifying option resolves, and falls back to the platform main-account token when none does — by design, for genuinely main-account-level webhooks. Five call sites built that option **conditionally from request data** (`callSid ? { callSid } : {}`), so omitting `CallSid` from a forged request silently switched validation to the one shared platform token instead of the workspace's own:

- `acd-router.action.server.ts`, `acd-router/agent-status.action.server.ts`, `acd-router/agent-bridge.action.server.ts`, `acd-router/complete.action.server.ts`, `dial/$number.action.server.ts`

A genuine Twilio voice callback to any of these always carries `CallSid` — now required, rejecting with a 403 hangup instead of falling through. `requireTwilioSignature` itself is untouched; other genuinely main-account routes are unaffected.

### 2. Two RPCs on the call/dial path had no workspace predicate

- `dequeue_contact` filtered only on `contact_id`, and its household-grouping join had **no workspace filter at all** — reachable via `/api/dial` and `/api/hangup`, both of which pass a client-supplied `contact_id`.
- `create_outreach_attempt`'s `campaign_queue.attempts` counter UPDATE filtered only on `queue_id` — reachable via `/api/dial` and `/api/questions`, both of which pass a client-supplied `queue_id`.

New migration adds a required workspace parameter to both and filters every write (and, for `dequeue_contact`, the household lookup itself) by it.

**Verified live** against Postgres 18 (docker-compose): seeded two workspaces, then confirmed a cross-tenant `dequeue_contact`/`create_outreach_attempt` call left the *other* workspace's row completely untouched (`queue_state`/`dequeued_at`/`attempts` all unchanged), while the same call scoped to the correct workspace worked normally.

`findCallSidByParentCallSid` (used by `/api/audiodrop`) was a similar global, untenanted lookup — now scoped by workspace too.

### Investigated, not changed
The `AccountSid`-fallback key-selection path and `/api/caller-id/status`'s `phoneNumber`-based lookup remain bound by HMAC signature verification against the resolved token — an attacker without that specific workspace's real secret can't forge a passing signature regardless of which workspace they claim. Lower actual risk than initially flagged in the original audit; left as-is with the reasoning documented in code comments / this PR for future reference.

## Test plan
- [x] `npm run ci:local` (build, all `check:*` gates, codegen-drift, bundle check) — exit 0
- [x] `npx tsc --noEmit` — clean
- [x] `npm run check:type-safety` — at baseline (no new escape hatches)
- [x] `npm run check:db-rpcs` — all 31 app-invoked functions created by a migration
- [x] New route tests for the fail-closed webhook behavior (`acd-router-subroutes.test.ts` covers all 3 previously-uncovered sub-routes; `acd-router-route.test.ts` and `dial-number.route.test.ts` updated)
- [x] Live-Postgres verification of both SQL fixes, documented in `scope-dequeue-and-outreach-attempt.integration.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)