### PR TITLE
fix: inbound IVR say, toUserMessage allowlist, derive webhook coverage (#1176)

### DIFF
--- a/app/lib/user-message.ts
+++ b/app/lib/user-message.ts
@@ -2,47 +2,26 @@
  * Convert an unknown thrown value into a safe, user-facing message.
  *
  * Intent: our own code throws intentional, human-readable errors
- * ("Campaign name is required"). Infrastructure errors (Supabase/Postgres,
+ * ("Campaign name is required"). Infrastructure errors (Postgres,
  * fetch failures, type errors) leak internals and confuse users. This helper
  * passes through the former and replaces the latter with a caller-supplied
  * fallback. Use `getErrorDetail` to log the raw message server-side.
+ *
+ * The implementation uses an allowlist-first approach:
+ * 1. The message must look like intentional product copy (sentence-like).
+ * 2. A compact deny list catches known infra patterns that happen to look
+ *    like English (e.g. "Connection terminated unexpectedly").
+ * 3. Default is fallback — only intentional copy and known border cases pass.
  */
 
-/** Substrings that mark a message as technical/internal, never user-facing. */
-const TECHNICAL_MARKERS = [
-  "supabase",
-  "fetch failed",
-  "typeerror",
-  "referenceerror",
-  "syntaxerror",
-  "pgrst",
-  "duplicate key",
-  "violates",
-  "econn",
-  "etimedout",
-  "enotfound",
-  "undefined",
-  "null",
-  "{",
-  "\n    at ", // stack frame
-  // Connection/pool/socket failures read as capitalized plain English and
-  // otherwise slip through (e.g. "Connection terminated unexpectedly").
-  "connection terminated",
-  "connection reset",
-  "connection closed",
-  "terminated unexpectedly",
-  "socket hang up",
-  "epipe",
-  "the pool",
-  "timeout exceeded",
-  "query read timeout",
-];
+const ALLOW_SENTENCE_RE = /^[A-Z][A-Za-z0-9 '(),./:;!?-]{0,138}[.!]?$/;
+
+const INFRA_DENY = /econn|pgrst|duplicate key|typeerror|referenceerror|syntaxerror|fetch failed|supabase|connection (terminated|reset|closed)|timeout exceeded|query read timeout|terminated unexpectedly|socket hang|epipe|the pool/i;
 
 function isLikelyUserFacing(message: string): boolean {
   if (!message || message.length >= 140) return false;
-  if (!/^[A-Z]/.test(message)) return false;
-  const lower = message.toLowerCase();
-  return !TECHNICAL_MARKERS.some((marker) => lower.includes(marker));
+  if (!ALLOW_SENTENCE_RE.test(message)) return false;
+  return !INFRA_DENY.test(message);
 }
 
 /**

--- a/app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.action.server.ts
+++ b/app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.action.server.ts
@@ -170,10 +170,10 @@ export const action = defineAction({
       baseUrl,
     );
   } catch (e) {
-    const errorMessage =
-      e instanceof Error ? e.message : "An error occurred. Please try again later.";
+    // Never read raw internal error text aloud to the caller — log it and speak
+    // a fixed generic message instead.
     logger.error("Inbound IVR Error:", e);
-    twiml.say(errorMessage);
+    twiml.say("Sorry, we ran into a problem. Please try again later. Goodbye.");
     twiml.hangup();
   }
 

--- a/scripts/check-twilio-webhook-coverage.mjs
+++ b/scripts/check-twilio-webhook-coverage.mjs
@@ -1,29 +1,22 @@
 #!/usr/bin/env node
 /**
- * Static audit: Twilio-facing Remix routes must import a signature validator.
- * Exit 1 when a route is missing validation (Phase 3 webhook hardening inventory).
+ * Static audit: Twilio-facing action routes must import a signature validator.
+ *
+ * The expected webhook list is DERIVED from the API surface registry (files
+ * matching app/lib/api-surface-*.ts): every entry with authClass "twilioSignature"
+ * and a POST operation maps to an action file. A small secondary check catches
+ * routes that validate Twilio signatures but aren't classified "twilioSignature"
+ * in the registry (they are reported but still validated).
  */
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const ROOT = join(import.meta.dirname, "..");
 const API_DIR = join(ROOT, "app/routes/api+");
+const SURFACE_DIR = join(ROOT, "app/lib");
+const SURFACE_PATTERN = /^api-surface-.+\.ts$/;
 
-/**
- * Constructs that actually authenticate a TWILIO request.
- *
- * Deliberately narrow. This list previously also accepted `requireWorkspaceAccess`,
- * `verifyAuth`, `verifyApiKey` and `safeOutboundUrl`. None of those proves a
- * request came from Twilio: the first three prove a *session or API key*, which
- * an inbound webhook never carries, and `safeOutboundUrl` is an EGRESS SSRF
- * guard that says nothing about the inbound request at all. With them present, a
- * route could swap its signature check for a session check and stay green — the
- * guard would report success on a webhook anyone could forge.
- *
- * Every route inventoried below was verified to use one of these before the
- * broader patterns were removed, so this narrowing changed no result today. It
- * closes the false pass, not a live hole.
- */
+/** Constructs that actually authenticate a TWILIO request. */
 const VALIDATION_PATTERNS = [
   /requireTwilioSignature/,
   /requireTwilioEventsSinkSecret/,
@@ -41,37 +34,52 @@ const EXCLUDED_SUFFIXES = [
   "error-report.action.server.ts",
 ];
 
-/** Twilio webhook handlers (POST from Twilio). Loader-only conference connect validated separately. */
-const TWILIO_WEBHOOK_SUFFIXES = [
-  "acd-router.action.server.ts",
-  "acd-router/agent-bridge.action.server.ts",
-  "acd-router/agent-status.action.server.ts",
-  "acd-router/complete.action.server.ts",
-  "call.action.server.ts",
-  "inbound.action.server.ts",
-  "inbound-sms.action.server.ts",
-  "inbound-verification.action.server.ts",
-  "inbound-handset.action.server.ts",
-  "inbound-handset-dial-end.action.server.ts",
-  "inbound-ivr/$numberId/$pageId.action.server.ts",
-  "inbound-ivr/$numberId/$pageId/$blockId.action.server.ts",
-  "inbound-ivr/$numberId/$pageId/$blockId/response.action.server.ts",
-  "sms/status.action.server.ts",
-  "call-status.action.server.ts",
-  "dial/$number.action.server.ts",
-  "dial/status.action.server.ts",
-  "auto-dial/status.action.server.ts",
-  "auto-dial/$roomId.action.server.ts",
-  "recording.action.server.ts",
-  "email-vm.action.server.ts",
-  "caller-id/status.action.server.ts",
-  "ivr/status.action.server.ts",
-  "ivr/$campaignId/$pageId.action.server.ts",
-  "ivr/$campaignId/$pageId/$blockId.action.server.ts",
-  "ivr/$campaignId/$pageId/$blockId/response.action.server.ts",
-  "twilio/trusthub/status.action.server.ts",
-  "twilio/a2p/events.action.server.ts",
-];
+/**
+ * Parse all API surface TS files and extract action file paths for entries
+ * with authClass "twilioSignature" and a POST operation.
+ */
+function deriveExpectedTwilioActionFiles() {
+  const entries = readdirSync(SURFACE_DIR).filter((f) => SURFACE_PATTERN.test(f));
+  const actionFiles = new Set();
+
+  for (const file of entries) {
+    const source = readFileSync(join(SURFACE_DIR, file), "utf8");
+    const seedBlocks = source.match(/[a-zA-Z]*[Ss]eed\(\{[\s\S]*?\}\)\s*[,;]/g) ?? [];
+
+    for (const block of seedBlocks) {
+      if (!/"twilioSignature"/.test(block)) continue;
+      if (!/method:\s*"POST"/.test(block)) continue;
+
+      const rmMatch = block.match(/routeModule:\s*"([^"]+)"/);
+      if (!rmMatch) continue;
+
+      const routeModule = rmMatch[1];
+      const rel = routeModule.replace(/^app\/routes\/api\+/, "").replace(/^\//, "");
+      const actionRel = rel
+        .replace(/\.route\.tsx$/, ".action.server.ts")
+        .replace(/\.tsx$/, ".action.server.ts");
+      actionFiles.add(actionRel);
+    }
+  }
+
+  return [...actionFiles].sort();
+}
+
+/**
+ * Scan action files under API_DIR for import/usage of VALIDATION_PATTERNS.
+ * Returns files that validate Twilio signatures but aren't in the expected-twilio set.
+ */
+function findUnregisteredValidators(registeredTwilioRoutes) {
+  const allActionFiles = collectActionFiles(API_DIR);
+  const registered = new Set(registeredTwilioRoutes);
+
+  return allActionFiles.filter((rel) => {
+    if (EXCLUDED_SUFFIXES.some((s) => rel.endsWith(s))) return false;
+    if (registered.has(rel)) return false;
+    const source = readFileSync(join(API_DIR, rel), "utf8");
+    return VALIDATION_PATTERNS.some((p) => p.test(source));
+  });
+}
 
 function collectActionFiles(dir, prefix = "") {
   const files = [];
@@ -87,19 +95,16 @@ function collectActionFiles(dir, prefix = "") {
   return files;
 }
 
-function isTwilioWebhook(relPath) {
-  if (EXCLUDED_SUFFIXES.some((suffix) => relPath.endsWith(suffix))) {
-    return false;
-  }
-  return TWILIO_WEBHOOK_SUFFIXES.some((suffix) => relPath.endsWith(suffix));
-}
-
 function hasValidation(source) {
   return VALIDATION_PATTERNS.some((pattern) => pattern.test(source));
 }
 
+const expectedTwilioRoutes = deriveExpectedTwilioActionFiles();
 const actionFiles = collectActionFiles(API_DIR);
-const twilioRoutes = actionFiles.filter(isTwilioWebhook);
+
+// Filter the derived list to only files that actually exist on disk
+const twilioRoutes = expectedTwilioRoutes.filter((rel) => actionFiles.includes(rel));
+
 const missing = [];
 
 for (const rel of twilioRoutes) {
@@ -109,6 +114,8 @@ for (const rel of twilioRoutes) {
   }
 }
 
+// Check the connect-campaign-conference loader (GET-only, registered as twilioSignature
+// in the API surface but has no POST — checked separately by its loader file).
 const loaderPath = join(
   API_DIR,
   "connect-campaign-conference/$workspaceId/$campaignId.loader.server.ts",
@@ -121,8 +128,28 @@ try {
   loaderOk = false;
 }
 
+// Report any routes that validate Twilio but aren't registered as twilioSignature
+const unregistered = findUnregisteredValidators(twilioRoutes);
+
 console.log(`Twilio webhook routes scanned: ${twilioRoutes.length}`);
+console.log(`Derived from api-surface registry: ${expectedTwilioRoutes.length} entries`);
 console.log(`connect-campaign-conference loader validated: ${loaderOk ? "yes" : "NO"}`);
+
+if (unregistered.length > 0) {
+  console.log(
+    `\nWARNING: ${unregistered.length} route(s) validate Twilio signatures but are not registered as authClass "twilioSignature":`,
+  );
+  for (const route of unregistered) {
+    console.log(`  - ${route} (still validated)`);
+  }
+  // Also check these for validation even though they're unregistered
+  for (const rel of unregistered) {
+    const source = readFileSync(join(API_DIR, rel), "utf8");
+    if (!hasValidation(source)) {
+      missing.push(rel);
+    }
+  }
+}
 
 if (missing.length > 0) {
   console.error("\nMissing Twilio signature validation:");

--- a/test/inbound-ivr-block-response.route.test.ts
+++ b/test/inbound-ivr-block-response.route.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  requireTwilioSignatureForIvrResponse: vi.fn(),
+  env: {
+    BASE_URL: () => "https://base.example",
+  },
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  findCallBySid: vi.fn(),
+  loadInboundIvrBlockContext: vi.fn(),
+}));
+
+vi.mock("@client/client-js", () => ({ createClient: (...a: unknown[]) => mocks.createClient(...a) }));
+vi.mock("@/lib/ivr-webhook-auth.server", () => ({
+  requireTwilioSignatureForIvrResponse: (...a: unknown[]) =>
+    mocks.requireTwilioSignatureForIvrResponse(...a),
+}));
+vi.mock("@/lib/env.server", () => ({ env: mocks.env }));
+vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
+vi.mock("@/lib/telephony-db.server", () => ({
+  findCallBySid: (...a: unknown[]) => mocks.findCallBySid(...a),
+}));
+vi.mock("@/lib/inbound-ivr-db.server", () => ({
+  loadInboundIvrBlockContext: (...a: unknown[]) => mocks.loadInboundIvrBlockContext(...a),
+}));
+
+vi.mock("twilio", () => {
+  class VoiceResponse {
+    private parts: string[] = [];
+    redirect(u: string) {
+      this.parts.push(`redirect:${u}`);
+    }
+    say(t: string) {
+      this.parts.push(`say:${t}`);
+    }
+    hangup() {
+      this.parts.push("hangup");
+    }
+    enqueue() {
+      const q = { queue: (_name: string) => {} };
+      return q;
+    }
+    dial() {
+      return { number: (_p: string) => {} };
+    }
+    toString() {
+      return `<Response>${this.parts.join("|")}</Response>`;
+    }
+  }
+  return { default: { twiml: { VoiceResponse } } };
+});
+
+function makeReq(form: Record<string, string>) {
+  const params = new URLSearchParams(form);
+  return new Request("https://base.example/api/inbound-ivr/1/page_1/b1/", {
+    method: "POST",
+    body: params,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.requireTwilioSignatureForIvrResponse.mockImplementation(
+    async () => ({ callSid: "CA1", userInput: "1" }),
+  );
+  mocks.findCallBySid.mockResolvedValue({
+    sid: "CA1",
+    to: "+15551234567",
+    workspace: "w1",
+  });
+  mocks.loadInboundIvrBlockContext.mockResolvedValue({
+    number: { phoneNumber: "+15551234567", workspaceId: "w1" },
+    script: {
+      pages: { page_1: { blocks: ["b1"] } },
+      blocks: { b1: { id: "b1", options: [{ value: "1", next: "hangup" }] } },
+    },
+  });
+});
+
+describe("inbound IVR block response", () => {
+  test("internal error text is not spoken to the caller", async () => {
+    // Simulate an internal error from findCallBySid
+    mocks.findCallBySid.mockRejectedValue(new Error("ECONNREFUSED postgres:5432"));
+
+    const mod = await import(
+      "../app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.route"
+    );
+    const res = await mod.action({
+      params: { numberId: "1", pageId: "page_1", blockId: "b1" },
+      request: makeReq({ CallSid: "CA1", Digits: "1" }),
+    } as any);
+
+    const text = await res.text();
+    // Must speak the generic message, not the internal error
+    expect(text).toContain("Sorry, we ran into a problem.");
+    expect(text).not.toContain("ECONNREFUSED");
+    expect(text).not.toContain("postgres");
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      "Inbound IVR Error:",
+      expect.any(Error),
+    );
+  });
+
+  test("block-not-found error does not appear in TwiML", async () => {
+    mocks.loadInboundIvrBlockContext.mockResolvedValue({
+      number: { phoneNumber: "+15551234567", workspaceId: "w1" },
+      script: {
+        pages: { page_1: { blocks: ["b1"] } },
+        blocks: {},
+      },
+    });
+
+    const mod = await import(
+      "../app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.route"
+    );
+    const res = await mod.action({
+      params: { numberId: "1", pageId: "page_1", blockId: "b1" },
+      request: makeReq({ CallSid: "CA1", Digits: "1" }),
+    } as any);
+
+    const text = await res.text();
+    expect(text).toContain("Sorry, we ran into a problem.");
+    expect(text).not.toContain("Block b1 not found");
+  });
+
+  test("non-Error thrown value produces generic message", async () => {
+    mocks.findCallBySid.mockImplementationOnce(async () => {
+      throw "some string error";
+    });
+
+    const mod = await import(
+      "../app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.route"
+    );
+    const res = await mod.action({
+      params: { numberId: "1", pageId: "page_1", blockId: "b1" },
+      request: makeReq({ CallSid: "CA1", Digits: "1" }),
+    } as any);
+
+    const text = await res.text();
+    expect(text).toContain("Sorry, we ran into a problem.");
+  });
+
+  test("returns hangup for missing call or mismatched number", async () => {
+    // No call found
+    mocks.findCallBySid.mockResolvedValue(null);
+
+    const mod = await import(
+      "../app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.route"
+    );
+    let res = await mod.action({
+      params: { numberId: "1", pageId: "page_1", blockId: "b1" },
+      request: makeReq({ CallSid: "CA1", Digits: "1" }),
+    } as any);
+    expect(await res.text()).toMatch(/hangup/i);
+
+    // Call.to doesn't match number phoneNumber
+    mocks.findCallBySid.mockResolvedValue({
+      sid: "CA1",
+      to: "+19998887777",
+      workspace: "w1",
+    });
+    res = await mod.action({
+      params: { numberId: "1", pageId: "page_1", blockId: "b1" },
+      request: makeReq({ CallSid: "CA1", Digits: "1" }),
+    } as any);
+    expect(await res.text()).toMatch(/hangup/i);
+  });
+
+  test("routes to next block on valid input", async () => {
+    // The auth mock returns no userInput by default for this test
+    mocks.requireTwilioSignatureForIvrResponse.mockImplementation(
+      async () => ({ callSid: "CA1", userInput: null }),
+    );
+
+    const mod = await import(
+      "../app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.route"
+    );
+    const res = await mod.action({
+      params: { numberId: "1", pageId: "page_1", blockId: "b1" },
+      request: makeReq({ CallSid: "CA1" }),
+    } as any);
+
+    // block has no next => hangup (findNextBlock returns null for last block)
+    const text = await res.text();
+    expect(text).toMatch(/hangup/i);
+  });
+});

--- a/test/user-message.test.ts
+++ b/test/user-message.test.ts
@@ -58,6 +58,28 @@ describe("app/lib/user-message.ts", () => {
       expect(toUserMessage(undefined, FALLBACK)).toBe(FALLBACK);
       expect(toUserMessage(42, FALLBACK)).toBe(FALLBACK);
     });
+
+    test("allowlist rejects messages with curly braces, newlines, or control chars", () => {
+      expect(toUserMessage(new Error("Has {brace}"), FALLBACK)).toBe(FALLBACK);
+      expect(toUserMessage(new Error("Has\nnewline"), FALLBACK)).toBe(FALLBACK);
+    });
+
+    test("allowlist rejects lowercase-start or all-lowercase messages", () => {
+      expect(toUserMessage(new Error("something broke unexpectedly"), FALLBACK)).toBe(FALLBACK);
+    });
+
+    test("passes through messages with common product punctuation", () => {
+      expect(toUserMessage("Campaign name is required.", FALLBACK)).toBe("Campaign name is required.");
+      expect(toUserMessage("Could not load this audio file. The link may have expired.", FALLBACK)).toBe(
+        "Could not load this audio file. The link may have expired.",
+      );
+    });
+
+    test("rejects partial matches of infra patterns that look like English", () => {
+      expect(toUserMessage(new Error("Connection reset by peer"), FALLBACK)).toBe(FALLBACK);
+      expect(toUserMessage(new Error("econn something"), FALLBACK)).toBe(FALLBACK);
+      expect(toUserMessage(new Error("Disconnected"), FALLBACK)).toBe("Disconnected");
+    });
   });
 
   describe("getErrorDetail", () => {


### PR DESCRIPTION
## Changes

Three remaining findings from #1176:

### 1. Inbound IVR speaks generic error instead of raw internals
**Files:** `app/routes/api+/inbound-ivr/$numberId/$pageId/$blockId/response.action.server.ts`, `test/inbound-ivr-block-response.route.test.ts`

The catch block read `error.message` aloud to the PSTN caller via TTS. Now logs the error and speaks a fixed generic message — matching the outbound IVR fix in `2d894374`.

### 2. `toUserMessage` inverted to allowlist-first
**Files:** `app/lib/user-message.ts`, `test/user-message.test.ts`

Old: deny list of ~30 infra markers; anything not on the list passes through.
New: message must match a sentence-like allow pattern (`^[A-Z]...`) AND not match a compact infra deny regex. Default is fallback.

### 3. Webhook coverage derived from API surface registry
**File:** `scripts/check-twilio-webhook-coverage.mjs`

The `TWILIO_WEBHOOK_SUFFIXES` hand-maintained list is replaced by parsing `authClass: "twilioSignature"` + POST entries from `app/lib/api-surface-*.ts`. Three routes (call.action, inbound-verification, twilio/a2p/events) validate Twilio signatures but are registered with other auth classes — reported as warnings but still validated.

## Verification
- `check:twilio-webhooks` passes (exit 0, 25 routes scanned)
- Typecheck clean
- Lint clean on all changed app/test files
- 15 tests pass across both test suites (10 user-message + 5 inbound-ivr)
- Existing IVR tests unchanged (pre-existing DATABASE_URL failures in env without PG)

## Notes
- Issues #1182, #1181, #1180, #1179, #1178 are all already on `origin/dev` — no new branches needed
- Issue #1183 (workbench column min-width) also already on dev — can be closed