### PR TITLE
Coerce raw-SQL bigint results at RPC boundaries; store valid Cache-Control

### DIFF
--- a/app/lib/database/workspace-conversations.server.ts
+++ b/app/lib/database/workspace-conversations.server.ts
@@ -344,9 +344,12 @@ export async function fetchConversationSummary(
 
   const chats: ConversationSummary[] = pageRows.map((row) => {
     const conversationKey = getConversationPhoneKey(row.contact_phone);
-    if (conversationKey && typeof row.primary_contact_id === "number") {
-      conversationContactIds.set(conversationKey, row.primary_contact_id);
-      contactIds.add(row.primary_contact_id);
+    // bigint aggregate arrives as a string from the raw execute (#1227);
+    // the sibling counts are ::int-cast in SQL, this one is coerced here.
+    const primaryContactId = Number(row.primary_contact_id);
+    if (conversationKey && Number.isFinite(primaryContactId)) {
+      conversationContactIds.set(conversationKey, primaryContactId);
+      contactIds.add(primaryContactId);
     }
 
     return {

--- a/app/lib/db-rpc.server.ts
+++ b/app/lib/db-rpc.server.ts
@@ -46,6 +46,27 @@ async function queryScalarNumber(
   return value;
 }
 
+/**
+ * Coerce named columns of raw-SQL rows to finite numbers. Same driver quirk
+ * as queryScalarNumber: bigint/numeric arrive as strings from postgres.js,
+ * and downstream `typeof === "number"` checks silently drop them
+ * (#1225/#1226/#1227). Non-finite values become null rather than NaN.
+ */
+function coerceRowNumbers<T extends Record<string, unknown>>(
+  rows: T[],
+  keys: ReadonlyArray<string>,
+): T[] {
+  return rows.map((row) => {
+    const patched: Record<string, unknown> = { ...row };
+    for (const key of keys) {
+      if (patched[key] == null) continue;
+      const value = Number(patched[key]);
+      patched[key] = Number.isFinite(value) ? value : null;
+    }
+    return patched as T;
+  });
+}
+
 async function execVoid(executor: RpcExecutor, query: SQL): Promise<void> {
   await executor.execute(query);
 }
@@ -310,10 +331,11 @@ export async function rpcGetCampaignStats(
   executor: RpcExecutor,
   campaignId: number | string,
 ): Promise<CampaignStatRow[]> {
-  return queryRows<CampaignStatRow>(
+  const rows = await queryRows<CampaignStatRow>(
     executor,
     sql`select * from get_campaign_stats(${Number(campaignId)})`,
   );
+  return coerceRowNumbers(rows, ["count", "expected_total"]);
 }
 
 export async function rpcResetCampaign(
@@ -384,10 +406,11 @@ export async function rpcFindContactByPhone(
   workspaceId: string,
   phoneNumber: string,
 ): Promise<Record<string, unknown>[]> {
-  return queryRows(
+  const rows = await queryRows(
     db,
     sql`select * from find_contact_by_phone(${phoneNumber}, ${workspaceId}::uuid)`,
   );
+  return coerceRowNumbers(rows, ["id"]);
 }
 
 export async function rpcFindContactsByPhones(
@@ -395,13 +418,14 @@ export async function rpcFindContactsByPhones(
   phoneNumbers: string[],
 ): Promise<Record<string, unknown>[]> {
   if (phoneNumbers.length === 0) return [];
-  return queryRows(
+  const rows = await queryRows(
     db,
     sql`select * from find_contacts_by_phones(${workspaceId}::uuid, array[${sql.join(
       phoneNumbers.map((phone) => sql`${phone}`),
       sql`, `,
     )}]::text[])`,
   );
+  return coerceRowNumbers(rows, ["id"]);
 }
 
 export async function rpcGetAudiencesByCampaign(
@@ -412,7 +436,7 @@ export async function rpcGetAudiencesByCampaign(
       db,
       sql`select * from get_audiences_by_campaign(${campaignId})`,
     );
-    return { data, error: null };
+    return { data: coerceRowNumbers(data, ["id"]), error: null };
   } catch (error) {
     return {
       data: null,

--- a/app/lib/inbound-sms-context.server.ts
+++ b/app/lib/inbound-sms-context.server.ts
@@ -113,11 +113,14 @@ export async function findMatchingContactIds(workspaceId: string,
     return [];
   }
 
+  // Coerce rather than type-filter: raw-SQL bigint ids arrive as strings,
+  // and the old `typeof === "number"` filter dropped every match — inbound
+  // SMS never linked to a contact and STOP opt-outs never applied (#1225).
   return Array.from(
     new Set(
       (contacts ?? [])
-        .map((contact) => contact?.id)
-        .filter((contactId): contactId is number => typeof contactId === "number"),
+        .map((contact) => Number(contact?.id))
+        .filter((contactId) => Number.isFinite(contactId)),
     ),
   );
 }

--- a/app/lib/object-storage.server.ts
+++ b/app/lib/object-storage.server.ts
@@ -173,7 +173,14 @@ export async function uploadObject(
         Key: key,
         Body: payload,
         ContentType: options.contentType,
-        CacheControl: options.cacheControl,
+        // Supabase Storage took bare seconds ("60") and expanded them to
+        // max-age; S3 stores the header verbatim, so a bare number is an
+        // invalid directive that caches nothing (#1228). Normalize here so
+        // no call site can regress.
+        CacheControl:
+          options.cacheControl && /^\d+$/.test(options.cacheControl)
+            ? `max-age=${options.cacheControl}`
+            : options.cacheControl,
         // `upsert` predates the S3 migration (it was a Supabase storage flag)
         // and was silently dropped here, so callers asking not to overwrite
         // were overwriting anyway. For audio that is not just a lost file: a

--- a/test/db-rpc-bigint-coercion.test.ts
+++ b/test/db-rpc-bigint-coercion.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression #1225/#1226/#1227: postgres.js returns bigint/numeric columns
+ * from raw SQL as STRINGS. RPC wrappers must coerce, or downstream
+ * `typeof === "number"` checks silently drop rows — inbound SMS never linked
+ * to contacts (STOP opt-outs ignored), campaign result totals concatenated,
+ * conversation contact-id matching never ran.
+ */
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const dbMock = vi.hoisted(() => ({ execute: vi.fn() }));
+vi.mock("@/server/db", () => ({ db: dbMock }));
+vi.mock("@/lib/logger.server", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  rpcFindContactByPhone,
+  rpcFindContactsByPhones,
+  rpcGetCampaignStats,
+  rpcGetAudiencesByCampaign,
+} from "@/lib/db-rpc.server";
+
+describe("raw-SQL bigint coercion at RPC boundaries", () => {
+  beforeEach(() => {
+    dbMock.execute.mockReset();
+  });
+
+  test("rpcFindContactByPhone coerces string ids to numbers", async () => {
+    dbMock.execute.mockResolvedValue([
+      { id: "123", phone: "+15550001111" },
+      { id: 456, phone: "+15550001111" },
+    ]);
+    const rows = await rpcFindContactByPhone("w1", "+15550001111");
+    expect(rows.map((r) => r.id)).toEqual([123, 456]);
+  });
+
+  test("rpcFindContactsByPhones coerces string ids to numbers", async () => {
+    dbMock.execute.mockResolvedValue([{ id: "9", phone: "+15550001111" }]);
+    const rows = await rpcFindContactsByPhones("w1", ["+15550001111"]);
+    expect(rows[0]?.id).toBe(9);
+  });
+
+  test("rpcGetCampaignStats coerces bigint count and numeric expected_total", async () => {
+    dbMock.execute.mockResolvedValue([
+      { disposition: "completed", count: "5", average_call_duration: null, expected_total: "12.5" },
+    ]);
+    const rows = await rpcGetCampaignStats(dbMock, 42);
+    expect(rows[0]?.count).toBe(5);
+    expect(rows[0]?.expected_total).toBe(12.5);
+    // The exact failure mode: string counts concatenate instead of adding.
+    expect(rows.reduce((acc, r) => acc + (r.count as number), 0)).toBe(5);
+  });
+
+  test("rpcGetAudiencesByCampaign coerces string audience ids", async () => {
+    dbMock.execute.mockResolvedValue([{ id: "7", name: "A" }]);
+    const result = await rpcGetAudiencesByCampaign(1);
+    expect(result.error).toBeNull();
+    expect(result.data?.[0]?.id).toBe(7);
+  });
+
+  test("garbage values become null, not NaN", async () => {
+    dbMock.execute.mockResolvedValue([{ id: "not-a-number", phone: "+1" }]);
+    const rows = await rpcFindContactByPhone("w1", "+1");
+    expect(rows[0]?.id).toBeNull();
+  });
+});
+
+describe("findMatchingContactIds", () => {
+  test("returns ids even when the driver hands back strings", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/database/contact.server", () => ({
+      findPotentialContacts: vi.fn(async () => ({
+        data: [{ id: "123" }, { id: "123" }, { id: 456 }],
+        error: null,
+      })),
+    }));
+    const { findMatchingContactIds } = await import("@/lib/inbound-sms-context.server");
+    const ids = await findMatchingContactIds("w1", "+15550001111");
+    expect(ids).toEqual([123, 456]);
+  });
+});

--- a/test/object-storage-upsert.test.ts
+++ b/test/object-storage-upsert.test.ts
@@ -128,4 +128,28 @@ describe("uploadObject upsert handling", () => {
       mod.uploadObject("workspaceAudio", "w1/intro.mp3", Buffer.from("a")),
     ).rejects.not.toBeInstanceOf(mod.ObjectExistsError);
   });
+
+  // #1228: Supabase Storage's cacheControl took bare seconds; S3 stores the
+  // header verbatim, so "60" was an invalid Cache-Control that cached nothing.
+  test("normalizes bare-seconds cacheControl to max-age", async () => {
+    mockS3();
+    send.mockResolvedValue({});
+    const mod = await import("../app/lib/object-storage.server");
+    await mod.uploadObject("workspaceAudio", "w1/a.mp3", Buffer.from("a"), {
+      cacheControl: "60",
+    });
+    const input = (send.mock.calls[0][0] as { input: { CacheControl?: string } }).input;
+    expect(input.CacheControl).toBe("max-age=60");
+  });
+
+  test("passes through an already-valid Cache-Control directive", async () => {
+    mockS3();
+    send.mockResolvedValue({});
+    const mod = await import("../app/lib/object-storage.server");
+    await mod.uploadObject("workspaceAudio", "w1/b.mp3", Buffer.from("a"), {
+      cacheControl: "max-age=3600, public",
+    });
+    const input = (send.mock.calls[0][0] as { input: { CacheControl?: string } }).input;
+    expect(input.CacheControl).toBe("max-age=3600, public");
+  });
 });


### PR DESCRIPTION
Legacy-sweep fixes: three more live instances of the postgres.js bigint-as-string class that broke campaign results in #1218, plus a Supabase-semantics header bug.

## #1225 — compliance-critical: STOP opt-outs silently ignored

`find_contact_by_phone` returns contact rows via raw SQL; bigint ids arrive as strings and `findMatchingContactIds` filtered them with `typeof === "number"` — always empty. Inbound SMS never linked to a contact, the STOP branch never marked `opt_out` or dequeued, START never re-subscribed, and the chat guards silently returned false. Ids are now coerced at the RPC boundary and the filter parses instead of type-dropping. (Tests had mocked the matcher with hand-written numbers, which is exactly why CI stayed green.)

## #1226 — results totals string-concatenated

`get_campaign_stats` `count bigint` / `expected_total numeric` reached the UI as strings; `+=` and `reduce` concatenated ("053"). Coerced in `rpcGetCampaignStats`.

## #1227 — conversation contact-id matching never ran

`primary_contact_id` (bigint aggregate, raw execute) failed its `typeof` check, so every conversations page paid a phone-lookup fallback and mis-resolved contacts sharing a number. Coerced like the sibling `::int`-cast counts.

## #1228 — invalid Cache-Control on uploads

Supabase Storage expanded bare seconds ("60") to `max-age=60`; S3 stores the header verbatim, so five call sites cached nothing. `uploadObject` now normalizes bare-numeric strings to `max-age=<n>` — fixed at the boundary so no call site can regress.

## Mechanics

Shared `coerceRowNumbers` helper in db-rpc (same boundary as #1218's `queryScalarNumber`); garbage coerces to `null`, never `NaN`. Also coerces `rpcGetAudiencesByCampaign` ids found in the same audit. Regression tests feed string ids/counts through every fixed path. Full local gate green: typecheck, lint, test:node (348 files), test:ui (110 files).

Follow-ups filed from the same sweep: #1229 (dangerous DB orphans + check:db-orphans ratchet), #1230 (schema serial-vs-bigint truth), #1231 (dead Supabase shims).

Closes #1225
Closes #1226
Closes #1227
Closes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)