### PR TITLE
fix: don't hang up on a detected machine when no voicemail audio is configured

### DIFF
--- a/app/routes/api+/dial/status.action.server.ts
+++ b/app/routes/api+/dial/status.action.server.ts
@@ -3,7 +3,7 @@ import { fetchCampaignByIdForWorkspace } from "@/lib/campaign-ivr.server";
 import { data as routeData } from "react-router";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { markContactLineType } from "@/lib/twilio-lookup.server";
-import { hangupTwiml, pausePlayTwiml } from "@/lib/twilio-twiml.server";
+import { pausePlayTwiml } from "@/lib/twilio-twiml.server";
 import { createSignedObjectUrl } from "@/lib/object-storage.server";
 import {
   findCallBySid,
@@ -87,34 +87,20 @@ export const action = defineAction({
       answeredBy &&
       answeredBy.includes("machine") &&
       !answeredBy.includes("other") &&
-      callStatus !== "completed"
+      callStatus !== "completed" &&
+      voicemailData?.signedUrl
     ) {
       try {
-        if (voicemailData && voicemailData.signedUrl) {
-          if (dbCall.outreach_attempt_id) {
-            const outreachResult = await updateOutreachAttemptForWorkspace(dbCall.workspace, dbCall.outreach_attempt_id, {
-              disposition: "voicemail",
-            });
-            if (outreachResult instanceof Response) {
-              throw new Error(await outreachResult.text());
-            }
-          }
-          await call.update({
-            twiml: pausePlayTwiml(voicemailData.signedUrl, 5),
-          });
-          return routeData({ success: true });
-        }
-
         if (dbCall.outreach_attempt_id) {
           const outreachResult = await updateOutreachAttemptForWorkspace(dbCall.workspace, dbCall.outreach_attempt_id, {
-            disposition: "no-answer",
+            disposition: "voicemail",
           });
           if (outreachResult instanceof Response) {
             throw new Error(await outreachResult.text());
           }
         }
         await call.update({
-          twiml: hangupTwiml(),
+          twiml: pausePlayTwiml(voicemailData.signedUrl, 5),
         });
         return routeData({ success: true });
       } catch (error) {
@@ -123,6 +109,12 @@ export const action = defineAction({
         return routeData({ success: false, error: errorMessage });
       }
     }
+    // A detected machine with no voicemail-drop audio configured for this
+    // campaign falls through to the same path as a human answer: the call
+    // is never auto-hung-up on AMD alone, only when there's an actual
+    // message to leave. Product decision (issue #1143) — the previous
+    // behavior hung up silently with nothing left behind, which read to
+    // agents as "the call just died" rather than "voicemail wasn't set up."
 
     await updateCallBySid(dbCall.workspace, callSid, { answered_by: answeredBy });
     if (dbCall.outreach_attempt_id) {

--- a/test/dial-status.route.test.ts
+++ b/test/dial-status.route.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { asRouteResponse } from "./helpers/route-result";
-import { configureTelephonyStub } from "./helpers/telephony-db-stub";
+import { configureTelephonyStub, telephonyStubState } from "./helpers/telephony-db-stub";
 
 const mocks = vi.hoisted(() => {
   return {
@@ -321,7 +321,7 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
     await expect(res.json()).resolves.toMatchObject({ success: true });
   });
 
-  test("machine answer plays voicemail or hangs up; machine handler catch formats errors", async () => {
+  test("machine answer plays voicemail or lets the call ring through; machine handler catch formats errors", async () => {
     const { client, twilio } = makeDbClient();
     mocks.createClient.mockReturnValueOnce(client);
     mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce(twilio as any);
@@ -336,7 +336,12 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
       expect.objectContaining({ twiml: expect.stringContaining("<Play>https://signed</Play>") }),
     );
 
-    // voicemail missing signedUrl => hangup + no-answer
+    // voicemail missing signedUrl (no voicemail-drop audio configured for
+    // this campaign) => falls through to the same "let it ring through"
+    // path as a human answer. Product decision (issue #1143): a detected
+    // machine is never auto-hung-up on its own — only when there's an
+    // actual voicemail message to leave. No TwiML update at all: the
+    // call's own <Dial> verb keeps running untouched.
     const { client: sup2, twilio: tw2 } = makeDbClient();
     dialStatusStorageState.signedUrl = null;
     mocks.createClient.mockReturnValueOnce(sup2);
@@ -344,12 +349,14 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
     res = await asRouteResponse(mod.action({
       request: makeReq({ CallSid: "CA1", AnsweredBy: "machine_start", CallStatus: "ringing" }),
     } as any));
-    await expect(res.json()).resolves.toEqual({ success: true });
-    expect(sup2._callUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ twiml: expect.stringContaining("<Hangup/>") }),
-    );
+    await expect(res.json()).resolves.toMatchObject({
+      success: true,
+      attempt: expect.objectContaining({ answered_at: expect.any(String) }),
+    });
+    expect(sup2._callUpdate).not.toHaveBeenCalled();
 
-    // handler catch: outreach update errors -> returns success:false with message
+    // Still no signedUrl (fallthrough path) — outreach update errors ->
+    // returns success:false with message, same as the human-answer path.
     const { client: sup3, twilio: tw3 } = makeDbClient();
     sup3._set.outreachUpdateError(new Error("upd"));
     mocks.createClient.mockReturnValueOnce(sup3);
@@ -359,7 +366,7 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
     } as any));
     await expect(res.json()).resolves.toEqual({ success: false, error: "Error updating outreach attempt: upd" });
 
-    // handler catch: non-Error thrown -> "Failed to handle voicemail"
+    // Still no signedUrl (fallthrough path) — non-Error thrown.
     const { client: sup4, twilio: tw4 } = makeDbClient();
     sup4._set.outreachUpdateThrows("nope");
     mocks.createClient.mockReturnValueOnce(sup4);
@@ -368,6 +375,29 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
       request: makeReq({ CallSid: "CA1", AnsweredBy: "machine_start", CallStatus: "ringing" }),
     } as any));
     await expect(res.json()).resolves.toEqual({ success: false, error: "Error updating outreach attempt: Unknown error" });
+  });
+
+  // Regression for issue #1143: "ring ring ring, voicemail -> 'please leave
+  // your message at the tone' -> it hung up". Root cause was this exact
+  // shape — AMD detects a machine, the campaign has no voicemail-drop audio
+  // configured, and the old code hung up immediately with no message left.
+  // Decision: never auto-hang-up on AMD alone; only when there's an actual
+  // voicemail message to leave.
+  test("a campaign with no voicemail_file configured never hangs up on a detected machine", async () => {
+    const { client, twilio } = makeDbClient();
+    client._set.campaignRow({ voicemail_file: null });
+    mocks.createClient.mockReturnValueOnce(client);
+    mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce(twilio as any);
+    const mod = await import("../app/routes/api+/dial/status.route");
+
+    const res = await asRouteResponse(mod.action({
+      request: makeReq({ CallSid: "CA1", AnsweredBy: "machine_end_beep", CallStatus: "in-progress" }),
+    } as any));
+
+    await expect(res.json()).resolves.toMatchObject({ success: true });
+    expect(client._callUpdate).not.toHaveBeenCalled();
+    const patch = telephonyStubState.callUpdateCalls.at(-1)?.patch;
+    expect(patch).toMatchObject({ answered_by: "machine_end_beep" });
   });
 
   test("human/other path upserts call, updates attempt, and outer catch formats non-Error", async () => {
@@ -410,7 +440,7 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
     await expect(res.json()).resolves.toEqual({ success: false, error: "An unexpected error occurred" });
   });
 
