### PR TITLE
Fix new workspace onboarding starting step

### DIFF
--- a/app/lib/database/workspace-provisioning.server.ts
+++ b/app/lib/database/workspace-provisioning.server.ts
@@ -153,7 +153,7 @@ export async function createNewWorkspace({
           status: "provisioning",
         },
         status: "provisioning",
-        currentStep: "business_identity",
+        currentStep: "path_selection",
         lastUpdatedBy: user_id,
       },
     );

--- a/app/lib/messaging-onboarding/normalize.server.ts
+++ b/app/lib/messaging-onboarding/normalize.server.ts
@@ -42,7 +42,7 @@ export {
 export const DEFAULT_WORKSPACE_MESSAGING_ONBOARDING_STATE: WorkspaceMessagingOnboardingState = {
   version: WORKSPACE_MESSAGING_ONBOARDING_VERSION,
   status: "not_started",
-  currentStep: "business_identity",
+  currentStep: "path_selection",
   operatingCountry: "CA",
   selectedChannels: [],
   selectedGoal: null,
@@ -227,7 +227,7 @@ export function normalizeWorkspaceMessagingOnboardingState(
       WORKSPACE_ONBOARDING_STATUS_VALUES,
       "not_started",
     ),
-    currentStep: parseOptionalString(value.currentStep) ?? "business_identity",
+  currentStep: parseOptionalString(value.currentStep) ?? "path_selection",
     operatingCountry: pickEnumValue(
       value.operatingCountry,
       WORKSPACE_OPERATING_COUNTRY_VALUES,

--- a/app/lib/messaging-onboarding/wizard-steps.ts
+++ b/app/lib/messaging-onboarding/wizard-steps.ts
@@ -31,9 +31,9 @@ export function isWizardOnboardingStepId(value: string): value is WizardOnboardi
 export function resolvePersistedWizardStep(
   currentStep: string | null | undefined,
 ): WizardOnboardingStepId {
-  if (!currentStep) return "business_identity";
+  if (!currentStep) return "path_selection";
   if (isWizardOnboardingStepId(currentStep)) return currentStep;
   const redirected = LEGACY_WIZARD_STEP_REDIRECTS[currentStep];
   if (redirected) return redirected;
-  return "business_identity";
+  return "path_selection";
 }

--- a/test/messaging-onboarding.server.test.ts
+++ b/test/messaging-onboarding.server.test.ts
@@ -268,7 +268,7 @@ describe("messaging onboarding helpers", () => {
       "bad" as any,
     );
 
-    expect(fromNull.currentStep).toBe("business_identity");
+    expect(fromNull.currentStep).toBe("path_selection");
     expect(fromPrimitive.selectedChannels).toEqual([]);
   });
 
@@ -345,7 +345,7 @@ describe("messaging onboarding helpers", () => {
     const loaded = await getWorkspaceMessagingOnboardingState({
       workspaceId: "w1",
     });
-    expect(loaded.currentStep).toBe("business_identity");
+    expect(loaded.currentStep).toBe("path_selection");
 
     const updated = await updateWorkspaceMessagingOnboardingState({
       workspaceId: "w1",

--- a/test/onboarding-business-profile-validation.test.ts
+++ b/test/onboarding-business-profile-validation.test.ts
@@ -230,7 +230,7 @@ describe("save_business_profile validation", () => {
 
   test("maps legacy business_profile persisted step to business_identity", () => {
     expect(resolvePersistedWizardStep("business_profile")).toBe("business_identity");
-    expect(resolvePersistedWizardStep(null)).toBe("business_identity");
+    expect(resolvePersistedWizardStep(null)).toBe("path_selection");
   });
 
   test("rejects an empty identity submit instead of advancing", async () => {


### PR DESCRIPTION
## Summary
- Start newly provisioned workspaces at the goal-first onboarding step.
- Preserve legacy persisted `business_identity` steps for existing workspaces.
- Update onboarding fallback coverage for the new default.

## Verification
- 49 focused onboarding tests passed
- `npm run typecheck`
- Targeted ESLint checks

Rebased onto the latest `origin/dev` before pushing.