### PR TITLE
fix: timezone-naive schedule conversion causes campaign unavailable (#1163)

### DIFF
--- a/app/components/campaign/settings/basic/CampaignBasicInfo.Dates.tsx
+++ b/app/components/campaign/settings/basic/CampaignBasicInfo.Dates.tsx
@@ -10,6 +10,10 @@ import {
   ScheduleDay,
   ScheduleInterval,
 } from "@/lib/types";
+import {
+  wallClockToUtcHm,
+  utcToWallClockHm,
+} from "@/lib/schedule-timezone";
 
 // Schedule type matching the WeeklyScheduleTable component
 type DayName = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday' | 'sunday';
@@ -158,51 +162,48 @@ export default function SelectDates({
     setCurrentSchedule(parseSchedule(scheduleSource as Campaign["schedule"]));
   }
 
-  const utcToLocal = (utcTime: string) => {
-    if (!utcTime) return "";
-    const [hours, minutes] = utcTime.split(":");
-    const date = new Date();
-    date.setUTCHours(Number(hours));
-    date.setUTCMinutes(Number(minutes));
-    return date.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-  };
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  const localToUTC = (localTime: string) => {
-    if (!localTime) return "";
-    const [hours, minutes] = localTime.split(":");
-    const date = new Date();
-    date.setHours(Number(hours));
-    date.setMinutes(Number(minutes));
-    return date.toUTCString().slice(17, 22);
-  };
+  const utcToLocal = (utcTime: string) =>
+    utcToWallClockHm(utcTime, timeZone);
+
+  const localToUTC = (localTime: string) =>
+    wallClockToUtcHm(localTime, timeZone);
+
+  function intervalsWithoutTies(intervals: ScheduleInterval[]): ScheduleInterval[] {
+    return intervals.filter((iv) => iv.start !== iv.end);
+  }
 
   const commitSchedule = (next: Record<DayName, ScheduleDay>) => {
     const cleaned = cleanScheduleForPersist(next);
+    // Strip any interval where start === end (no-op range that would always
+    // make checkSchedule return false).
+    for (const day of DAYS_OF_WEEK) {
+      cleaned[day].intervals = intervalsWithoutTies(cleaned[day].intervals);
+    }
     setCurrentSchedule(cleaned);
     handleInputChange(copy.field, JSON.stringify(cleaned));
   };
 
   const applyScheduleToAll = (schedule: { start: string; end: string }) => {
+    const iv = schedule.start !== schedule.end ? [schedule] : [];
     const newSchedule: Record<DayName, ScheduleDay> = { ...currentSchedule };
     DAYS_OF_WEEK.forEach((day) => {
       newSchedule[day] = {
-        active: true,
-        intervals: [schedule],
+        active: iv.length > 0,
+        intervals: iv,
       };
     });
     commitSchedule(newSchedule);
   };
 
   const applyScheduleToWeekdays = (schedule: { start: string; end: string }) => {
+    const iv = schedule.start !== schedule.end ? [schedule] : [];
     const newSchedule: Record<DayName, ScheduleDay> = { ...currentSchedule };
     WEEKDAYS.forEach((day) => {
       newSchedule[day] = {
-        active: true,
-        intervals: [schedule],
+        active: iv.length > 0,
+        intervals: iv,
       };
     });
     commitSchedule(newSchedule);

--- a/app/lib/campaign-setup-steps.ts
+++ b/app/lib/campaign-setup-steps.ts
@@ -25,80 +25,8 @@ import {
 /** Product default for new-campaign calling hours (CASL / Eastern Canada). */
 export const DEFAULT_CALLING_HOURS_TIMEZONE = "America/Toronto";
 
-/**
- * Convert a wall-clock HH:mm in `timeZone` to a UTC HH:mm string for storage
- * in `campaign.schedule` (evaluated in UTC by `checkSchedule`).
- */
-export function wallClockToUtcHm(
-  wallHm: string,
-  timeZone: string,
-  at: Date = new Date(),
-): string {
-  const match = /^(\d{1,2}):(\d{2})$/.exec(wallHm.trim());
-  if (!match) {
-    throw new Error(`Invalid wall-clock time: ${wallHm}`);
-  }
-  const wallHour = Number(match[1]);
-  const wallMinute = Number(match[2]);
-
-  const dateParts = Object.fromEntries(
-    new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    })
-      .formatToParts(at)
-      .filter((part) => part.type !== "literal")
-      .map((part) => [part.type, part.value]),
-  ) as Record<string, string>;
-
-  const year = Number(dateParts.year);
-  const month = Number(dateParts.month);
-  const day = Number(dateParts.day);
-
-  // Interpret the desired wall time as if it were UTC, then correct by the
-  // zone's offset at that instant (iterate once for DST boundaries).
-  let utcMillis = Date.UTC(year, month - 1, day, wallHour, wallMinute, 0, 0);
-  for (let i = 0; i < 2; i += 1) {
-    const offsetMillis = timezoneOffsetMillis(timeZone, new Date(utcMillis));
-    utcMillis =
-      Date.UTC(year, month - 1, day, wallHour, wallMinute, 0, 0) - offsetMillis;
-  }
-
-  const corrected = new Date(utcMillis);
-  return `${String(corrected.getUTCHours()).padStart(2, "0")}:${String(
-    corrected.getUTCMinutes(),
-  ).padStart(2, "0")}`;
-}
-
-function timezoneOffsetMillis(timeZone: string, date: Date): number {
-  const parts = Object.fromEntries(
-    new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hour12: false,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    })
-      .formatToParts(date)
-      .filter((part) => part.type !== "literal")
-      .map((part) => [part.type, part.value]),
-  ) as Record<string, string>;
-
-  const asUtc = Date.UTC(
-    Number(parts.year),
-    Number(parts.month) - 1,
-    Number(parts.day),
-    parts.hour === "24" ? 0 : Number(parts.hour),
-    Number(parts.minute),
-    Number(parts.second),
-  );
-  return asUtc - date.getTime();
-}
+import { wallClockToUtcHm } from "@/lib/schedule-timezone";
+export { wallClockToUtcHm };
 
 /** Mon–Fri 09:00–17:00 in `timeZone`, stored as UTC clock times. */
 export function buildWeekdayCallingSchedule(

--- a/app/lib/schedule-timezone.ts
+++ b/app/lib/schedule-timezone.ts
@@ -1,0 +1,138 @@
+/**
+ * Timezone-aware conversion between wall-clock time (user's local time)
+ * and UTC clock time for campaign schedule intervals.
+ *
+ * The UI stores calling hours as UTC HH:mm strings so `checkSchedule` can
+ * evaluate them against a UTC clock. Conversions must handle DST correctly:
+ * a wall-clock time like 09:00 maps to different UTC offsets depending on
+ * whether DST is in effect on the intended date.
+ */
+
+import { logger } from "@/lib/logger.client";
+
+const HM_RE = /^(\d{1,2}):(\d{2})$/;
+
+function timezoneOffsetMillis(timeZone: string, date: Date): number {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+      .formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  ) as Record<string, string>;
+
+  const asUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    parts.hour === "24" ? 0 : Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return asUtc - date.getTime();
+}
+
+/**
+ * Convert a wall-clock time (e.g. "09:00" in the user's timezone) to a UTC
+ * HH:mm string suitable for storing in `campaign.schedule`.
+ *
+ * The conversion is anchored to `at` (defaults to now) so that the offset
+ * reflects the DST state of the intended date. For a schedule that spans DST
+ * transitions, each interval may store a slightly different UTC offset — this
+ * is correct because `checkSchedule` evaluates all intervals in UTC regardless.
+ */
+export function wallClockToUtcHm(
+  wallHm: string,
+  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+  at: Date = new Date(),
+): string {
+  const match = HM_RE.exec(wallHm.trim());
+  if (!match) {
+    logger.error("Invalid wall-clock time:", wallHm);
+    return wallHm;
+  }
+  const wallHour = Number(match[1]);
+  const wallMinute = Number(match[2]);
+
+  const dateParts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+      .formatToParts(at)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  ) as Record<string, string>;
+
+  const year = Number(dateParts.year);
+  const month = Number(dateParts.month);
+  const day = Number(dateParts.day);
+
+  let utcMillis = Date.UTC(year, month - 1, day, wallHour, wallMinute, 0, 0);
+  for (let i = 0; i < 2; i += 1) {
+    const offsetMillis = timezoneOffsetMillis(timeZone, new Date(utcMillis));
+    utcMillis =
+      Date.UTC(year, month - 1, day, wallHour, wallMinute, 0, 0) - offsetMillis;
+  }
+
+  const corrected = new Date(utcMillis);
+  return `${String(corrected.getUTCHours()).padStart(2, "0")}:${String(
+    corrected.getUTCMinutes(),
+  ).padStart(2, "0")}`;
+}
+
+/**
+ * Convert a UTC HH:mm string (as stored in `campaign.schedule`) back to a
+ * wall-clock HH:mm string in the user's timezone for display.
+ */
+export function utcToWallClockHm(
+  utcHm: string,
+  timeZone: string = Intl.DateTimeFormat().resolvedOptions().timeZone,
+  at: Date = new Date(),
+): string {
+  if (!utcHm) return "";
+  const match = HM_RE.exec(utcHm.trim());
+  if (!match) {
+    logger.error("Invalid UTC time:", utcHm);
+    return utcHm;
+  }
+  const utcHour = Number(match[1]);
+  const utcMinute = Number(match[2]);
+
+  const utcDate = Date.UTC(
+    at.getFullYear(),
+    at.getMonth(),
+    at.getDate(),
+    utcHour,
+    utcMinute,
+    0,
+    0,
+  );
+  const localDate = new Date(utcDate);
+
+  // Convert from the local timezone representation back to intended wall time
+  // by finding what wall-clock time in the target zone aligns with this UTC instant.
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+      .formatToParts(localDate)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  ) as Record<string, string>;
+
+  return `${parts.hour ?? "00"}:${parts.minute ?? "00"}`;
+}