-  test("covers campaign not found + no voicemail_file path + outreachError throw in voicemail-present path", async () => {
+  test("covers campaign not found + no voicemail_file falls through + outreachError throw in voicemail-present path", async () => {
     const mod = await import("../app/routes/api+/dial/status.route");
 
     // campaign not found
@@ -424,7 +454,8 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
     } as any));
     await expect(res.json()).resolves.toEqual({ success: false, error: "Campaign 1 not found" });
 
-    // voicemail_file falsy => ternary else branch and machine no-answer hangup path
+    // voicemail_file falsy => ternary else branch; falls through to the
+    // same "let it ring through" path as a human answer (issue #1143).
     const { client: sup2, twilio: tw2 } = makeDbClient();
     sup2._set.campaignRow({ voicemail_file: null });
     mocks.createClient.mockReturnValueOnce(sup2);
@@ -432,7 +463,11 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
     res = await asRouteResponse(mod.action({
       request: makeReq({ CallSid: "CA1", AnsweredBy: "machine_start", CallStatus: "ringing" }),
     } as any));
-    await expect(res.json()).resolves.toEqual({ success: true });
+    await expect(res.json()).resolves.toMatchObject({
+      success: true,
+      attempt: expect.objectContaining({ answered_at: expect.any(String) }),
+    });
+    expect(sup2._callUpdate).not.toHaveBeenCalled();
 
     // voicemail present but outreach update returns error => hits `if (outreachError) throw outreachError`
     const { client: sup3, twilio: tw3 } = makeDbClient();


### PR DESCRIPTION
Closes #1143

## Summary

Root cause: "ring ring ring, voicemail -> 'please leave your message at the tone' -> it hung up". Twilio's AMD detects a machine, the campaign has no voicemail-drop audio configured, and the handler responded by marking the disposition "no-answer" and immediately hanging up — the callee's own carrier voicemail greeting plays, we detect the machine, and hang up right at/after the beep instead of leaving any message.

**Product decision** (discussed and confirmed): a detected machine should never be auto-hung-up on AMD alone — only when there's an actual voicemail message to leave. When no voicemail-drop audio is configured for the campaign, the call now falls through to the exact same path as a human answer: no TwiML update at all, so the call's own `<Dial>` verb keeps running and rings through to the agent instead of being silently dropped.

Options considered and not taken: a generic fallback TTS message when no custom audio is set, or leaving the silent-hangup behavior and instead making voicemail-audio configuration more prominent in campaign setup. Both are viable follow-ups if the "ring through" behavior turns out not to be what agents want in practice.

## Test plan
- [x] `npm run ci:local` — exit 0
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:node` — 2447 passed, 0 failed
- [x] New regression test reproducing the exact reported shape (machine detected, no `voicemail_file`, asserts no Twilio TwiML update happens and `answered_by` is still recorded)
- [x] Updated the two existing tests that asserted the old hangup behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)