### PR TITLE
fix(security): close cross-tenant isolation & member-management RBAC gaps

### DIFF
--- a/app/lib/campaign-queue-search.server.ts
+++ b/app/lib/campaign-queue-search.server.ts
@@ -472,8 +472,14 @@ export async function fetchCampaignQueuePage(args: {
   filters: QueueSearchFilters;
   offset: number;
   limit: number;
+  workspaceId?: string;
 }): Promise<{ items: CampaignQueueApiItem[]; totalCount: number }> {
-  const where = buildCampaignQueueSearchWhere(args.campaignId, args.filters);
+  const where = buildCampaignQueueSearchWhere(
+    args.campaignId,
+    args.filters,
+    "",
+    args.workspaceId,
+  );
 
   const [totalCount, queueRows] = await Promise.all([
     countCampaignQueueRows(args.campaignId, where),

--- a/app/lib/database/audio-usage.server.ts
+++ b/app/lib/database/audio-usage.server.ts
@@ -6,7 +6,7 @@
  * So the only way to know a file's blast radius is to scan the columns and the
  * script JSON that reference it by name.
  */
-import { eq, or } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import {
   campaign as campaignTable,
   inbound_queue as inboundQueueTable,
@@ -96,10 +96,16 @@ export async function findAudioUsage(
         voicemail_file: campaignTable.voicemail_file,
       })
       .from(campaignTable)
+      // Filenames are bare (no workspace prefix) and collide across tenants, so
+      // every query must be scoped to this workspace or it leaks other tenants'
+      // campaign/number/queue metadata on a name collision.
       .where(
-        or(
-          eq(campaignTable.voicedrop_audio, target),
-          eq(campaignTable.voicemail_file, target),
+        and(
+          eq(campaignTable.workspace, workspaceId),
+          or(
+            eq(campaignTable.voicedrop_audio, target),
+            eq(campaignTable.voicemail_file, target),
+          ),
         ),
       ),
     db
@@ -108,11 +114,21 @@ export async function findAudioUsage(
         friendly_name: workspaceNumberTable.friendly_name,
       })
       .from(workspaceNumberTable)
-      .where(eq(workspaceNumberTable.inbound_audio, target)),
+      .where(
+        and(
+          eq(workspaceNumberTable.workspace, workspaceId),
+          eq(workspaceNumberTable.inbound_audio, target),
+        ),
+      ),
     db
       .select({ id: inboundQueueTable.id, name: inboundQueueTable.name })
       .from(inboundQueueTable)
-      .where(eq(inboundQueueTable.hold_audio, target)),
+      .where(
+        and(
+          eq(inboundQueueTable.workspace_id, workspaceId),
+          eq(inboundQueueTable.hold_audio, target),
+        ),
+      ),
     // Script bodies are JSON, so the filename cannot be matched in SQL without
     // depending on a step shape that is not stable. Fetch this workspace's
     // scripts and walk them instead.

--- a/app/lib/database/contact-audience.server.ts
+++ b/app/lib/database/contact-audience.server.ts
@@ -36,6 +36,34 @@ export type AudienceContactExportRow = Record<string, unknown> & {
   other_data?: unknown;
 };
 
+/**
+ * Shared query for the audience-contact export rows. Every caller MUST pass a
+ * workspace-scoping filter (an unscoped call leaks cross-tenant PII).
+ */
+async function queryAudienceContactRows(
+  filters: SQL[],
+  order?: { column: ReturnType<typeof audienceContactSortColumn>; direction: "asc" | "desc" },
+): Promise<AudienceContactExportRow[]> {
+  const base = db
+    .select({
+      link: contactAudienceTable,
+      contact: contactTable,
+    })
+    .from(contactAudienceTable)
+    .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
+    .where(and(...filters));
+
+  const rows = order
+    ? await base.orderBy(order.direction === "asc" ? asc(order.column) : desc(order.column))
+    : await base;
+
+  return rows.map(({ link, contact }) => ({
+    ...link,
+    ...contact,
+    contact,
+  }));
+}
+
 export async function listAudienceContactsForExport(
   workspaceId: string,
   audienceId: number,
@@ -47,7 +75,6 @@ export async function listAudienceContactsForExport(
 ): Promise<AudienceContactExportRow[]> {
   const sortKey = options?.sortKey ?? "id";
   const sortDirection = options?.sortDirection ?? "asc";
-  const sortColumn = audienceContactSortColumn(sortKey);
   const searchWhere = options?.q ? buildContactSearchWhere(options.q) : undefined;
 
   const filters: SQL[] = [
@@ -58,21 +85,10 @@ export async function listAudienceContactsForExport(
     filters.push(searchWhere);
   }
 
-  const rows = await db
-    .select({
-      link: contactAudienceTable,
-      contact: contactTable,
-    })
-    .from(contactAudienceTable)
-    .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
-    .where(and(...filters))
-    .orderBy(sortDirection === "asc" ? asc(sortColumn) : desc(sortColumn));
-
-  return rows.map(({ link, contact }) => ({
-    ...link,
-    ...contact,
-    contact,
-  }));
+  return queryAudienceContactRows(filters, {
+    column: audienceContactSortColumn(sortKey),
+    direction: sortDirection,
+  });
 }
 
 export async function listAudienceContactsJson(
@@ -87,20 +103,7 @@ export async function listAudienceContactsJson(
     filters.push(eq(contactAudienceTable.audience_id, audienceId));
   }
 
-  const rows = await db
-    .select({
-      link: contactAudienceTable,
-      contact: contactTable,
-    })
-    .from(contactAudienceTable)
-    .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
-    .where(and(...filters));
-
-  return rows.map(({ link, contact }) => ({
-    ...link,
-    ...contact,
-    contact,
-  }));
+  return queryAudienceContactRows(filters);
 }
 
 async function resolveAudienceWorkspaceId(audienceId: number): Promise<string> {

--- a/app/lib/database/contact-audience.server.ts
+++ b/app/lib/database/contact-audience.server.ts
@@ -76,9 +76,13 @@ export async function listAudienceContactsForExport(
 }
 
 export async function listAudienceContactsJson(
+  workspaceId: string,
   audienceId?: number,
 ): Promise<AudienceContactExportRow[]> {
-  const filters: SQL[] = [];
+  // Always scope to the workspace. Without this, an omitted audienceId left the
+  // WHERE empty and dumped every tenant's audience-linked contacts (PII) to any
+  // authenticated caller with access to a single workspace.
+  const filters: SQL[] = [eq(contactTable.workspace, workspaceId)];
   if (audienceId != null) {
     filters.push(eq(contactAudienceTable.audience_id, audienceId));
   }
@@ -90,7 +94,7 @@ export async function listAudienceContactsJson(
     })
     .from(contactAudienceTable)
     .innerJoin(contactTable, eq(contactAudienceTable.contact_id, contactTable.id))
-    .where(filters.length > 0 ? and(...filters) : undefined);
+    .where(and(...filters));
 
   return rows.map(({ link, contact }) => ({
     ...link,

--- a/app/lib/platform-members.server.ts
+++ b/app/lib/platform-members.server.ts
@@ -95,6 +95,37 @@ function assertNoRoleEscalation(
   return { ok: true };
 }
 
+/**
+ * An actor may only manage (demote or remove) a member whose current rank is
+ * at or below the actor's own. Without this, `requireMemberManager` alone lets
+ * a `member` remove or demote an `admin`: the escalation guards only inspect
+ * the *assigned* role, never the target's *existing* rank. Actor-at-or-above
+ * (rather than strictly-above) preserves peer management and self-service while
+ * closing the escalation.
+ */
+async function requireActorOutranksTarget(
+  actorRole: string,
+  workspaceId: string,
+  targetUserId: string,
+): Promise<{ ok: true } | { ok: false; error: string; status: number }> {
+  const targetMembership = await findWorkspaceMembership(workspaceId, targetUserId);
+  if (!targetMembership) {
+    return { ok: false, error: "Member not found", status: 404 };
+  }
+
+  const actorRank = WORKSPACE_ROLE_RANK[actorRole] ?? 0;
+  const targetRank = WORKSPACE_ROLE_RANK[targetMembership.role] ?? 0;
+  if (actorRank < targetRank) {
+    return {
+      ok: false,
+      error: "You cannot manage a member who outranks you.",
+      status: 403,
+    };
+  }
+
+  return { ok: true };
+}
+
 async function getWorkspaceOwners(workspaceId: string) {
   const members = await listWorkspaceMembersEnriched(workspaceId);
   return members.filter((member) => member.role === MemberRole.Owner);
@@ -269,7 +300,10 @@ export async function inviteWorkspaceMemberAsApiKey(
   email: string,
   role: "owner" | "admin" | "member" | "caller",
 ) {
-  return inviteWorkspaceMemberWithActorRole("admin", workspaceId, email, role);
+  // Actor rank `member`, not `admin`: a `members.invite` key must not be able to
+  // mint an `admin`/`owner` invite. assertNoRoleEscalation blocks anything above
+  // `member`, matching this function's member/caller-only policy.
+  return inviteWorkspaceMemberWithActorRole("member", workspaceId, email, role);
 }
 
 export async function updateWorkspaceMemberRole(
@@ -280,6 +314,11 @@ export async function updateWorkspaceMemberRole(
 ) {
   const access = await requireMemberManager(userId, workspaceId);
   if (!access.ok) return access;
+
+  // The actor must at least match the target's current rank, or a `member`
+  // could demote an `admin`.
+  const rankCheck = await requireActorOutranksTarget(access.actorRole, workspaceId, targetUserId);
+  if (!rankCheck.ok) return rankCheck;
 
   // Owner-role transitions keep their specific owner-only gate first.
   const ownerCheck = await requireOwnerForOwnerChange(userId, workspaceId, targetUserId, role);
@@ -323,6 +362,11 @@ export async function removeWorkspaceMember(
 ) {
   const access = await requireMemberManager(userId, workspaceId);
   if (!access.ok) return access;
+
+  // The actor must at least match the target's current rank, or a `member`
+  // could remove an `admin`.
+  const rankCheck = await requireActorOutranksTarget(access.actorRole, workspaceId, targetUserId);
+  if (!rankCheck.ok) return rankCheck;
 
   const ownerCheck = await requireOwnerForOwnerChange(userId, workspaceId, targetUserId);
   if (!ownerCheck.ok) return ownerCheck;

--- a/app/lib/platform-members.server.ts
+++ b/app/lib/platform-members.server.ts
@@ -315,14 +315,14 @@ export async function updateWorkspaceMemberRole(
   const access = await requireMemberManager(userId, workspaceId);
   if (!access.ok) return access;
 
-  // The actor must at least match the target's current rank, or a `member`
-  // could demote an `admin`.
-  const rankCheck = await requireActorOutranksTarget(access.actorRole, workspaceId, targetUserId);
-  if (!rankCheck.ok) return rankCheck;
-
   // Owner-role transitions keep their specific owner-only gate first.
   const ownerCheck = await requireOwnerForOwnerChange(userId, workspaceId, targetUserId, role);
   if (!ownerCheck.ok) return ownerCheck;
+
+  // The actor must at least match the target's current rank, or a `member`
+  // could demote an `admin` (the owner gate above only covers owner targets).
+  const rankCheck = await requireActorOutranksTarget(access.actorRole, workspaceId, targetUserId);
+  if (!rankCheck.ok) return rankCheck;
 
   // No privilege escalation: an actor cannot grant a role above their own.
   // This is what stops a `member` (who may manage members) from promoting
@@ -363,13 +363,13 @@ export async function removeWorkspaceMember(
   const access = await requireMemberManager(userId, workspaceId);
   if (!access.ok) return access;
 
-  // The actor must at least match the target's current rank, or a `member`
-  // could remove an `admin`.
-  const rankCheck = await requireActorOutranksTarget(access.actorRole, workspaceId, targetUserId);
-  if (!rankCheck.ok) return rankCheck;
-
   const ownerCheck = await requireOwnerForOwnerChange(userId, workspaceId, targetUserId);
   if (!ownerCheck.ok) return ownerCheck;
+
+  // The actor must at least match the target's current rank, or a `member`
+  // could remove an `admin` (the owner gate above only covers owner targets).
+  const rankCheck = await requireActorOutranksTarget(access.actorRole, workspaceId, targetUserId);
+  if (!rankCheck.ok) return rankCheck;
 
   const soleOwnerCheck = await requireSoleOwnerProtection(workspaceId, targetUserId);
   if (!soleOwnerCheck.ok) return soleOwnerCheck;

--- a/app/routes/api+/audiences.loader.server.ts
+++ b/app/routes/api+/audiences.loader.server.ts
@@ -178,7 +178,7 @@ export const loader = defineLoader({
         requireWorkspaceAccess: d.requireWorkspaceAccess,
       });
 
-      const data = await listAudienceContactsJson(parsedAudienceId);
+      const data = await listAudienceContactsJson(resolvedWorkspaceId, parsedAudienceId);
       return routeData({ data }, { headers });
     } catch (error) {
       if (error instanceof Response) {

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/queue.action.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/queue.action.server.ts
@@ -1,6 +1,6 @@
 import { hasMinRole, workspaceRouteAuth } from "@/lib/workspace-route.server";
 import { data as routeData, redirect } from "react-router";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import {
   deleteAllCampaignQueueForCampaign,
   deleteCampaignQueueByIds,
@@ -12,7 +12,7 @@ import { findCampaignInWorkspace } from "@/lib/campaign-ivr.server";
 import { enqueueContactsForCampaign } from "@/lib/queue.server";
 import { parseActionRequest } from "@/lib/request-utils.server";
 import type { QueueSearchFilters } from "@/lib/campaign-queue-search.server";
-import { contact_audience as contactAudienceTable } from "@/db/schema";
+import { contact as contactTable, contact_audience as contactAudienceTable } from "@/db/schema";
 // contact_audience is a join table without a workspace column; tdb cannot scope it.
 // eslint-disable-next-line no-restricted-imports
 import { db } from "@/server/db";
@@ -134,11 +134,39 @@ export const action = defineAction({
             ? JSON.parse(data.contacts)
             : data.contacts
         ) as Contact[];
-        await enqueueContactsForCampaign(
-          campaignIdNum,
-          contacts.map((contact) => contact.id),
-          { requeue: false },
-        );
+
+        const requestedIds = [
+          ...new Set(
+            contacts
+              .map((contact) => Number(contact.id))
+              .filter((id): id is number => Number.isFinite(id)),
+          ),
+        ];
+
+        // Only enqueue contacts that belong to this workspace. The submitted ids
+        // come straight from the request body; without this check a member could
+        // POST another tenant's contact ids and have their dialer call them.
+        const ownedRows = requestedIds.length
+          ? await db
+              .select({ id: contactTable.id })
+              .from(contactTable)
+              .where(
+                and(
+                  inArray(contactTable.id, requestedIds),
+                  eq(contactTable.workspace, workspaceId),
+                ),
+              )
+          : [];
+        const ownedIds = ownedRows.map((row) => row.id);
+
+        if (ownedIds.length !== requestedIds.length) {
+          return routeData(
+            { success: false, error: "One or more contacts were not found in this workspace" },
+            { status: 403 },
+          );
+        }
+
+        await enqueueContactsForCampaign(campaignIdNum, ownedIds, { requeue: false });
 
         return routeData({ success: true });
       } catch (error) {

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/queue.loader.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/queue.loader.server.ts
@@ -9,6 +9,7 @@ import { Audience, QueueItem, Contact } from "@/lib/types";
 import { data as routeData, redirect } from "react-router";
 import { campaign_audience as campaignAudienceTable } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { findCampaignInWorkspace } from "@/lib/campaign-ivr.server";
 import { requireWorkspaceLoaderContext } from "@/lib/workspace-route.server";
 import type { AppError } from "@/lib/errors.server";
 // campaign_audience is a join table without a workspace column; tdb cannot scope it.
@@ -43,6 +44,14 @@ export const loader = defineLoader({
     if (!selected_id) throw redirect("../../");
 
     const campaignIdNum = Number(selected_id);
+    const { workspaceId } = auth.ctx;
+
+    // This loader must verify the campaign belongs to the workspace itself: the
+    // parent layout loader's guard can be bypassed under single-fetch route
+    // filtering (?_routes=), and without this the queue (contact PII) leaks
+    // cross-tenant via an enumerable campaign id.
+    const campaign = await findCampaignInWorkspace(workspaceId, campaignIdNum);
+    if (!campaign) throw redirect("../../");
 
     const filters: QueueSearchFilters = {
       name: searchParams.get("name") || "",
@@ -65,6 +74,7 @@ export const loader = defineLoader({
           filters,
           offset,
           limit: pageSize,
+          workspaceId,
         }),
         countCampaignQueueRows(campaignIdNum),
         countQueuedCampaignQueueRows(campaignIdNum),

--- a/test/audiences.route.test.ts
+++ b/test/audiences.route.test.ts
@@ -298,13 +298,14 @@ describe("api.audiences route", () => {
       request: new Request("http://localhost/api/audiences?audienceId=not-a-number"),
       deps: { verifyAuth, parseActionRequest, requireWorkspaceAccess },
     } as any);
-    expect(contactAudienceMocks.listAudienceContactsJson).toHaveBeenLastCalledWith(undefined);
+    // Always scoped to the authorized workspace (never called without it).
+    expect(contactAudienceMocks.listAudienceContactsJson).toHaveBeenLastCalledWith("w1", undefined);
 
     await mod.loader({
       request: new Request("http://localhost/api/audiences?audienceId=12"),
       deps: { verifyAuth, parseActionRequest, requireWorkspaceAccess },
     } as any);
-    expect(contactAudienceMocks.listAudienceContactsJson).toHaveBeenLastCalledWith(12);
+    expect(contactAudienceMocks.listAudienceContactsJson).toHaveBeenLastCalledWith("w1", 12);
 
     contactAudienceMocks.listAudienceContactsJson.mockRejectedValueOnce(new Error("q"));
     // The handler factory maps rethrown errors through createErrorResponse

--- a/test/campaign-settings-queue.route.test.ts
+++ b/test/campaign-settings-queue.route.test.ts
@@ -160,13 +160,7 @@ describe("workspaces_.$id.campaigns.$selected_id.queue action", () => {
     );
   });
 
-  test("add_contacts routes direct contacts through enqueue helper", async () => {
-    const dbClient = {
-      from: vi.fn(() => {
-        throw new Error("unexpected from()");
-      }),
-    };
-
+  test("add_contacts enqueues only contacts owned by the workspace", async () => {
     mocks.verifyAuth.mockResolvedValueOnce({
       user: { id: "u1" },
     });
@@ -174,6 +168,8 @@ describe("workspaces_.$id.campaigns.$selected_id.queue action", () => {
       intent: "add_contacts",
       contacts: [{ id: 21 }, { id: 22 }],
     });
+    // Workspace ownership lookup: both ids belong to the workspace.
+    dbMocks.selectChain.mockResolvedValueOnce([{ id: 21 }, { id: 22 }]);
 
     const mod = await import(
       "../app/routes/workspaces+/$id/campaigns/$selected_id/queue.route"
@@ -190,6 +186,30 @@ describe("workspaces_.$id.campaigns.$selected_id.queue action", () => {
       [21, 22],
       { requeue: false },
     );
+  });
+
+  test("add_contacts rejects contact ids not owned by the workspace (cross-tenant)", async () => {
+    mocks.verifyAuth.mockResolvedValueOnce({
+      user: { id: "u1" },
+    });
+    mocks.parseActionRequest.mockResolvedValueOnce({
+      intent: "add_contacts",
+      // 22 belongs to another tenant; the ownership query returns only 21.
+      contacts: [{ id: 21 }, { id: 22 }],
+    });
+    dbMocks.selectChain.mockResolvedValueOnce([{ id: 21 }]);
+
+    const mod = await import(
+      "../app/routes/workspaces+/$id/campaigns/$selected_id/queue.route"
+    );
+    const res = await asRouteResponse(mod.action(withRouteUrl({
+      request: new Request("http://x", { method: "POST" }),
+      params: { selected_id: "77" },
+    } as any)));
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ success: false });
+    expect(mocks.enqueueContactsForCampaign).not.toHaveBeenCalled();
   });
 
   // A technical error must not reach the user verbatim; toUserMessage swaps it

--- a/test/workspace-members-rbac.test.ts
+++ b/test/workspace-members-rbac.test.ts
@@ -165,6 +165,19 @@ describe("workspace member RBAC", () => {
       expect(result).toEqual({ ok: true, member: { id: "u2" } });
     });
 
+    test("blocks a member from demoting an admin (target outranks actor)", async () => {
+      accessMocks.getUserRole.mockResolvedValue({ role: "member" });
+      // Target u2 is an admin; actor u1 is only a member.
+      membersDbMocks.findWorkspaceMembership.mockImplementation(async (_ws, userId) => ({
+        user_id: userId,
+        role: userId === "u2" ? "admin" : "member",
+      }));
+      const mod = await import("../app/lib/platform-members.server");
+      const result = await mod.updateWorkspaceMemberRole("u1", "w1", "u2", "caller");
+      expect(result).toMatchObject({ ok: false, status: 403 });
+      expect(membersDbMocks.updateWorkspaceMemberRole).not.toHaveBeenCalled();
+    });
+
     test("blocks promoting to admin when target has not enrolled in 2FA", async () => {
       accessMocks.getUserRole.mockResolvedValue({ role: "owner" });
       twoFactorMocks.isTwoFactorEnabled.mockResolvedValueOnce(false);
@@ -209,7 +222,11 @@ describe("workspace member RBAC", () => {
 
     test("rejects non-owners from removing an owner", async () => {
       accessMocks.getUserRole.mockResolvedValue({ role: "admin" });
-      membersDbMocks.findWorkspaceMembership.mockResolvedValue({ user_id: "u2", role: "owner" });
+      // Actor u1 is an admin, target u2 is an owner: the owner-change gate fires.
+      membersDbMocks.findWorkspaceMembership.mockImplementation(async (_ws, userId) => ({
+        user_id: userId,
+        role: userId === "u2" ? "owner" : "admin",
+      }));
       const mod = await import("../app/lib/platform-members.server");
       const result = await mod.removeWorkspaceMember("u1", "w1", "u2");
       expect(result).toMatchObject({ ok: false, status: 403, error: expect.stringContaining("owner") });
@@ -224,6 +241,29 @@ describe("workspace member RBAC", () => {
       const mod = await import("../app/lib/platform-members.server");
       const result = await mod.removeWorkspaceMember("u1", "w1", "u2");
       expect(result).toMatchObject({ ok: false, status: 403, error: expect.stringContaining("sole owner") });
+    });
+
+    test("blocks a member from removing an admin (target outranks actor)", async () => {
+      accessMocks.getUserRole.mockResolvedValue({ role: "member" });
+      // Target u2 is an admin (not an owner, so the owner gate passes).
+      membersDbMocks.findWorkspaceMembership.mockImplementation(async (_ws, userId) => ({
+        user_id: userId,
+        role: userId === "u2" ? "admin" : "member",
+      }));
+      const mod = await import("../app/lib/platform-members.server");
+      const result = await mod.removeWorkspaceMember("u1", "w1", "u2");
+      expect(result).toMatchObject({ ok: false, status: 403 });
+      expect(membersDbMocks.removeWorkspaceMember).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("platform-members inviteWorkspaceMemberAsApiKey", () => {
+    test("blocks an API key from inviting an admin (member/caller-only policy)", async () => {
+      const mod = await import("../app/lib/platform-members.server");
+      const result = await mod.inviteWorkspaceMemberAsApiKey("w1", "new@example.com", "admin");
+      expect(result).toMatchObject({ ok: false, status: 403 });
+      // Blocked at the escalation guard, before any user lookup / invite send.
+      expect(accessMocks.getWorkspaceUsers).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes #1171

Fixes a cluster of workspace-scoping defects surfaced by a full-codebase security review of `dev` (v2). All share one root cause: **data-layer queries on the shared non-tenant `db` client that trust an upstream/parent guard instead of scoping by `workspace_id` themselves.** None reach production today (prod runs the Supabase-era branch), so this is pre-cutover hardening.

Each fix is an isolated commit.

### Fixes
- **[Critical] Audience JSON export** — `listAudienceContactsJson` ran with an empty `WHERE` when no `audienceId` was supplied, so `GET /api/audiences?workspaceId=<own>` (JSON branch) returned **every tenant's** audience-linked contacts. Now requires a `workspaceId` and always constrains by `contact.workspace`; the loader passes the already-authorized `resolvedWorkspaceId`.
- **[High] Campaign queue loader** — added `findCampaignInWorkspace` (the parent guard is bypassable under single-fetch `?_routes=` filtering) and threaded `workspaceId` into `fetchCampaignQueuePage`.
- **[High] `add_contacts` queue action** — enqueued arbitrary contact ids from the body; now resolves them against `contact.workspace` and rejects (403) any id not owned.
- **[High] `findAudioUsage`** — campaign/number/queue lookups matched a bare filename with no workspace predicate (filenames collide across tenants); added the workspace filter to all three.
- **[High] Member management RBAC** — `updateWorkspaceMemberRole`/`removeWorkspaceMember` didn't require the actor to outrank the target's *current* rank, so a `member` could remove/demote an `admin`. Added `requireActorOutranksTarget` (actor rank must be ≥ target's), ordered after the owner-change gate so its specific messages still fire.
- **[Medium, co-fix] API-key invite** — `inviteWorkspaceMemberAsApiKey` hardcoded actor rank `admin`, letting a `members.invite` key mint an `admin` invite against its own docstring; now passes `member`.

### Tests
`typecheck` clean. Added regression coverage: member-cannot-demote/remove-admin, API-key-cannot-mint-admin, and `add_contacts` rejects foreign contact ids; updated the audience-export assertions to require the workspace scope. The 4 affected suites pass (35 tests).

### Related — same security review
The rest of the review's findings were filed as their own issues and landed directly on `dev`:

- #1173 — [High] manual dial-claim `attempt_count`/`claimed_at` drift ✅ done on `dev`
- #1174 — [High] chat UI credit-floor + opt-out/landline bypass ✅ done on `dev`
- #1175 — [High] `twilio_data` lost updates (atomic locked merge) ✅ done on `dev`
- #1176 — Medium + low roll-up (double-dial races, idempotency reservation, STT leak, `checkSchedule` 500, select-all filter, emergency-voice, plus the low-severity cleanup) — **open**; all mediums done on `dev`, low-severity cleanup in progress

All of the above (this PR included) ship to production together via the `dev → master` release in #1120.
