### PR TITLE
Improve workspace navigation, account MFA, and call list uploads

### DIFF
--- a/app/components/audience/AudienceUploadFileStep.tsx
+++ b/app/components/audience/AudienceUploadFileStep.tsx
@@ -3,16 +3,23 @@ import { MdUploadFile } from "react-icons/md";
 
 export type AudienceUploadFileStepProps = {
   onFileChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onFileDrop: (file: File) => void;
 };
 
 export const AudienceUploadFileStep = forwardRef<
   HTMLInputElement,
   AudienceUploadFileStepProps
->(function AudienceUploadFileStep({ onFileChange }, ref) {
+>(function AudienceUploadFileStep({ onFileChange, onFileDrop }, ref) {
   return (
     <label
       htmlFor="contacts"
       className="flex min-h-[8rem] cursor-pointer flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border bg-muted/30 px-6 py-8 text-center transition-colors hover:border-border hover:bg-muted/50"
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={(event) => {
+        event.preventDefault();
+        const file = event.dataTransfer.files[0];
+        if (file) onFileDrop(file);
+      }}
     >
       <span className="inline-flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
         <MdUploadFile className="size-5" aria-hidden />

--- a/app/components/audience/AudienceUploadFileSummary.tsx
+++ b/app/components/audience/AudienceUploadFileSummary.tsx
@@ -1,4 +1,3 @@
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 
 export type AudienceUploadFileSummaryProps = {
@@ -13,16 +12,12 @@ export function AudienceUploadFileSummary({
   columnCount,
 }: AudienceUploadFileSummaryProps) {
   return (
-    <Alert>
-      <AlertDescription>
-        <div className="flex flex-wrap items-center gap-2">
-          <span>
-            File: <span className="font-medium text-foreground">{fileName}</span>
-          </span>
-          <Badge variant="outline">{rowCount.toLocaleString()} rows</Badge>
-          <Badge variant="outline">{columnCount} columns</Badge>
-        </div>
-      </AlertDescription>
-    </Alert>
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm">
+      <span>
+        File: <span className="font-medium text-foreground">{fileName}</span>
+      </span>
+      <Badge variant="outline">{rowCount.toLocaleString()} rows</Badge>
+      <Badge variant="outline">{columnCount} columns</Badge>
+    </div>
   );
 }

--- a/app/components/audience/AudienceUploadFileSummary.tsx
+++ b/app/components/audience/AudienceUploadFileSummary.tsx
@@ -2,14 +2,12 @@ export type AudienceUploadFileSummaryProps = {
   fileName: string;
   rowCount: number;
   columnCount: number;
-  hint?: string;
 };
 
 export function AudienceUploadFileSummary({
   fileName,
   rowCount,
   columnCount,
-  hint,
 }: AudienceUploadFileSummaryProps) {
   return (
     <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm">
@@ -20,7 +18,6 @@ export function AudienceUploadFileSummary({
         <span className="shrink-0 text-muted-foreground">
           {rowCount.toLocaleString()} rows {columnCount} columns
         </span>
-        {hint ? <span className="min-w-0 text-right text-muted-foreground">{hint}</span> : null}
       </div>
     </div>
   );

--- a/app/components/audience/AudienceUploadFileSummary.tsx
+++ b/app/components/audience/AudienceUploadFileSummary.tsx
@@ -1,23 +1,27 @@
-import { Badge } from "@/components/ui/badge";
-
 export type AudienceUploadFileSummaryProps = {
   fileName: string;
   rowCount: number;
   columnCount: number;
+  hint?: string;
 };
 
 export function AudienceUploadFileSummary({
   fileName,
   rowCount,
   columnCount,
+  hint,
 }: AudienceUploadFileSummaryProps) {
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm">
-      <span>
+    <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-sm">
+      <div className="truncate">
         File: <span className="font-medium text-foreground">{fileName}</span>
-      </span>
-      <Badge variant="outline">{rowCount.toLocaleString()} rows</Badge>
-      <Badge variant="outline">{columnCount} columns</Badge>
+      </div>
+      <div className="mt-1 flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs">
+        <span className="shrink-0 text-muted-foreground">
+          {rowCount.toLocaleString()} rows {columnCount} columns
+        </span>
+        {hint ? <span className="min-w-0 text-right text-muted-foreground">{hint}</span> : null}
+      </div>
     </div>
   );
 }

--- a/app/components/audience/AudienceUploadMapStep.tsx
+++ b/app/components/audience/AudienceUploadMapStep.tsx
@@ -51,12 +51,6 @@ export function AudienceUploadMapStep({
 }: AudienceUploadMapStepProps) {
   return (
     <div className="space-y-4">
-      <AudienceUploadFileSummary
-        fileName={fileName}
-        rowCount={rowCount}
-        columnCount={headers.length}
-      />
-
       <Alert>
         <AlertDescription>{PHONE_SKIP_HINT}</AlertDescription>
       </Alert>
@@ -68,7 +62,14 @@ export function AudienceUploadMapStep({
       ) : null}
 
       <div className="rounded-md border bg-muted/40 p-4">
-        <h3 className="mb-4 font-medium text-foreground">Map CSV Headers</h3>
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <h3 className="font-medium text-foreground">Map CSV Headers</h3>
+          <AudienceUploadFileSummary
+            fileName={fileName}
+            rowCount={rowCount}
+            columnCount={headers.length}
+          />
+        </div>
 
         <Table className="w-full">
           <TableHeader>

--- a/app/components/audience/AudienceUploadReviewStep.tsx
+++ b/app/components/audience/AudienceUploadReviewStep.tsx
@@ -29,8 +29,9 @@ export function AudienceUploadReviewStep({
         fileName={fileName}
         rowCount={rowCount}
         columnCount={columnCount}
-        hint={PHONE_SKIP_HINT}
       />
+
+      <div className="text-xs text-muted-foreground">{PHONE_SKIP_HINT}</div>
 
       {showSplitNameOption ? (
         <label className="flex items-center gap-2 text-xs text-foreground">

--- a/app/components/audience/AudienceUploadReviewStep.tsx
+++ b/app/components/audience/AudienceUploadReviewStep.tsx
@@ -29,26 +29,21 @@ export function AudienceUploadReviewStep({
         fileName={fileName}
         rowCount={rowCount}
         columnCount={columnCount}
+        hint={PHONE_SKIP_HINT}
       />
 
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border/70 bg-muted/30 px-3 py-2">
-        <div className="text-sm font-medium text-foreground">
-          {rowCount.toLocaleString()} contacts ready to upload
-        </div>
-        <div className="text-xs text-muted-foreground">{PHONE_SKIP_HINT}</div>
-        {showSplitNameOption ? (
-          <label className="flex items-center gap-2 text-xs text-foreground">
-            <input
-              type="checkbox"
-              id="split-name"
-              className="rounded border-gray-300"
-              checked={splitNameEnabled}
-              onChange={(e) => onSplitNameChange(e.target.checked)}
-            />
-            Split full name into first name and last name
-          </label>
-        ) : null}
-      </div>
+      {showSplitNameOption ? (
+        <label className="flex items-center gap-2 text-xs text-foreground">
+          <input
+            type="checkbox"
+            id="split-name"
+            className="rounded border-gray-300"
+            checked={splitNameEnabled}
+            onChange={(e) => onSplitNameChange(e.target.checked)}
+          />
+          Split full name into first name and last name
+        </label>
+      ) : null}
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <Button type="button" variant="outline" onClick={onBackToMapping}>

--- a/app/components/audience/AudienceUploadReviewStep.tsx
+++ b/app/components/audience/AudienceUploadReviewStep.tsx
@@ -31,13 +31,13 @@ export function AudienceUploadReviewStep({
         columnCount={columnCount}
       />
 
-      <div className="space-y-2 rounded-md border bg-muted/40 p-4">
-        <div className="text-sm text-foreground">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border/70 bg-muted/30 px-3 py-2">
+        <div className="text-sm font-medium text-foreground">
           {rowCount.toLocaleString()} contacts ready to upload
         </div>
-        <div className="text-sm text-muted-foreground">{PHONE_SKIP_HINT}</div>
+        <div className="text-xs text-muted-foreground">{PHONE_SKIP_HINT}</div>
         {showSplitNameOption ? (
-          <label className="flex items-center gap-2 text-sm text-foreground">
+          <label className="flex items-center gap-2 text-xs text-foreground">
             <input
               type="checkbox"
               id="split-name"

--- a/app/components/audience/AudienceUploader.tsx
+++ b/app/components/audience/AudienceUploader.tsx
@@ -102,10 +102,7 @@ export default function AudienceUploader({
     }
   };
 
-  const displayFileToUpload = async (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    const file = e.target.files?.[0];
+  const processSelectedFile = async (file: File | undefined) => {
     if (!file) return;
 
     const data = await file.text();
@@ -143,6 +140,12 @@ export default function AudienceUploader({
     });
     setWizard("map");
     onStageChange?.("map");
+  };
+
+  const displayFileToUpload = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    await processSelectedFile(e.target.files?.[0]);
   };
 
   const updateHeaderMapping = (
@@ -263,6 +266,7 @@ export default function AudienceUploader({
               <AudienceUploadFileStep
                 ref={fileInputRef}
                 onFileChange={displayFileToUpload}
+                onFileDrop={(file) => void processSelectedFile(file)}
               />
             );
           case "map":

--- a/app/components/audience/AudienceUploader.tsx
+++ b/app/components/audience/AudienceUploader.tsx
@@ -34,6 +34,7 @@ type AudienceUploaderProps = {
   campaignId?: string;
   returnTo?: string | null;
   onUploadComplete?: (audienceId: string) => void;
+  onStageChange?: (stage: "file" | "map" | "upload") => void;
 };
 
 export default function AudienceUploader({
@@ -42,6 +43,7 @@ export default function AudienceUploader({
   campaignId,
   returnTo,
   onUploadComplete,
+  onStageChange,
 }: AudienceUploaderProps) {
   const params = useParams();
   const workspaceId = params["id"];
@@ -93,6 +95,7 @@ export default function AudienceUploader({
   const resetFileState = () => {
     setDraft(null);
     setWizard("file");
+    onStageChange?.("file");
     resetProgress();
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
@@ -139,6 +142,7 @@ export default function AudienceUploader({
       splitNameColumn: nameColumnHeader ?? null,
     });
     setWizard("map");
+    onStageChange?.("map");
   };
 
   const updateHeaderMapping = (
@@ -166,6 +170,7 @@ export default function AudienceUploader({
     if (!draft || !workspaceId) return;
 
     startSubmitting(draft.rowCount);
+    onStageChange?.("upload");
 
     try {
       const formData = new FormData();
@@ -275,6 +280,7 @@ export default function AudienceUploader({
                 onContinue={() => {
                   if (hasBlockingMappingIssue) return;
                   setWizard("review");
+                  onStageChange?.("upload");
                 }}
                 onChooseAnotherFile={resetFileState}
               />
@@ -328,9 +334,6 @@ export default function AudienceUploader({
               />
             );
           case "completed":
-            if (embedded) {
-              return null;
-            }
             return (
               <AudienceUploadProgressPanel
                 status="completed"

--- a/app/components/audience/audience-upload-wizard.shared.ts
+++ b/app/components/audience/audience-upload-wizard.shared.ts
@@ -1,7 +1,7 @@
 export const AUDIENCE_UPLOAD_WIZARD_STEPS = [
-  { id: "file", label: "1. File" },
+  { id: "file", label: "1. Select file" },
   { id: "map", label: "2. Map columns" },
-  { id: "review", label: "3. Review" },
+  { id: "review", label: "3. Upload" },
 ] as const;
 
 export type AudienceUploadWizardStepId =

--- a/app/components/contacts/ContactsPage.tsx
+++ b/app/components/contacts/ContactsPage.tsx
@@ -8,7 +8,6 @@ import { WorkspaceResourceEmptyState } from "@/components/workspace/WorkspaceRes
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Heading } from "@/components/ui/typography";
 import type { ContactsLoaderData } from "@/lib/contacts-loader.types";
 import { formatDateToLocale } from "@/lib/utils";
 
@@ -86,9 +85,6 @@ export default function ContactsPage() {
   return (
     <div className="space-y-6">
       <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-        <Heading as="h1" level={2} branded={false}>
-          Contacts
-        </Heading>
         <div className="flex flex-wrap items-center gap-4">
           <Button
             asChild

--- a/app/components/layout/Navbar.tsx
+++ b/app/components/layout/Navbar.tsx
@@ -252,7 +252,7 @@ export default function Navbar({
     <div></div>
   ) : (
     <header className={`w-full border-b border-border/70 ${className}`}>
-      <nav className="relative mx-auto flex w-full items-center justify-between px-4 py-3 sm:h-[80px] sm:px-6">
+      <nav className="relative mx-auto flex w-full items-center justify-between px-4 py-3 sm:px-6">
         <Link
           to="/"
           className="hidden font-Tabac-Slab text-4xl font-black text-brand-primary sm:block"

--- a/app/components/people/PeopleHubLayout.tsx
+++ b/app/components/people/PeopleHubLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { NavLink, useParams } from "react-router";
 import { BookUser, Users } from "lucide-react";
+import { Heading } from "@/components/ui/typography";
 
 const tabClassName = ({ isActive }: { isActive: boolean }) =>
   `inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold transition-colors ${
@@ -9,34 +10,37 @@ const tabClassName = ({ isActive }: { isActive: boolean }) =>
       : "text-muted-foreground hover:bg-muted hover:text-foreground"
   }`;
 
-export function PeopleHubLayout({ children }: { children: ReactNode }) {
+export function PeopleHubLayout({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
   const { id: workspaceId } = useParams();
   const baseUrl = `/workspaces/${workspaceId}`;
 
   return (
     <div className="space-y-5">
-      <header className="space-y-3">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-            People
-          </p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Organize contacts and Call lists for your campaigns.
-          </p>
+      <header>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Heading as="h1" level={2} branded={false}>
+            {title}
+          </Heading>
+          <nav
+            aria-label="People sections"
+            className="flex w-fit gap-1 rounded-lg bg-muted/40 p-1"
+          >
+            <NavLink to={`${baseUrl}/audiences`} className={tabClassName}>
+              <Users className="h-4 w-4" />
+              Call lists
+            </NavLink>
+            <NavLink to={`${baseUrl}/contacts`} className={tabClassName}>
+              <BookUser className="h-4 w-4" />
+              Contacts
+            </NavLink>
+          </nav>
         </div>
-        <nav
-          aria-label="People sections"
-          className="flex w-fit gap-1 rounded-lg bg-muted/40 p-1"
-        >
-          <NavLink to={`${baseUrl}/audiences`} className={tabClassName}>
-            <Users className="h-4 w-4" />
-            Call lists
-          </NavLink>
-          <NavLink to={`${baseUrl}/contacts`} className={tabClassName}>
-            <BookUser className="h-4 w-4" />
-            Contacts
-          </NavLink>
-        </nav>
       </header>
       {children}
     </div>

--- a/app/components/ui/page-shell.tsx
+++ b/app/components/ui/page-shell.tsx
@@ -13,6 +13,7 @@ const maxWidthClasses: Record<PageShellMaxWidth, string> = {
 
 type PageShellProps = {
   title: string;
+  titleAs?: "h1" | "h2";
   description?: string;
   /** Right-aligned slot for page-level actions (buttons, links). */
   actions?: ReactNode;
@@ -32,6 +33,7 @@ type PageShellProps = {
  */
 export function PageShell({
   title,
+  titleAs = "h1",
   description,
   actions,
   maxWidth = "full",
@@ -42,7 +44,7 @@ export function PageShell({
     <div className={cn("flex flex-col gap-6", maxWidthClasses[maxWidth], className)}>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-1 text-center sm:text-left">
-          <Heading as="h1" level={2} branded={false}>
+          <Heading as={titleAs} level={2} branded={false}>
             {title}
           </Heading>
           {description ? <Text variant="muted">{description}</Text> : null}

--- a/app/components/workspace/WorkspaceResourceListShell.tsx
+++ b/app/components/workspace/WorkspaceResourceListShell.tsx
@@ -51,6 +51,7 @@ type WorkspaceResourceListShellProps = {
   emptyDescription?: string;
   emptyIcon?: ReactNode;
   addAction?: ReactNode;
+  hideTitle?: boolean;
   children?: ReactNode;
 };
 
@@ -62,6 +63,7 @@ export function WorkspaceResourceListShell({
   emptyDescription,
   emptyIcon,
   addAction,
+  hideTitle = false,
   children,
 }: WorkspaceResourceListShellProps) {
   const showError = Boolean(error) && !isEmpty;
@@ -69,14 +71,16 @@ export function WorkspaceResourceListShell({
   return (
     <div className="flex h-full flex-col gap-4">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <Heading
-          as="h1"
-          level={2}
-          branded={false}
-          className="text-center sm:text-left"
-        >
-          {title}
-        </Heading>
+        {hideTitle ? null : (
+          <Heading
+            as="h1"
+            level={2}
+            branded={false}
+            className="text-center sm:text-left"
+          >
+            {title}
+          </Heading>
+        )}
         {!isEmpty ? addAction : null}
       </div>
 

--- a/app/lib/platform-auth.server.ts
+++ b/app/lib/platform-auth.server.ts
@@ -403,7 +403,15 @@ export async function updateMeProfile(
       returnHeaders: true,
     });
     const payload = (result?.response ?? result) as any;
-    const user = payload?.user;
+    const user =
+      payload?.user ??
+      (payload?.status === true
+        ? {
+            id: userId,
+            email: body.email ?? currentProfile?.username ?? null,
+            name: updateBody.name ?? currentProfile?.first_name ?? null,
+          }
+        : null);
     if (!user) {
       return { ok: false, error: "Update failed", status: 400 };
     }

--- a/app/lib/two-factor.server.ts
+++ b/app/lib/two-factor.server.ts
@@ -227,7 +227,7 @@ export async function requireTwoFactorEnrollmentForPrivilegedUser(args: {
   }
 
   const next = args.nextPath ?? pathname;
-  throw redirect(`/account/security?enroll=1&next=${encodeURIComponent(next)}`);
+  throw redirect(`/account?enroll=1&next=${encodeURIComponent(next)}`);
 }
 
 export function isTwoFactorRedirectResponse(

--- a/app/routes/account.loader.server.ts
+++ b/app/routes/account.loader.server.ts
@@ -6,6 +6,7 @@ import { mergeBetterAuthSetCookieHeaders } from "@/lib/better-auth-headers.serve
 import { defineAction, defineLoader } from "@/lib/handler.server";
 import { updateMeProfile } from "@/lib/platform-auth.server";
 import { getUserById } from "@/lib/workspace-members-db.server";
+import { isTwoFactorEnabled, userHasPrivilegedWorkspaceRole } from "@/lib/two-factor.server";
 
 const accountProfileSchema = z.object({
   first_name: z.string().trim().min(1, "First name is required").max(100),
@@ -15,14 +16,22 @@ const accountProfileSchema = z.object({
 export const loader = defineLoader({
   auth: ({ request }) => verifyAuth(request, "/account"),
   sideEffects: ["db-read"],
-  handler: async ({ auth }) => {
+  handler: async ({ auth, request }) => {
     const profile = await getUserById(auth.user.id);
+    const url = new URL(request.url);
+    const [twoFactorEnabled, privileged] = await Promise.all([
+      isTwoFactorEnabled(auth.user.id),
+      userHasPrivilegedWorkspaceRole(auth.user.id),
+    ]);
 
     return routeData(
       {
         firstName: profile?.first_name ?? "",
         lastName: profile?.last_name ?? "",
         email: auth.user.email ?? profile?.username ?? "",
+        twoFactorEnabled,
+        privileged,
+        enrollRequired: url.searchParams.get("enroll") === "1",
       },
       { headers: auth.headers },
     );

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -95,7 +95,7 @@ export default function Account() {
           <SectionHeader
             title="Personal information"
             description="This information identifies you across your workspaces."
-            className="mb-3 pb-3"
+            className="mb-3 border-b-0 pb-0"
             actions={
               editingProfile ? (
                 <div className="flex gap-2">
@@ -172,7 +172,7 @@ export default function Account() {
           <SectionHeader
             title="MFA"
             description="Protect your account with multi-factor authentication."
-            className="mb-3 pb-3"
+            className="mb-3 border-b-0 pb-0"
             actions={
               editingMfa ? (
                 <div className="flex gap-2">

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -68,12 +68,24 @@ export default function Account() {
     }
   };
 
+  /**
+   * @effect Exit profile edit mode after the profile action succeeds.
+   * @effect-deps actionData?.success (the route action result changes after a successful save)
+   * @effect-side-effects none (local setState only)
+   * @effect-why-not-loader This is client-only edit-mode UI state tied to the action response.
+   */
   useEffect(() => {
     if (actionData?.success) {
       setEditingProfile(false);
     }
   }, [actionData?.success]);
 
+  /**
+   * @effect Exit MFA edit mode after MFA enrollment succeeds.
+   * @effect-deps mfaData?.enabled (the fetcher result changes after verification)
+   * @effect-side-effects none (local setState only)
+   * @effect-why-not-loader This is client-only edit-mode UI state tied to the fetcher response.
+   */
   useEffect(() => {
     if (mfaData?.enabled) {
       setEditingMfa(false);

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-router";
 import type { MetaFunction } from "react-router";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 
 import { Section, SectionHeader } from "@/components/shared/Section";
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,7 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { PageShell } from "@/components/ui/page-shell";
 import { Text } from "@/components/ui/typography";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useActionFeedback } from "@/hooks/utils/useActionFeedback";
 
 type LoaderData = {
@@ -56,6 +58,16 @@ export default function Account() {
   const twoFactorEnabled = mfaData?.enabled ?? profile.twoFactorEnabled;
   const showingMfaVerification = mfaData?.step === "verify";
 
+  const copyMfaSetupUri = async () => {
+    if (!mfaData?.totpURI) return;
+    try {
+      await navigator.clipboard.writeText(mfaData.totpURI);
+      toast.success("MFA setup code copied to clipboard");
+    } catch {
+      toast.error("Could not copy the MFA setup code");
+    }
+  };
+
   useEffect(() => {
     if (actionData?.success) {
       setEditingProfile(false);
@@ -83,6 +95,7 @@ export default function Account() {
           <SectionHeader
             title="Personal information"
             description="This information identifies you across your workspaces."
+            className="mb-3 pb-3"
             actions={
               editingProfile ? (
                 <div className="flex gap-2">
@@ -108,6 +121,12 @@ export default function Account() {
               )
             }
           />
+          {actionData?.error ? (
+            <Alert variant="destructive" role="alert" className="mb-4">
+              <AlertTitle>Could not update your profile</AlertTitle>
+              <AlertDescription>{actionData.error}</AlertDescription>
+            </Alert>
+          ) : null}
           <Form ref={profileFormRef} id="profile-form" method="POST" className="space-y-5">
             <div className="grid gap-5 sm:grid-cols-2">
               <FormField htmlFor="first_name" label="First name" required>
@@ -153,6 +172,7 @@ export default function Account() {
           <SectionHeader
             title="MFA"
             description="Protect your account with multi-factor authentication."
+            className="mb-3 pb-3"
             actions={
               editingMfa ? (
                 <div className="flex gap-2">
@@ -187,7 +207,12 @@ export default function Account() {
           <Text className="text-sm text-muted-foreground">
             Status: {twoFactorEnabled ? "Enabled" : "Not enabled"}
           </Text>
-          {mfaData?.error ? <Text className="text-destructive">{mfaData.error}</Text> : null}
+          {mfaData?.error ? (
+            <Alert variant="destructive" role="alert">
+              <AlertTitle>Could not update MFA</AlertTitle>
+              <AlertDescription>{mfaData.error}</AlertDescription>
+            </Alert>
+          ) : null}
           {mfaData?.success ? <Text className="text-green-600">{mfaData.success}</Text> : null}
 
           {editingMfa && !twoFactorEnabled && !showingMfaVerification ? (
@@ -212,9 +237,24 @@ export default function Account() {
 
           {editingMfa && showingMfaVerification ? (
             <div className="space-y-4">
-              {mfaData?.totpURI ? (
-                <Text className="break-all text-xs">{mfaData.totpURI}</Text>
-              ) : null}
+              <Alert className="border-warning/50 bg-warning/10">
+                <AlertTitle>Connect your authenticator app</AlertTitle>
+                <AlertDescription>
+                  Copy this setup code into Google Authenticator, Microsoft Authenticator,
+                  1Password, or another TOTP authenticator app. Then enter the six-digit
+                  code it generates below.
+                  {mfaData?.totpURI ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <code className="min-w-0 flex-1 break-all rounded bg-muted px-2 py-1 text-xs">
+                        {mfaData.totpURI}
+                      </code>
+                      <Button type="button" size="sm" onClick={() => void copyMfaSetupUri()}>
+                        Copy setup code
+                      </Button>
+                    </div>
+                  ) : null}
+                </AlertDescription>
+              </Alert>
               {mfaData?.backupCodes?.length ? (
                 <Text className="text-sm">
                   Backup codes: {mfaData.backupCodes.join(", ")}

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -1,31 +1,44 @@
 export { action, loader } from "./account.loader.server";
 
-import { ShieldCheck } from "lucide-react";
 import {
   Form,
-  Link,
   useActionData,
+  useFetcher,
   useLoaderData,
   useNavigation,
 } from "react-router";
 import type { MetaFunction } from "react-router";
+import { useEffect, useRef, useState } from "react";
 
 import { Section, SectionHeader } from "@/components/shared/Section";
 import { Button } from "@/components/ui/button";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { PageShell } from "@/components/ui/page-shell";
+import { Text } from "@/components/ui/typography";
 import { useActionFeedback } from "@/hooks/utils/useActionFeedback";
 
 type LoaderData = {
   firstName: string;
   lastName: string;
   email: string;
+  twoFactorEnabled: boolean;
+  privileged: boolean;
+  enrollRequired: boolean;
 };
 
 type ActionData = {
   error?: string;
   success?: boolean;
+};
+
+type MfaActionData = {
+  error?: string;
+  success?: string;
+  step?: "verify";
+  totpURI?: string | null;
+  backupCodes?: string[];
+  enabled?: boolean;
 };
 
 export const meta: MetaFunction = () => [{ title: "Account — CallCaster" }];
@@ -34,7 +47,26 @@ export default function Account() {
   const profile = useLoaderData<LoaderData>();
   const actionData = useActionData<ActionData>();
   const navigation = useNavigation();
+  const mfaFetcher = useFetcher<MfaActionData>();
+  const profileFormRef = useRef<HTMLFormElement>(null);
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [editingMfa, setEditingMfa] = useState(profile.enrollRequired);
   const isSaving = navigation.state === "submitting";
+  const mfaData = mfaFetcher.data;
+  const twoFactorEnabled = mfaData?.enabled ?? profile.twoFactorEnabled;
+  const showingMfaVerification = mfaData?.step === "verify";
+
+  useEffect(() => {
+    if (actionData?.success) {
+      setEditingProfile(false);
+    }
+  }, [actionData?.success]);
+
+  useEffect(() => {
+    if (mfaData?.enabled) {
+      setEditingMfa(false);
+    }
+  }, [mfaData?.enabled]);
 
   useActionFeedback(actionData, {
     successMessage: "Profile updated.",
@@ -49,10 +81,34 @@ export default function Account() {
       >
         <Section>
           <SectionHeader
-            title="Profile"
+            title="Personal information"
             description="This information identifies you across your workspaces."
+            actions={
+              editingProfile ? (
+                <div className="flex gap-2">
+                  <Button type="submit" form="profile-form" disabled={isSaving}>
+                    {isSaving ? "Saving…" : "Save"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      profileFormRef.current?.reset();
+                      setEditingProfile(false);
+                    }}
+                    disabled={isSaving}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              ) : (
+                <Button type="button" variant="outline" onClick={() => setEditingProfile(true)}>
+                  Edit
+                </Button>
+              )
+            }
           />
-          <Form method="POST" className="space-y-5">
+          <Form ref={profileFormRef} id="profile-form" method="POST" className="space-y-5">
             <div className="grid gap-5 sm:grid-cols-2">
               <FormField htmlFor="first_name" label="First name" required>
                 <Input
@@ -61,6 +117,7 @@ export default function Account() {
                   defaultValue={profile.firstName}
                   autoComplete="given-name"
                   maxLength={100}
+                  disabled={!editingProfile}
                   required
                 />
               </FormField>
@@ -71,6 +128,7 @@ export default function Account() {
                   defaultValue={profile.lastName}
                   autoComplete="family-name"
                   maxLength={100}
+                  disabled={!editingProfile}
                   required
                 />
               </FormField>
@@ -88,25 +146,103 @@ export default function Account() {
                 aria-readonly="true"
               />
             </FormField>
-            <div className="flex justify-end">
-              <Button type="submit" disabled={isSaving}>
-                {isSaving ? "Saving…" : "Save profile"}
-              </Button>
-            </div>
           </Form>
         </Section>
 
         <Section>
           <SectionHeader
-            title="Security"
-            description="Protect your account with two-factor authentication."
+            title="MFA"
+            description="Protect your account with multi-factor authentication."
+            actions={
+              editingMfa ? (
+                <div className="flex gap-2">
+                  <Button
+                    type="submit"
+                    form="mfa-form"
+                    disabled={mfaFetcher.state !== "idle"}
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setEditingMfa(false)}
+                    disabled={mfaFetcher.state !== "idle"}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              ) : (
+                <Button type="button" variant="outline" onClick={() => setEditingMfa(true)}>
+                  Edit
+                </Button>
+              )
+            }
           />
-          <Button asChild variant="outline">
-            <Link to="/account/security">
-              <ShieldCheck className="mr-2 h-4 w-4" />
-              Manage account security
-            </Link>
-          </Button>
+          {profile.enrollRequired && profile.privileged && !twoFactorEnabled ? (
+            <Text className="text-sm text-destructive">
+              MFA enrollment is required before you can access your workspace.
+            </Text>
+          ) : null}
+          <Text className="text-sm text-muted-foreground">
+            Status: {twoFactorEnabled ? "Enabled" : "Not enabled"}
+          </Text>
+          {mfaData?.error ? <Text className="text-destructive">{mfaData.error}</Text> : null}
+          {mfaData?.success ? <Text className="text-green-600">{mfaData.success}</Text> : null}
+
+          {editingMfa && !twoFactorEnabled && !showingMfaVerification ? (
+            <mfaFetcher.Form
+              id="mfa-form"
+              method="POST"
+              action="/account/security"
+              className="space-y-4"
+            >
+              <input type="hidden" name="intent" value="enable" />
+              <FormField htmlFor="mfa-password" label="Current password" required>
+                <Input
+                  id="mfa-password"
+                  name="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                />
+              </FormField>
+            </mfaFetcher.Form>
+          ) : null}
+
+          {editingMfa && showingMfaVerification ? (
+            <div className="space-y-4">
+              {mfaData?.totpURI ? (
+                <Text className="break-all text-xs">{mfaData.totpURI}</Text>
+              ) : null}
+              {mfaData?.backupCodes?.length ? (
+                <Text className="text-sm">
+                  Backup codes: {mfaData.backupCodes.join(", ")}
+                </Text>
+              ) : null}
+              <mfaFetcher.Form
+                id="mfa-form"
+                method="POST"
+                action="/account/security"
+                className="space-y-4"
+              >
+                <input type="hidden" name="intent" value="verify" />
+                <FormField htmlFor="mfa-code" label="Verification code" required>
+                  <Input
+                    id="mfa-code"
+                    name="code"
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    required
+                  />
+                </FormField>
+              </mfaFetcher.Form>
+            </div>
+          ) : null}
+
+          {!editingMfa && !twoFactorEnabled ? (
+            <Text className="text-sm text-muted-foreground">MFA is not enabled.</Text>
+          ) : null}
         </Section>
       </PageShell>
     </main>

--- a/app/routes/workspaces+/$id.tsx
+++ b/app/routes/workspaces+/$id.tsx
@@ -237,10 +237,9 @@ export default function Workspace() {
   const outlet = useOutlet();
   const context = useOutletContext<ContextType>();
   const onboardingStrip = findOnboardingStripData(useMatches());
-  // Sidebar stays visible after short intake. Hide only while the intake
-  // route is active or the root loader would still bounce into intake.
-  const showSidebar =
-    !onboardingStrip && !onboardingReadiness.shouldRedirectToOnboarding;
+  // Keep the workspace sidebar available on all workspace screens; onboarding
+  // itself is the only focused layout that should hide it.
+  const showSidebar = !onboardingStrip;
 
   return (
     <>

--- a/app/routes/workspaces+/$id/audiences.route.tsx
+++ b/app/routes/workspaces+/$id/audiences.route.tsx
@@ -24,7 +24,7 @@ export default function WorkspaceAudiencesPage() {
 
   if (outlet) {
     return (
-      <PeopleHubLayout>
+      <PeopleHubLayout title="Call lists">
         <Outlet context={parentContext} />
       </PeopleHubLayout>
     );
@@ -33,9 +33,10 @@ export default function WorkspaceAudiencesPage() {
   const title = "Call lists";
 
   return (
-    <PeopleHubLayout>
+    <PeopleHubLayout title="Call lists">
       <WorkspaceResourceListShell
         title={title}
+        hideTitle
         error={error}
         isEmpty={isWorkspaceAudienceEmpty}
         emptyMessage="Add a Call list to this workspace"

--- a/app/routes/workspaces+/$id/audiences/new.route.tsx
+++ b/app/routes/workspaces+/$id/audiences/new.route.tsx
@@ -53,7 +53,7 @@ export default function AudiencesNew() {
 
   return (
     <section id="form">
-      <PageShell title="Add a Call list" maxWidth="narrow">
+      <PageShell title="Add a Call list" titleAs="h2" maxWidth="narrow">
         {actionData?.error ? (
           <Text className="text-center text-destructive">
             Error: {actionData.error}

--- a/app/routes/workspaces+/$id/audiences/new.route.tsx
+++ b/app/routes/workspaces+/$id/audiences/new.route.tsx
@@ -60,7 +60,7 @@ export default function AudiencesNew() {
           </Text>
         ) : null}
         <Tabs value={`step-${currentStep}`} className="w-full">
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger 
               value="step-1" 
               disabled={currentStep !== 1}
@@ -70,18 +70,26 @@ export default function AudiencesNew() {
               Name
             </TabsTrigger>
             <TabsTrigger 
-              value="step-2" 
+              value="step-2"
               disabled={currentStep !== 2}
               className={currentStep > 2 ? "text-green-800" : ""}
             >
               {currentStep > 2 && <MdCheck className="mr-1" />}
-              Upload
+              Select File
             </TabsTrigger>
             <TabsTrigger 
               value="step-3" 
               disabled={currentStep !== 3}
+              className={currentStep > 3 ? "text-green-800" : ""}
             >
-              Process
+              {currentStep > 3 && <MdCheck className="mr-1" />}
+              Map Columns
+            </TabsTrigger>
+            <TabsTrigger
+              value="step-4"
+              disabled={currentStep !== 4}
+            >
+              Upload
             </TabsTrigger>
           </TabsList>
 
@@ -114,56 +122,48 @@ export default function AudiencesNew() {
                     disabled={!audienceName.trim()}
                     className="bg-brand-primary text-white hover:bg-brand-secondary"
                   >
-                    Next: Upload Contacts <MdArrowForward className="ml-2" />
+                    Next: Select File <MdArrowForward className="ml-2" />
                   </Button>
                 </div>
               </form>
             </Section>
           ) : null}
 
-          {currentStep === 2 ? (
+          {currentStep >= 2 ? (
             <Section variant="flat" className="space-y-4">
-              <div className="mb-4 text-center" data-testid="audience-upload-step">
-                <h3 className="text-lg font-medium">Upload Contacts</h3>
-              </div>
-              
               <div className="space-y-6">
                 <AudienceUploader
                   audienceName={audienceName}
                   campaignId={campaignId}
                   returnTo={returnTo}
+                  onStageChange={(stage) => {
+                    setCurrentStep(stage === "file" ? 2 : stage === "map" ? 3 : 4);
+                  }}
                   onUploadComplete={(audienceId) => {
                     setCompletedAudienceId(audienceId);
-                    setCurrentStep(3);
                   }}
                 />
+                {completedAudienceId ? (
+                  <div className="flex justify-end">
+                    <Button
+                      type="button"
+                      className="bg-brand-primary text-white hover:bg-brand-secondary"
+                      onClick={() => {
+                        if (!workspaceId) return;
+                        navigate(
+                          returnTo ??
+                            `/workspaces/${workspaceId}/audiences/${completedAudienceId}`,
+                        );
+                      }}
+                    >
+                      {returnTo ? "Continue setup" : "View Call list"}
+                    </Button>
+                  </div>
+                ) : null}
               </div>
             </Section>
           ) : null}
 
-          {currentStep === 3 ? (
-            <Section variant="flat" className="space-y-4">
-              <div className="text-center space-y-4">
-                <h3 className="mb-2 text-lg font-medium">Upload Complete</h3>
-                <Text variant="muted">
-                  Your Call list is ready and contacts are being processed.
-                </Text>
-                <Button
-                  type="button"
-                  className="bg-brand-primary text-white hover:bg-brand-secondary"
-                  onClick={() => {
-                    if (!workspaceId || !completedAudienceId) return;
-                    navigate(
-                      returnTo ??
-                        `/workspaces/${workspaceId}/audiences/${completedAudienceId}`,
-                    );
-                  }}
-                >
-                  {returnTo ? "Continue setup" : "View Call list"}
-                </Button>
-              </div>
-            </Section>
-          ) : null}
         </Tabs>
       </PageShell>
     </section>

--- a/app/routes/workspaces+/$id/audiences/new.route.tsx
+++ b/app/routes/workspaces+/$id/audiences/new.route.tsx
@@ -130,7 +130,11 @@ export default function AudiencesNew() {
           ) : null}
 
           {currentStep >= 2 ? (
-            <Section variant="flat" className="space-y-4">
+            <Section
+              variant="flat"
+              className="space-y-4"
+              data-testid="audience-upload-step"
+            >
               <div className="space-y-6">
                 <AudienceUploader
                   audienceName={audienceName}

--- a/app/routes/workspaces+/$id/contacts.route.tsx
+++ b/app/routes/workspaces+/$id/contacts.route.tsx
@@ -12,14 +12,14 @@ export default function WorkspaceContactsPage() {
 
   if (outlet) {
     return (
-      <PeopleHubLayout>
+      <PeopleHubLayout title="Contacts">
         <Outlet />
       </PeopleHubLayout>
     );
   }
 
   return (
-    <PeopleHubLayout>
+    <PeopleHubLayout title="Contacts">
       <ContactsPage />
     </PeopleHubLayout>
   );

--- a/docs/effects-inventory.md
+++ b/docs/effects-inventory.md
@@ -5,7 +5,7 @@
 > the state it depends on, and the side effects it performs. See
 > [effects-strictness.md](./effects-strictness.md).
 
-**113** documented / **113** total effects (0 grandfathered, ratcheting to 0).
+**116** documented / **116** total effects (0 grandfathered, ratcheting to 0).
 
 | File | Purpose | Depends on | Side effects | Why not a loader/fetcher |
 | --- | --- | --- | --- | --- |
@@ -117,6 +117,8 @@
 | `app/hooks/utils/useUnsavedChangesGuard.ts` | Ask the user to confirm in-app navigation via window.confirm when the blocker trips, then proceed/reset. | blocker (React Router's useBlocker result; re-runs whenever its state/proceed/reset change) | dom (window.confirm — a blocking UI prompt) + navigation (blocker.proceed()/reset()) | Not data fetching — reacts to React Router's blocker state to show an |
 | `app/hooks/utils/useUnsavedChangesGuard.ts` | Warn on tab close/refresh via beforeunload while there are unsaved changes. | isChanged (only subscribes while there's something to lose) | dom (window 'beforeunload' listener; removed on cleanup/when isChanged flips) | Not data fetching — beforeunload is a browser-native tab-close guard that |
 | `app/hooks/workspace/useApiKeys.ts` | CANDIDATE-REMOVE Fetches from the API keys resource route (external system) on mount | workspaceId, hasAccess, initialKeys.length. `listFetcher` is intentionally omitted | fetch (listFetcher.load against /api/workspace-api-keys) | Fallback fetch for data the route loader is expected to provide — if the |
+| `app/routes/account.tsx` | Exit profile edit mode after the profile action succeeds. | actionData?.success (the route action result changes after a successful save) | none (local setState only) | This is client-only edit-mode UI state tied to the action response. |
+| `app/routes/account.tsx` | Exit MFA edit mode after MFA enrollment succeeds. | mfaData?.enabled (the fetcher result changes after verification) | none (local setState only) | This is client-only edit-mode UI state tied to the fetcher response. |
 | `app/routes/docs.tsx` | Dynamically import and imperatively mount the Scalar API-reference widget into containerRef for the active spec. | config.url — remounts the widget against the newly selected spec (public vs. complete) when it changes. | dom (imperative third-party widget mount) + dynamic import; instance destroyed on cleanup/re-run. | Scalar's `createApiReference` is an imperative DOM-mounting API from a lazily-loaded client bundle, not data a loader could hand to a component tree. |
 | `app/routes/workspaces+/$id/campaigns/$selected_id/settings.route.tsx` | Redirect legacy #campaign-launch hash deep-links to the dedicated launch route. | location.hash, location.search, navigate | navigate (client redirect) | Hash fragments are not available to loaders; this preserves old bookmarks. |
 | `app/routes/workspaces+/$id/onboarding/OnboardingFirstNumberStep.tsx` | Open the verification-code dialog when the route action returns a validationRequest | validationRequest from useActionData via the parent route | setState for dialog open + retained request payload | Action data arrives after the mutation; opening a modal is client-only. |

--- a/e2e/specs/audience-upload-completion.spec.ts
+++ b/e2e/specs/audience-upload-completion.spec.ts
@@ -31,7 +31,7 @@ ownerTest("AUD-05 upload wizard completes end-to-end via the job worker", async 
 
   // Submit → job enqueue → worker claim (≤5s poll) → chunk insert → status
   // flip. 20s leaves headroom over the observed ~6s without masking a hang.
-  await expect(page.getByText("Upload Complete")).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText("Upload completed successfully!")).toBeVisible({ timeout: 20_000 });
 
   // The finished list is reachable and carries the name it was given.
   await page.getByRole("button", { name: "View Call list" }).click();

--- a/test/account.route.test.ts
+++ b/test/account.route.test.ts
@@ -4,6 +4,8 @@ import { asRouteResponse } from "./helpers/route-result";
 
 const mocks = vi.hoisted(() => ({
   getUserById: vi.fn(),
+  isTwoFactorEnabled: vi.fn(),
+  userHasPrivilegedWorkspaceRole: vi.fn(),
   updateMeProfile: vi.fn(),
   verifyAuth: vi.fn(),
 }));
@@ -20,6 +22,11 @@ vi.mock("@/lib/workspace-members-db.server", () => ({
   getUserById: mocks.getUserById,
 }));
 
+vi.mock("@/lib/two-factor.server", () => ({
+  isTwoFactorEnabled: mocks.isTwoFactorEnabled,
+  userHasPrivilegedWorkspaceRole: mocks.userHasPrivilegedWorkspaceRole,
+}));
+
 describe("account route", () => {
   beforeEach(() => {
     mocks.verifyAuth.mockReset();
@@ -34,6 +41,8 @@ describe("account route", () => {
       last_name: "Last",
       username: "person@example.com",
     });
+    mocks.isTwoFactorEnabled.mockResolvedValue(false);
+    mocks.userHasPrivilegedWorkspaceRole.mockResolvedValue(false);
     mocks.updateMeProfile.mockReset();
   });
 
@@ -51,6 +60,9 @@ describe("account route", () => {
       firstName: "First",
       lastName: "Last",
       email: "person@example.com",
+      twoFactorEnabled: false,
+      privileged: false,
+      enrollRequired: false,
     });
   });
 

--- a/test/platform-auth.test.ts
+++ b/test/platform-auth.test.ts
@@ -177,5 +177,24 @@ describe("platform-auth.server.ts", () => {
       });
       expect(mocks.changePassword).not.toHaveBeenCalled();
     });
+
+    test("accepts Better Auth status-only update response", async () => {
+      mocks.updateUser.mockResolvedValueOnce({ response: { status: true } });
+      const mod = await import("../app/lib/platform-auth.server");
+
+      const result = await mod.updateMeProfile(
+        new Request("http://localhost/api/me", { headers: new Headers() }),
+        "u1",
+        { first_name: "Updated", last_name: "Name" } as any,
+      );
+
+      expect(result.ok).toBe(true);
+      expect(mocks.updateOwnUserProfile).toHaveBeenCalledWith({
+        userId: "u1",
+        first_name: "Updated",
+        last_name: "Name",
+        username: "a@b.com",
+      });
+    });
   });
 });

--- a/test/two-factor.server.test.ts
+++ b/test/two-factor.server.test.ts
@@ -135,7 +135,7 @@ describe("requireTwoFactorEnrollmentForPrivilegedUser (sudo path)", () => {
     delete process.env.RAILWAY_ENVIRONMENT_NAME;
   });
 
-  test("sudo (isPrivileged) not enrolled is redirected to /account/security", async () => {
+  test("sudo (isPrivileged) not enrolled is redirected to account MFA", async () => {
     let thrown: unknown;
     try {
       await requireTwoFactorEnrollmentForPrivilegedUser({
@@ -149,7 +149,7 @@ describe("requireTwoFactorEnrollmentForPrivilegedUser (sudo path)", () => {
     expect(thrown).toBeInstanceOf(Response);
     expect((thrown as Response).status).toBe(302);
     expect((thrown as Response).headers.get("location")).toContain(
-      "/account/security?enroll=1",
+      "/account?enroll=1",
     );
   });
 

--- a/test/ui/audience-uploader.test.tsx
+++ b/test/ui/audience-uploader.test.tsx
@@ -246,7 +246,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     expect(screen.getByText("Alice")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-    expect(screen.getByText(/contacts ready to upload/)).toBeInTheDocument();
+    expect(screen.getByText(/2 rows 3 columns/)).toBeInTheDocument();
     const split = screen.getByLabelText(
       "Split full name into first name and last name",
     ) as HTMLInputElement;

--- a/test/ui/audience-uploader.test.tsx
+++ b/test/ui/audience-uploader.test.tsx
@@ -175,7 +175,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     expect(
       screen.getByText("Drop or choose a CSV file"),
     ).toBeInTheDocument();
-    expect(screen.getByText("1. File")).toBeInTheDocument();
+    expect(screen.getByText("1. Select file")).toBeInTheDocument();
   });
 
   test("hides step strip when embedded (onUploadComplete)", async () => {
@@ -381,8 +381,8 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
       expect(mocks.onUploadComplete).toHaveBeenCalledWith("5");
     });
 
-    expect(screen.queryByText("Completed!")).toBeNull();
-    expect(screen.queryByText("Redirecting to audience page...")).toBeNull();
+    expect(screen.getByText("Completed!")).toBeInTheDocument();
+    expect(screen.getByText("Redirecting to audience page...")).toBeInTheDocument();
   }, 15000);
 
   test("polling completion without onUploadComplete shows chrome and redirects after 2s", async () => {
@@ -571,7 +571,7 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
       });
     });
 
-    expect(screen.queryByText("Completed!")).toBeNull();
+    expect(screen.getByText("Completed!")).toBeInTheDocument();
     expect(mocks.onUploadComplete).toHaveBeenCalledWith("123");
   });
 

--- a/test/ui/audience-uploader.test.tsx
+++ b/test/ui/audience-uploader.test.tsx
@@ -178,6 +178,22 @@ describe("app/components/audience/AudienceUploader.tsx", () => {
     expect(screen.getByText("1. Select file")).toBeInTheDocument();
   });
 
+  test("accepts a CSV dropped onto the file picker", async () => {
+    const { default: AudienceUploader } =
+      await import("@/components/audience/AudienceUploader");
+    render(<AudienceUploader audienceName="A1" />);
+    const file = new File(["Phone\n123"], "contacts.csv", { type: "text/csv" });
+    (file as any).text = async () => "Phone\n123";
+    const dropZone = screen.getByText("Drop or choose a CSV file").closest("label");
+
+    expect(dropZone).not.toBeNull();
+    fireEvent.drop(dropZone!, { dataTransfer: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Map CSV Headers")).toBeInTheDocument();
+    });
+  });
+
   test("hides step strip when embedded (onUploadComplete)", async () => {
     const { default: AudienceUploader } =
       await import("@/components/audience/AudienceUploader");

--- a/test/ui/contacts-route-outlet.test.tsx
+++ b/test/ui/contacts-route-outlet.test.tsx
@@ -57,13 +57,13 @@ describe("app/routes/workspaces+/$id/contacts.route.tsx", () => {
     await renderContactsRoute(`/workspaces/${workspaceId}/contacts/new`);
 
     expect(await screen.findByText("contact-child-route")).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Contacts" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Contacts" })).toBeTruthy();
   });
 
   test("renders the child route for an existing contact id", async () => {
     await renderContactsRoute(`/workspaces/${workspaceId}/contacts/42`);
 
     expect(await screen.findByText("contact-child-route")).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Contacts" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Contacts" })).toBeTruthy();
   });
 });

--- a/test/ui/workspace-sidebar-onboarding-gating.test.tsx
+++ b/test/ui/workspace-sidebar-onboarding-gating.test.tsx
@@ -2,13 +2,9 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import Workspace from "@/routes/workspaces+/$id";
 
-// The workspace sidebar stays hidden until onboarding is complete:
-//   1. while the onboarding wizard child route is active (its loader data is
-//      present in useMatches), and
-//   2. on any workspace page while the workspace is fresh enough that the
-//      root loader would still bounce it into the wizard
-//      (onboardingReadiness.shouldRedirectToOnboarding).
-// Once neither holds, the sidebar renders as before.
+// The workspace sidebar stays hidden only while the onboarding wizard child
+// route is active. Workspace pages remain navigable while onboarding is
+// incomplete, including when the workspace has no phone number yet.
 const mocks = vi.hoisted(() => ({
   revalidate: vi.fn(),
   state: {
@@ -90,10 +86,10 @@ describe("workspaces+/$id.tsx sidebar onboarding gating", () => {
     expect(screen.getByTestId("workspace-nav")).toBeInTheDocument();
   });
 
-  test("hides the sidebar while the workspace still redirects to onboarding", () => {
+  test("shows the sidebar while the workspace still needs onboarding", () => {
     mocks.state.shouldRedirectToOnboarding = true;
     render(<Workspace />);
-    expect(screen.queryByTestId("workspace-nav")).not.toBeInTheDocument();
+    expect(screen.getByTestId("workspace-nav")).toBeInTheDocument();
   });
 
   test("hides the sidebar while the onboarding wizard route is active", () => {


### PR DESCRIPTION
## Summary
- Keep the workspace sidebar visible on workspace screens during onboarding.
- Add inline account profile and MFA editing with enrollment guidance and copyable setup code.
- Fix Better Auth status-only profile updates.
- Simplify call-list upload steps and add CSV drag-and-drop support.
- Compact upload metadata and improve upload-stage messaging.

## Verification
- `npx vitest run -c vitest.ui.config.ts test/ui/audience-uploader.test.tsx test/ui/audience-uploader-progress.test.tsx test/ui/workspace-sidebar-onboarding-gating.test.tsx`
- `npx vitest run -c vitest.node.config.ts test/account.route.test.ts test/platform-auth.test.ts test/two-factor.server.test.ts`
- `npm run typecheck`
- Targeted ESLint checks

Rebased onto `origin/dev` before pushing.