### PR TITLE
Fix call-screen testing blockers: stale terminal flash, missing results, toast loop

### DIFF
--- a/app/hooks/call/useCallHandling.ts
+++ b/app/hooks/call/useCallHandling.ts
@@ -292,6 +292,26 @@ export function useCallHandling({
         typeof call.parameters.To === "string" &&
         call.parameters.To.includes("client")
       ) {
+        // Teardown listeners only — the full listener set fires "connected"
+        // on accept, which campaign outbound suppresses (agent-leg accept is
+        // not the customer answering). Without a disconnect handler here, a
+        // callee-initiated hangup left activeCall stale and the FSM stuck,
+        // so no disposition was ever written (#1218).
+        clearIncomingListeners(call);
+        const cleanups = [
+          attachCallListener(call, "disconnect", () => {
+            updateActiveCall(null);
+            onStatusChange?.("Registered");
+            updateCallState("completed");
+          }),
+          attachCallListener(call, "cancel", () => {
+            updateIncomingCall(null);
+          }),
+        ];
+        incomingListenerCleanupsRef.current.set(call, () => {
+          cleanups.forEach((fn) => fn());
+        });
+
         call.accept();
         if (!suppressConnectedState) {
           onStatusChange?.("connected");
@@ -311,6 +331,7 @@ export function useCallHandling({
       updateCallState,
       onStatusChange,
       setupIncomingCallListeners,
+      clearIncomingListeners,
     ],
   );
 

--- a/app/hooks/call/useCampaignCallFlow.ts
+++ b/app/hooks/call/useCampaignCallFlow.ts
@@ -178,13 +178,33 @@ export function useCampaignCallFlow({
     if (previousFsmRef.current === fsmState) return;
     previousFsmRef.current = fsmState;
 
+    // A new dial always resets the lifecycle — the reducer starts a fresh
+    // generation even from terminal phases (#1220). Drop the previous call's
+    // provider tracking too, so a stale leg's late events can't repaint the
+    // old outcome over the new dial.
+    if (fsmState === "dialing") {
+      setCustomerLegSid(null);
+      setPollingTargetSid(null);
+      setProviderStatus(null);
+      dispatch({ type: "START_DIALING" });
+      return;
+    }
+
+    // FSM returning to idle (the NEXT action after a finished call) clears
+    // the lifecycle too — the reducer ignores RESET mid-call, so this only
+    // wipes terminal outcomes, never a live dial.
+    if (fsmState === "idle") {
+      setCustomerLegSid(null);
+      setPollingTargetSid(null);
+      setProviderStatus(null);
+      dispatch({ type: "RESET" });
+      return;
+    }
+
     const currentPhase = lifecycleRef.current.phase;
     if (TERMINAL_PHASES.has(currentPhase)) return;
 
     switch (fsmState) {
-      case "dialing":
-        dispatch({ type: "START_DIALING" });
-        break;
       case "connected":
         dispatch({ type: "CONNECT" });
         break;

--- a/app/hooks/call/useCampaignDialActions.ts
+++ b/app/hooks/call/useCampaignDialActions.ts
@@ -133,7 +133,9 @@ export function useCampaignDequeueActions({
       dequeue({ contact: nextRecipient });
       fetchMore({ householdMap });
       handleNextNumber(campaign?.group_household_queue || false);
-      send({ type: "HANG_UP" });
+      // NEXT resets a finished call to idle; HANG_UP here parked the FSM in
+      // "completed" even from idle, which the next dial then flashed (#1220).
+      send({ type: "NEXT" });
       setRecentAttempt(null);
       setUpdate({});
       setCallDuration(0);

--- a/app/hooks/call/useDialFailureRecovery.ts
+++ b/app/hooks/call/useDialFailureRecovery.ts
@@ -24,22 +24,22 @@ export function useDialFailureRecovery({
   send,
   showError,
 }: UseDialFailureRecoveryOptions) {
-  /**
-   * @effect Dispatch FAIL to the call FSM when a settled dial fetcher
-   * carries an error or creditsError, and toast the error message if one was
-   * given.
-   * @effect-deps fetcherState, fetcherData, send, showError (fires once per
-   * settled fetcher response carrying a rejection)
-   * @effect-side-effects none directly (FSM dispatch + toast)
-   * @effect-why-not-loader Reacts to a mutation result to fix client FSM
-   * state; not request/response data for render.
-   */
   // One reaction per settled response: fetcher.data keeps its identity until
   // the next submission settles, while `send`/`showError` are recreated every
   // render — without this latch a single 409 re-toasted once per render for
   // as long as its data stayed current (#1221).
   const handledDataRef = useRef<unknown>(null);
 
+  /**
+   * @effect Dispatch FAIL to the call FSM when a settled dial fetcher
+   * carries an error or creditsError, and toast the error message if one was
+   * given — once per settled response (latched on fetcher data identity).
+   * @effect-deps fetcherState, fetcherData, send, showError (fires once per
+   * settled fetcher response carrying a rejection)
+   * @effect-side-effects none directly (FSM dispatch + toast)
+   * @effect-why-not-loader Reacts to a mutation result to fix client FSM
+   * state; not request/response data for render.
+   */
   useEffect(() => {
     if (fetcherState !== "idle" || !fetcherData) return;
     if (handledDataRef.current === fetcherData) return;

--- a/app/hooks/call/useDialFailureRecovery.ts
+++ b/app/hooks/call/useDialFailureRecovery.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 type UseDialFailureRecoveryOptions = {
   fetcherState: string;
@@ -34,8 +34,16 @@ export function useDialFailureRecovery({
    * @effect-why-not-loader Reacts to a mutation result to fix client FSM
    * state; not request/response data for render.
    */
+  // One reaction per settled response: fetcher.data keeps its identity until
+  // the next submission settles, while `send`/`showError` are recreated every
+  // render — without this latch a single 409 re-toasted once per render for
+  // as long as its data stayed current (#1221).
+  const handledDataRef = useRef<unknown>(null);
+
   useEffect(() => {
     if (fetcherState !== "idle" || !fetcherData) return;
+    if (handledDataRef.current === fetcherData) return;
+    handledDataRef.current = fetcherData;
     const { error, creditsError } = fetcherData;
     if (error || creditsError) {
       send({ type: "FAIL" });

--- a/app/lib/db-rpc.server.ts
+++ b/app/lib/db-rpc.server.ts
@@ -26,6 +26,26 @@ async function queryScalar<T>(
   return value ?? null;
 }
 
+/**
+ * Scalar RPC result coerced to a finite number. Postgres `bigint` (int8)
+ * comes back from the driver as a string — postgres.js only auto-parses
+ * int2/int4/oid/float — so a `RETURNS bigint` function silently fails
+ * `typeof === "number"` / `Number.isFinite` checks downstream (#1218).
+ */
+async function queryScalarNumber(
+  executor: RpcExecutor,
+  query: SQL,
+  label: string,
+): Promise<number | null> {
+  const raw = await queryScalar<number | string>(executor, query);
+  if (raw == null) return null;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new Error(`${label} returned a non-numeric value: ${String(raw)}`);
+  }
+  return value;
+}
+
 async function execVoid(executor: RpcExecutor, query: SQL): Promise<void> {
   await executor.execute(query);
 }
@@ -137,7 +157,7 @@ export async function rpcCreateOutreachAttempt(
     queueId: number;
   },
 ): Promise<number> {
-  const id = await queryScalar<number>(
+  const id = await queryScalarNumber(
     executor,
     sql`select create_outreach_attempt(
       ${args.contactId}::bigint,
@@ -146,6 +166,7 @@ export async function rpcCreateOutreachAttempt(
       ${args.workspaceId}::uuid,
       ${args.queueId}::bigint
     ) as id`,
+    "create_outreach_attempt",
   );
   if (id == null) {
     throw new Error("create_outreach_attempt returned no id");
@@ -425,14 +446,15 @@ export async function rpcReserveCampaignQueueOrderRange(
   executor: RpcExecutor,
   args: { campaignId: number; count: number },
 ): Promise<number> {
-  const startOrder = await queryScalar<number>(
+  const startOrder = await queryScalarNumber(
     executor,
     sql`select reserve_campaign_queue_order_range(
       ${args.campaignId},
       ${args.count}
     ) as start_order`,
+    "reserve_campaign_queue_order_range",
   );
-  if (typeof startOrder !== "number" || !Number.isFinite(startOrder)) {
+  if (startOrder == null) {
     throw new Error(
       `Invalid start queue order returned for campaign ${args.campaignId}`,
     );

--- a/app/lib/object-storage.server.ts
+++ b/app/lib/object-storage.server.ts
@@ -2,6 +2,7 @@ import { DeleteObjectCommand, GetObjectCommand, ListObjectsV2Command, PutObjectC
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { env } from "@/lib/env.server";
 import { objectStorageUsesPathStyle } from "@/lib/object-storage-config";
+import { logger } from "@/lib/logger.server";
 
 /** Postgres-compatible logical bucket names. */
 export type ObjectStorageBucket =
@@ -236,11 +237,25 @@ export async function deleteObject(
   );
 }
 
+/** SigV4's hard ceiling for presigned URLs — the signer rejects anything longer. */
+const MAX_SIGNED_URL_TTL_SECONDS = 7 * 24 * 60 * 60;
+
 export async function createSignedObjectUrl(
   logicalBucket: ObjectStorageBucket,
   objectPath: string,
   expiresInSeconds: number,
 ): Promise<string> {
+  // Clamp rather than let the signer throw: an over-long TTL silently killed
+  // every voicemail email for months (#1224) because the failure surfaced
+  // only at send time, deep inside a webhook handler.
+  let expiresIn = expiresInSeconds;
+  if (expiresIn > MAX_SIGNED_URL_TTL_SECONDS) {
+    logger.warn("createSignedObjectUrl: TTL exceeds the SigV4 7-day cap; clamping", {
+      requested: expiresInSeconds,
+      objectPath,
+    });
+    expiresIn = MAX_SIGNED_URL_TTL_SECONDS;
+  }
   const { bucketName, key } = resolveLocation(logicalBucket, objectPath);
   return getSignedUrl(
     getS3Client(),
@@ -248,7 +263,7 @@ export async function createSignedObjectUrl(
       Bucket: bucketName,
       Key: key,
     }),
-    { expiresIn: expiresInSeconds },
+    { expiresIn },
   );
 }
 

--- a/app/lib/worker/webhook-side-effects.server.ts
+++ b/app/lib/worker/webhook-side-effects.server.ts
@@ -38,6 +38,15 @@ import { enqueueJob } from "@/lib/worker/enqueue-job.server";
 import { ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE } from "@/lib/worker/job-types.server";
 import { isBatchTranscriptionEnabled } from "@/lib/worker/handlers/elevenlabs-batch-transcribe.server";
 
+/** Terminal Twilio call statuses and the outreach disposition they imply. */
+const CALL_STATUS_TO_DISPOSITION: Record<string, string> = {
+  completed: "completed",
+  busy: "busy",
+  "no-answer": "no-answer",
+  failed: "failed",
+  canceled: "canceled",
+};
+
 export async function runCallStatusSideEffects(args: {
   callSid: string;
   twilioParams: Record<string, string>;
@@ -63,6 +72,27 @@ export async function runCallStatusSideEffects(args: {
       contact_id: currentAttempt.contact_id,
       status: String(underCaseData.call_status ?? ""),
     });
+
+    // Provider-terminal statuses stamp a disposition so every call yields a
+    // results row even when the browser never reaches /api/hangup (callee
+    // hangs up, tab closes) and the agent picks nothing (#1218). The
+    // transition guard keeps AMD "voicemail" and other terminal values from
+    // being downgraded, and an explicit agent choice via /api/questions
+    // bypasses this guard entirely, so it always wins.
+    const terminalDisposition =
+      CALL_STATUS_TO_DISPOSITION[String(underCaseData.call_status ?? "").toLowerCase()];
+    if (
+      terminalDisposition &&
+      shouldUpdateOutreachDisposition({
+        currentDisposition: currentAttempt.disposition,
+        nextDisposition: terminalDisposition,
+      })
+    ) {
+      await updateOutreachAttemptForWorkspace(billingWorkspace, outreachAttemptId!, {
+        disposition: terminalDisposition,
+        ended_at: new Date().toISOString(),
+      });
+    }
   }
 
   return { ok: true };

--- a/app/routes/api+/email-vm.action.server.ts
+++ b/app/routes/api+/email-vm.action.server.ts
@@ -85,10 +85,10 @@ export const action = defineAction({
 
       // Idempotency guard: Twilio retries the recordingStatusCallback on
       // timeout, and the retry carries the exact same RecordingUrl/RecordingSid
-      // as the original. If this call's recording URL was already persisted
-      // (by a prior run of this same handler, below), the voicemail has
-      // already been fetched, stored, and emailed — ack success without
-      // reprocessing so we don't send a duplicate email.
+      // as the original. recording_url is persisted only AFTER the email is
+      // sent (below), so its presence means the voicemail was fully
+      // processed — ack success without sending a duplicate email. A run
+      // that failed mid-flight left it unset, so the retry reprocesses.
       if (callRow.recording_url && callRow.recording_url === recordingUrl) {
         logger.debug("Voicemail webhook retry detected; skipping duplicate processing", {
           callSid,
@@ -111,12 +111,7 @@ export const action = defineAction({
         throw new Error("Workspace twilio data not found");
       }
 
-      const call = await updateCallRecordingUrlBySid(callSid, recordingUrl);
-
-      if (!call) {
-        throw new Error("Error updating call: not found");
-      }
-
+      const call = callRow;
       const action = number.inbound_action;
       const now = new Date();
 
@@ -157,9 +152,18 @@ export const action = defineAction({
         throw new Error(`Error uploading to storage: ${error instanceof Error ? error.message : String(error)}`);
       }
 
+      // SigV4 presigned URLs are capped at 7 days — the signer itself
+      // rejects anything longer, which is what silently killed every
+      // voicemail email after the S3 migration (#1224). The email also
+      // links to the voicemails page, which mints fresh URLs on demand.
+      const SIGNED_URL_TTL_SECONDS = 7 * 24 * 60 * 60;
       let signedUrl: string;
       try {
-        signedUrl = await createSignedObjectUrl("workspaceAudio", fileName, 8640000);
+        signedUrl = await createSignedObjectUrl(
+          "workspaceAudio",
+          fileName,
+          SIGNED_URL_TTL_SECONDS,
+        );
       } catch (error) {
         throw new Error(`Error creating signed URL: ${error instanceof Error ? error.message : String(error)}`);
       }
@@ -191,6 +195,21 @@ export const action = defineAction({
         View in workspace: ${env.BASE_URL()}/workspaces/${number.workspace.id}/voicemails
       `,
       });
+
+      // resend returns { data, error } and never throws on API errors — an
+      // unverified from-domain or bad recipient was previously reported as
+      // "email sent". Throwing keeps the callback retryable.
+      if (result.error) {
+        throw new Error(`Email send failed: ${result.error.message}`);
+      }
+
+      // Mark fully processed only now: persisting recording_url earlier made
+      // the retry guard above swallow every retry after a mid-flight failure
+      // as "Already processed" while no email had ever gone out.
+      const updatedCall = await updateCallRecordingUrlBySid(callSid, recordingUrl);
+      if (!updatedCall) {
+        throw new Error("Error updating call: not found");
+      }
 
       const voicemailWebhook = number.workspace.webhook.filter((webhook) =>
         Array.isArray(webhook.events) && (webhook.events as string[]).includes("voicemail"),

--- a/test/db-rpc-outreach-attempt.test.ts
+++ b/test/db-rpc-outreach-attempt.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression #1218/#1219: `create_outreach_attempt` RETURNS bigint, and the
+ * postgres.js driver hands int8 back as a STRING (it only auto-parses
+ * int2/int4/oid/float). The dial route then failed `Number.isFinite("123")`
+ * and wrote `call.outreach_attempt_id = NULL`, which silently disabled every
+ * disposition writer — so completed calls never appeared in campaign results.
+ */
+import { describe, expect, test, vi } from "vitest";
+import type { SQL } from "drizzle-orm";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+import {
+  rpcCreateOutreachAttempt,
+  rpcReserveCampaignQueueOrderRange,
+} from "@/lib/db-rpc.server";
+
+const ATTEMPT_ARGS = {
+  contactId: 1,
+  campaignId: 2,
+  userId: "u1",
+  workspaceId: "w1",
+  queueId: 3,
+};
+
+describe("rpcCreateOutreachAttempt", () => {
+  test("coerces a bigint-as-string id to a number", async () => {
+    const execute = vi.fn(async (_q: SQL) => [{ id: "123" }]);
+    await expect(rpcCreateOutreachAttempt({ execute }, ATTEMPT_ARGS)).resolves.toBe(123);
+  });
+
+  test("passes through a numeric id", async () => {
+    const execute = vi.fn(async (_q: SQL) => [{ id: 77 }]);
+    await expect(rpcCreateOutreachAttempt({ execute }, ATTEMPT_ARGS)).resolves.toBe(77);
+  });
+
+  test("throws on a non-numeric id instead of returning garbage", async () => {
+    const execute = vi.fn(async (_q: SQL) => [{ id: "not-a-number" }]);
+    await expect(rpcCreateOutreachAttempt({ execute }, ATTEMPT_ARGS)).rejects.toThrow(
+      /non-numeric/,
+    );
+  });
+
+  test("throws when no id is returned", async () => {
+    const execute = vi.fn(async (_q: SQL) => []);
+    await expect(rpcCreateOutreachAttempt({ execute }, ATTEMPT_ARGS)).rejects.toThrow(
+      /returned no id/,
+    );
+  });
+});
+
+describe("rpcReserveCampaignQueueOrderRange", () => {
+  test("coerces a stringified start order", async () => {
+    const execute = vi.fn(async (_q: SQL) => [{ start_order: "40" }]);
+    await expect(
+      rpcReserveCampaignQueueOrderRange({ execute }, { campaignId: 1, count: 5 }),
+    ).resolves.toBe(40);
+  });
+});

--- a/test/email-vm.route.test.ts
+++ b/test/email-vm.route.test.ts
@@ -443,4 +443,92 @@ describe("app/routes/api+/email-vm/route.tsx", () => {
     expect(res.status).toBe(500);
   });
 
+  // Regression #1224: the presign TTL was 100 days; SigV4 caps presigned
+  // URLs at 7 days and the signer throws client-side, so the upload landed
+  // (voicemail visible in the app) but the email never sent — and the retry
+  // guard swallowed every Twilio retry as "Already processed".
+  test("signs the recording link within the SigV4 7-day cap", async () => {
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      statusText: "OK",
+      blob: async () => new Blob(["abc"], { type: "audio/mpeg" }),
+    } as any);
+    mocks.sendEmail.mockResolvedValueOnce({ id: "em1" });
+
+    const mod = await import("../app/routes/api+/email-vm");
+    await asRouteResponse(mod.action({
+      request: makeReq({ RecordingUrl: "https://tw/rec", CallSid: "CA1", AccountSid: "AC1", RecordingSid: "RE1" }),
+      params: {},
+    } as any));
+
+    const expiry = objectStorageMocks.createSignedObjectUrl.mock.calls[0]?.[2];
+    expect(expiry).toBeLessThanOrEqual(7 * 24 * 60 * 60);
+  });
+
+  test("marks the call processed only after the email is sent", async () => {
+    const order: string[] = [];
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      statusText: "OK",
+      blob: async () => new Blob(["abc"], { type: "audio/mpeg" }),
+    } as any);
+    mocks.sendEmail.mockImplementationOnce(async () => {
+      order.push("email");
+      return { id: "em1" };
+    });
+    telephonyDbMocks.updateCallRecordingUrlBySid.mockImplementation(async () => {
+      order.push("persist");
+      return { sid: "CA1", from: "+15550001111", to: "+15550002222" };
+    });
+
+    const mod = await import("../app/routes/api+/email-vm");
+    const res = await asRouteResponse(mod.action({
+      request: makeReq({ RecordingUrl: "https://tw/rec", CallSid: "CA1", AccountSid: "AC1", RecordingSid: "RE1" }),
+      params: {},
+    } as any));
+
+    expect(res.status).toBe(200);
+    expect(order).toEqual(["email", "persist"]);
+  });
+
+  test("a failed presign leaves the call unprocessed so Twilio's retry can heal it", async () => {
+    setupEmailVmMocks({ signedUrlError: new Error("expiration date less than one week") });
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      statusText: "OK",
+      blob: async () => new Blob(["abc"], { type: "audio/mpeg" }),
+    } as any);
+
+    const mod = await import("../app/routes/api+/email-vm");
+    const res = await asRouteResponse(mod.action({
+      request: makeReq({ RecordingUrl: "https://tw/rec", CallSid: "CA1", AccountSid: "AC1", RecordingSid: "RE1" }),
+      params: {},
+    } as any));
+
+    expect(res.status).toBe(500);
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(telephonyDbMocks.updateCallRecordingUrlBySid).not.toHaveBeenCalled();
+  });
+
+  test("a resend API error is a retryable failure, not a silent success", async () => {
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      statusText: "OK",
+      blob: async () => new Blob(["abc"], { type: "audio/mpeg" }),
+    } as any);
+    mocks.sendEmail.mockResolvedValueOnce({
+      data: null,
+      error: { message: "Domain not verified" },
+    });
+
+    const mod = await import("../app/routes/api+/email-vm");
+    const res = await asRouteResponse(mod.action({
+      request: makeReq({ RecordingUrl: "https://tw/rec", CallSid: "CA1", AccountSid: "AC1", RecordingSid: "RE1" }),
+      params: {},
+    } as any));
+
+    expect(res.status).toBe(500);
+    expect(telephonyDbMocks.updateCallRecordingUrlBySid).not.toHaveBeenCalled();
+  });
+
 });

--- a/test/ui/use-campaign-call-flow.test.tsx
+++ b/test/ui/use-campaign-call-flow.test.tsx
@@ -68,4 +68,63 @@ describe("useCampaignCallFlow", () => {
     act(() => polling.onStatus?.("completed"));
     expect(send).toHaveBeenCalledWith({ type: "HANG_UP" });
   });
+
+  function renderFlow(initialState: string) {
+    const send = vi.fn();
+    const view = renderHook(
+      ({ state }: { state: string }) =>
+        useCampaignCallFlow({
+          callSid: "CA1",
+          agentLegSid: null,
+          workspaceId: "w1",
+          state,
+          activeCall: null,
+          recentAttemptDisposition: null,
+          predictiveState: { status: "unknown", contact_id: null },
+          isPredictive: false,
+          send,
+        }),
+      { initialProps: { state: initialState } },
+    );
+    return { ...view, send };
+  }
+
+  // Regression #1220: the previous call's terminal outcome flashed (or, with
+  // no browser leg SID, stuck) at the top of the screen when a new dial began.
+  test("a new dial immediately clears the previous call's terminal display", () => {
+    const { result, rerender } = renderFlow("dialing");
+
+    act(() => polling.onStatus?.("completed"));
+    rerender({ state: "completed" });
+    expect(result.current.displayState).toBe("completed");
+
+    // New dial: FSM goes dialing before any new leg SID exists (phone-as-
+    // device never gets one). The old outcome must not survive the gap.
+    rerender({ state: "dialing" });
+    expect(result.current.displayState).toBe("dialing");
+  });
+
+  test("a stale provider status does not repaint after a new dial starts", () => {
+    const { result, rerender } = renderFlow("dialing");
+
+    act(() => polling.onStatus?.("failed"));
+    rerender({ state: "failed" });
+    expect(result.current.displayState).toBe("failed");
+
+    rerender({ state: "dialing" });
+    expect(result.current.displayState).toBe("dialing");
+  });
+
+  test("advancing to the next contact resets a finished call to idle", () => {
+    const { result, rerender } = renderFlow("dialing");
+
+    act(() => polling.onStatus?.("completed"));
+    rerender({ state: "completed" });
+    expect(result.current.displayState).toBe("completed");
+
+    // The Next action sends NEXT to the FSM (completed -> idle); the bridge
+    // must clear the lifecycle rather than keep showing the old outcome.
+    rerender({ state: "idle" });
+    expect(result.current.displayState).toBe("idle");
+  });
 });

--- a/test/ui/use-campaign-dial-actions.test.ts
+++ b/test/ui/use-campaign-dial-actions.test.ts
@@ -190,7 +190,9 @@ describe("useCampaignDequeueActions", () => {
     expect(dequeue).toHaveBeenCalledWith({ contact: nextRecipient });
     expect(fetchMore).toHaveBeenCalledWith({ householdMap: { h1: [nextRecipient] } });
     expect(handleNextNumber).toHaveBeenCalledWith(false);
-    expect(send).toHaveBeenCalledWith({ type: "HANG_UP" });
+    // NEXT (not HANG_UP): advancing the queue must not park the FSM in
+    // "completed" from idle — the next dial flashed that stale outcome (#1220).
+    expect(send).toHaveBeenCalledWith({ type: "NEXT" });
     expect(setRecentAttempt).toHaveBeenCalledWith(null);
     expect(setUpdate).toHaveBeenCalledWith({});
     expect(setCallDuration).toHaveBeenCalledWith(0);

--- a/test/ui/use-dial-failure-recovery.test.ts
+++ b/test/ui/use-dial-failure-recovery.test.ts
@@ -86,4 +86,50 @@ describe("useDialFailureRecovery", () => {
     rerender(props);
     expect(send).toHaveBeenCalledTimes(1);
   });
+
+  // Regression #1221: the call screen recreates `showError`/`send` every
+  // render (and renders every second while the duration ticks), so identity
+  // churn alone re-ran the effect and re-toasted one rejection indefinitely.
+  test("fires once per rejection even when callback identities change every render", () => {
+    const send = vi.fn();
+    const showError = vi.fn();
+    const rejection = { error: "This contact already has a call in progress." };
+    const { rerender } = renderHook(
+      (p: HookProps) => useDialFailureRecovery(p),
+      {
+        initialProps: baseProps({ fetcherData: rejection, send, showError }),
+      },
+    );
+    expect(showError).toHaveBeenCalledTimes(1);
+
+    // Same settled data, fresh callback identities — must not re-fire.
+    rerender(
+      baseProps({
+        fetcherData: rejection,
+        send: (action) => send(action),
+        showError: (message) => showError(message),
+      }),
+    );
+    rerender(
+      baseProps({
+        fetcherData: rejection,
+        send: (action) => send(action),
+        showError: (message) => showError(message),
+      }),
+    );
+    expect(showError).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // A new settled rejection (new data identity) fires again.
+    rerender(
+      baseProps({
+        fetcherData: { error: "This contact is no longer queued." },
+        send: (action) => send(action),
+        showError: (message) => showError(message),
+      }),
+    );
+    expect(showError).toHaveBeenCalledTimes(2);
+    expect(showError).toHaveBeenLastCalledWith("This contact is no longer queued.");
+    expect(send).toHaveBeenCalledTimes(2);
+  });
 });

--- a/test/webhook-side-effects.test.ts
+++ b/test/webhook-side-effects.test.ts
@@ -164,6 +164,58 @@ describe("webhook side-effect handlers", () => {
       "w1",
       expect.objectContaining({ contact_id: 123 }),
     );
+    // #1218: a provider-terminal status stamps the disposition so the call
+    // shows up in campaign results even when the browser never hit /api/hangup.
+    expect(mocks.updateOutreachAttemptForWorkspace).toHaveBeenCalledWith(
+      "w1",
+      10,
+      expect.objectContaining({ disposition: "completed", ended_at: expect.any(String) }),
+    );
+  });
+
+  test.each([
+    ["no-answer", "no-answer"],
+    ["busy", "busy"],
+    ["failed", "failed"],
+  ])("runCallStatusSideEffects stamps %s as disposition", async (status, disposition) => {
+    const { runCallStatusSideEffects } = await import(
+      "@/lib/worker/webhook-side-effects.server"
+    );
+    await runCallStatusSideEffects({
+      callSid: "CA1",
+      twilioParams: { CallSid: "CA1", CallStatus: status },
+    });
+    expect(mocks.updateOutreachAttemptForWorkspace).toHaveBeenCalledWith(
+      "w1",
+      10,
+      expect.objectContaining({ disposition }),
+    );
+  });
+
+  test("runCallStatusSideEffects never downgrades a terminal disposition (AMD voicemail)", async () => {
+    mocks.findOutreachAttemptWithCampaignType.mockResolvedValue({
+      disposition: "voicemail",
+      contact_id: 123,
+      workspace: "w1",
+    });
+    const { runCallStatusSideEffects } = await import(
+      "@/lib/worker/webhook-side-effects.server"
+    );
+    await runCallStatusSideEffects({
+      callSid: "CA1",
+      twilioParams: { CallSid: "CA1", CallStatus: "completed" },
+    });
+    expect(mocks.updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("runCallStatusSideEffects ignores non-terminal statuses", async () => {
+    const { runCallStatusSideEffects } = await import(
+      "@/lib/worker/webhook-side-effects.server"
+    );
+    await runCallStatusSideEffects({
+      callSid: "CA1",
+      twilioParams: { CallSid: "CA1", CallStatus: "in-progress" },
+    });
     expect(mocks.updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Fixes the three call-screen bugs blocking testing on dev, from today's QA session.

## #1220 — previous call's Call Failed/Completed flashed on every new dial

The FSM→lifecycle bridge refused `START_DIALING` from a terminal phase (the reducer handles it — it starts a fresh generation), so the old outcome showed until the new browser leg SID arrived — and **stuck forever** when the agent device is a physical phone (no SDK SID ever arrives). The bridge now delivers `START_DIALING` and drops the previous call's provider status + leg SIDs so late events from old legs can't repaint. Advancing the queue sends `NEXT` instead of `HANG_UP` (which parked the FSM in "completed" from idle), and the FSM's return to idle maps to a lifecycle `RESET`.

## #1218 / #1219 — completed calls invisible in campaign results

`create_outreach_attempt` RETURNS **bigint**; postgres.js returns int8 as a **string**, and the dial route's `Number.isFinite("123")` guard is false — so every manual dial wrote `call.outreach_attempt_id = NULL` and all four disposition writers (browser hangup, AMD voicemail, AMD answered_at, worker side effects) silently no-oped. The results query counts only attempts with a disposition → 0 results.

- db-rpc scalar bigint results are coerced via `queryScalarNumber` (garbage throws instead of propagating); the queue-order-range RPC is hardened the same way.
- Worker call-status side effects now stamp a disposition + `ended_at` from provider-terminal statuses behind the transition guard — every call yields a results row even when the browser never reaches `/api/hangup`. AMD `voicemail` is never downgraded; an explicit agent choice via `/api/questions` bypasses the guard and always wins.
- Auto-accepted campaign calls now attach disconnect/cancel listeners (teardown only — the full set's accept handler fires "connected", which campaign outbound suppresses), so a callee-initiated hangup tears down `activeCall` and the FSM.

## #1221 — dial-rejection toast re-fired every render

`useDialFailureRecovery` latches on the settled fetcher data identity; `showError`/`send` are recreated each render (once per second during a call), so identity churn alone re-toasted a single 409 indefinitely.

## #1224 — voicemail captured but email never sent

The email route presigned the recording link for **100 days**; SigV4 caps presigned URLs at 7 days and the signer throws client-side, so the upload landed (voicemail visible in the app) but the send was never reached — and because `recording_url` persisted *before* the send, the idempotency guard answered every Twilio retry with "Already processed". Broken in every environment since the Supabase→S3 storage migration. Fixed: TTL clamped to 7 days (with a clamp+warn guardrail inside `createSignedObjectUrl` so no call site can reintroduce it), `recording_url` persists only after a successful send so failures stay retryable, and resend's `{ error }` result is now checked instead of reported as "email sent".

## Tests

- New: bigint-coercion regression suite; worker disposition-stamping cases (terminal statuses, voicemail no-downgrade, non-terminal ignored); call-flow regressions (new dial clears terminal display, stale provider status can't repaint, NEXT resets to idle); identity-churn toast regression (the old test held identities stable, which is exactly why the bug escaped it).
- Full local gate green: typecheck, lint, test:node (347 files), test:ui (110 files).

Related: #1222 (queue_id never persisted on dial — filed separately, found in passing).

Closes #1218
Closes #1219
Closes #1220
Closes #1221
Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