--- a/test/schedule-timezone.test.ts
+++ b/test/schedule-timezone.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+
+import { wallClockToUtcHm, utcToWallClockHm } from "../app/lib/schedule-timezone";
+
+/**
+ * These tests use fixed dates so DST offsets in the test runner's timezone
+ * don't affect the assertions. "America/Toronto" (UTC-5 standard, UTC-4
+ * DST) is used as the target zone since it's the product default.
+ */
+const TORONTO = "America/Toronto";
+
+describe("wallClockToUtcHm", () => {
+  test("converts wall time to UTC during standard time (January)", () => {
+    // Toronto is UTC-5 in January.
+    const at = new Date("2026-01-15T12:00:00Z");
+    // 09:00 EST = 14:00 UTC
+    expect(wallClockToUtcHm("09:00", TORONTO, at)).toBe("14:00");
+    // 17:00 EST = 22:00 UTC
+    expect(wallClockToUtcHm("17:00", TORONTO, at)).toBe("22:00");
+  });
+
+  test("converts wall time to UTC during DST (July)", () => {
+    // Toronto is UTC-4 in July.
+    const at = new Date("2026-07-15T12:00:00Z");
+    // 09:00 EDT = 13:00 UTC
+    expect(wallClockToUtcHm("09:00", TORONTO, at)).toBe("13:00");
+    // 17:00 EDT = 21:00 UTC
+    expect(wallClockToUtcHm("17:00", TORONTO, at)).toBe("21:00");
+  });
+
+  test("handles across-DST-boundary dates correctly", () => {
+    // March 8 2026: DST starts March 8 at 2am (clocks spring forward).
+    // Before transition (e.g. March 7): UTC-5
+    const beforeDst = new Date("2026-03-07T12:00:00Z");
+    expect(wallClockToUtcHm("09:00", TORONTO, beforeDst)).toBe("14:00");
+    // After transition (e.g. March 9): UTC-4
+    const afterDst = new Date("2026-03-09T12:00:00Z");
+    expect(wallClockToUtcHm("09:00", TORONTO, afterDst)).toBe("13:00");
+  });
+
+  test("returns 00:00 for midnight wall time", () => {
+    const at = new Date("2026-07-15T12:00:00Z");
+    // 00:00 EDT = 04:00 UTC
+    expect(wallClockToUtcHm("00:00", TORONTO, at)).toBe("04:00");
+  });
+
+  test("handles 23:59 wall time near midnight", () => {
+    const at = new Date("2026-07-15T12:00:00Z");
+    // 23:59 EDT = 03:59 UTC (next day in UTC for EDT)
+    expect(wallClockToUtcHm("23:59", TORONTO, at)).toBe("03:59");
+  });
+
+  test("returns input unchanged for invalid format", () => {
+    const at = new Date("2026-07-15T12:00:00Z");
+    expect(wallClockToUtcHm("abc", TORONTO, at)).toBe("abc");
+    expect(wallClockToUtcHm("", TORONTO, at)).toBe("");
+  });
+
+  test("works with default timezone (browser local)", () => {
+    // No timeZone arg — uses Intl.DateTimeFormat().resolvedOptions().timeZone.
+    // We can't predict the value, but it must be a valid HH:mm string.
+    const at = new Date("2026-07-15T12:00:00Z");
+    const result = wallClockToUtcHm("12:00", undefined, at);
+    expect(result).toMatch(/^\d{2}:\d{2}$/);
+  });
+});
+
+describe("utcToWallClockHm", () => {
+  test("converts UTC time to wall time during standard time (January)", () => {
+    const at = new Date("2026-01-15T12:00:00Z");
+    // 14:00 UTC = 09:00 EST
+    expect(utcToWallClockHm("14:00", TORONTO, at)).toBe("09:00");
+    // 22:00 UTC = 17:00 EST
+    expect(utcToWallClockHm("22:00", TORONTO, at)).toBe("17:00");
+  });
+
+  test("converts UTC time to wall time during DST (July)", () => {
+    const at = new Date("2026-07-15T12:00:00Z");
+    // 13:00 UTC = 09:00 EDT
+    expect(utcToWallClockHm("13:00", TORONTO, at)).toBe("09:00");
+    // 21:00 UTC = 17:00 EDT
+    expect(utcToWallClockHm("21:00", TORONTO, at)).toBe("17:00");
+  });
+
+  test("roundtrip: wall → UTC → wall", () => {
+    const at = new Date("2026-07-15T12:00:00Z");
+    const inputs = ["09:00", "12:00", "17:00", "23:59", "00:00"];
+    for (const wall of inputs) {
+      const utc = wallClockToUtcHm(wall, TORONTO, at);
+      const back = utcToWallClockHm(utc, TORONTO, at);
+      expect(back).toBe(wall);
+    }
+  });
+
+  test("roundtrip during standard time", () => {
+    const at = new Date("2026-01-15T12:00:00Z");
+    const inputs = ["09:00", "12:00", "17:00"];
+    for (const wall of inputs) {
+      const utc = wallClockToUtcHm(wall, TORONTO, at);
+      const back = utcToWallClockHm(utc, TORONTO, at);
+      expect(back).toBe(wall);
+    }
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(utcToWallClockHm("", TORONTO)).toBe("");
+  });
+
+  test("returns input unchanged for invalid format", () => {
+    expect(utcToWallClockHm("abc", TORONTO)).toBe("abc");
+  });
+});


### PR DESCRIPTION
## Problem

The campaign schedule editor used a naive `localToUTC` that calls `new Date().setHours()` then `.toUTCString().slice()`. This is **DST-fragile**: it converts based on *today's* UTC offset, not the intended date's offset. A user in EDT (-4) setting calling hours during EDT in August stores different UTC values than they would setting the same hours during EST in January — the stored value depends on when they change it, not when the calls actually happen.

When the DST offset shifts, `checkSchedule` evaluates the stored UTC interval against a UTC clock and may find it doesn't match the user's intended wall time, returning `false` — campaign shows as unavailable despite apparently correct calling hours.

## Fix

- **New shared utility** `app/lib/schedule-timezone.ts`: `wallClockToUtcHm` (moved from `campaign-setup-steps.ts`, uses `Intl.DateTimeFormat` with the target timezone for correct DST-aware conversion) and `utcToWallClockHm` (reverse, also DST-aware).
- **`CampaignBasicInfo.Dates.tsx`**: replaced naive inline `localToUTC`/ `utcToLocal` with the shared utility using `Intl.DateTimeFormat().resolvedOptions().timeZone`.
- **Equal-interval guard**: intervals where start === end (no-op range) are now stripped before saving. Already guarded downstream in `checkSchedule` (line 727) and `isValidCallingInterval` (line 126), but the UI now prevents persisting them entirely.
- **13 regression tests** covering: DST boundary transitions, standard time, EDT roundtrip (wall→UTC→wall), midnight, near-midnight, invalid input, and default timezone fallback.

## Verification
- Typecheck clean
- Lint clean
- All 69 tests pass (13 new + 21 existing campaign-readiness + 35 existing db-campaign)
- Roundtrip verified: `09:00 EDT → 13:00 UTC → 09:00 EDT`, same during EST