### PR TITLE
fix(billing): wire bounded credit reconciliation after terminal campaign calls

### DIFF
--- a/app/hooks/billing/useCreditBalance.ts
+++ b/app/hooks/billing/useCreditBalance.ts
@@ -1,38 +1,48 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { PostgresChangePayload } from "@/lib/workspace-events.shared";
 
 export function useCreditBalance(initialCredits: number) {
   const [credits, setCredits] = useState(initialCredits);
-  const [lastAppliedLedgerId, setLastAppliedLedgerId] = useState<number>(0);
+  // Ref, not state: applyLedgerEntry and reconcileFromServer must observe the
+  // latest applied ledger id synchronously (SSE events and fetch responses can
+  // interleave within one render), and dedup must survive applySnapshot.
+  const lastAppliedLedgerIdRef = useRef(0);
 
-  const applyLedgerEntry = useCallback(
-    (payload: PostgresChangePayload) => {
-      if (payload.eventType !== "INSERT") return;
-      const newRow = payload.new as { id?: number; amount?: number } | null;
-      if (!newRow || newRow.id == null || newRow.amount == null) return;
-      if (newRow.id <= lastAppliedLedgerId) return;
+  const applyLedgerEntry = useCallback((payload: PostgresChangePayload) => {
+    if (payload.eventType !== "INSERT") return;
+    const newRow = payload.new as { id?: number; amount?: number } | null;
+    if (!newRow || newRow.id == null || newRow.amount == null) return;
+    if (newRow.id <= lastAppliedLedgerIdRef.current) return;
 
-      setCredits((prev) => prev + Number(newRow.amount!));
-      setLastAppliedLedgerId(newRow.id!);
-    },
-    [lastAppliedLedgerId],
-  );
-
-  const applySnapshot = useCallback((newCredits: number) => {
-    setCredits(newCredits);
-    setLastAppliedLedgerId(0);
+    lastAppliedLedgerIdRef.current = newRow.id;
+    setCredits((prev) => prev + Number(newRow.amount));
   }, []);
 
+  const applySnapshot = useCallback((newCredits: number) => {
+    // The snapshot is an authoritative balance that already includes every
+    // ledger row it postdates — keep the dedup watermark so a duplicate SSE
+    // delivery of an already-applied event cannot re-apply on top of it.
+    setCredits(newCredits);
+  }, []);
+
+  /**
+   * Fetch the authoritative balance and apply it, unless a newer ledger event
+   * arrived while the request was in flight (the snapshot would then predate
+   * local state). Returns the applied balance, or null when skipped.
+   */
   const reconcileFromServer = useCallback(
-    async (workspaceId: string) => {
+    async (workspaceId: string): Promise<number | null> => {
+      const ledgerIdAtFetch = lastAppliedLedgerIdRef.current;
       const res = await fetch(
         `/api/workspaces/${encodeURIComponent(workspaceId)}/credits`,
       );
       if (!res.ok) throw new Error(`Failed to reconcile credits: ${res.status}`);
       const data = (await res.json()) as { credits: number };
-      applySnapshot(data.credits);
+      if (lastAppliedLedgerIdRef.current !== ledgerIdAtFetch) return null;
+      setCredits(data.credits);
+      return data.credits;
     },
-    [applySnapshot],
+    [],
   );
 
   return {

--- a/app/hooks/billing/useCreditReconciliation.ts
+++ b/app/hooks/billing/useCreditReconciliation.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import { logger } from "@/lib/logger.client";
+
+export const CREDIT_RECONCILE_INTERVAL_MS = 2_000;
+export const CREDIT_RECONCILE_WINDOW_MS = 30_000;
+
+type UseCreditReconciliationOptions = {
+  workspaceId: string;
+  /** True while the campaign call screen shows a terminal outcome. */
+  isTerminal: boolean;
+  /** Current balance from useCreditBalance — used to detect convergence. */
+  credits: number;
+  /** useCreditBalance.reconcileFromServer */
+  reconcile: (workspaceId: string) => Promise<number | null>;
+};
+
+/**
+ * Bounded credit reconciliation after a terminal campaign call (#1234).
+ *
+ * Billing is server-authoritative and normally reaches the UI as a ledger SSE
+ * event. If that event is missed, the balance shown on the call screen is
+ * stale until reload. When a call reaches a terminal outcome, poll the narrow
+ * balance endpoint every 2s for up to 30s, stopping early as soon as the
+ * balance moves (SSE debit or fetched snapshot), a new dial starts (isTerminal
+ * drops), or the screen unmounts.
+ */
+export function useCreditReconciliation({
+  workspaceId,
+  isTerminal,
+  credits,
+  reconcile,
+}: UseCreditReconciliationOptions) {
+  const creditsRef = useRef(credits);
+  creditsRef.current = credits;
+  const reconcileRef = useRef(reconcile);
+  reconcileRef.current = reconcile;
+
+  /**
+   * @effect Poll the workspace balance endpoint after a terminal call until the credit display converges on the ledger.
+   * @effect-deps isTerminal (call reached/left a terminal outcome), workspaceId
+   * @effect-side-effects setInterval polling GET /api/workspaces/:workspaceId/credits (max 30s, 2s cadence); cleared on convergence, timeout, new dial, unmount
+   * @effect-why-not-loader Convergence is a client-time bounded retry against a missed SSE event; a loader only runs on navigation/revalidation and cannot poll.
+   */
+  useEffect(() => {
+    if (!isTerminal || !workspaceId) return;
+
+    const baseline = creditsRef.current;
+    const startedAt = Date.now();
+    const interval = setInterval(() => {
+      if (
+        creditsRef.current !== baseline ||
+        Date.now() - startedAt >= CREDIT_RECONCILE_WINDOW_MS
+      ) {
+        clearInterval(interval);
+        return;
+      }
+      void reconcileRef.current(workspaceId).catch((error) => {
+        // Transient fetch failures just wait for the next tick.
+        logger.debug("credit reconciliation poll failed", { error });
+      });
+    }, CREDIT_RECONCILE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [isTerminal, workspaceId]);
+}

--- a/app/hooks/call/useCallScreen.ts
+++ b/app/hooks/call/useCallScreen.ts
@@ -30,6 +30,7 @@ import {
 import { usePredictiveCallSync } from "@/hooks/call/usePredictiveCallSync";
 import { useNextRecipientSync } from "@/hooks/call/useNextRecipientSync";
 import { useDialFailureRecovery } from "@/hooks/call/useDialFailureRecovery";
+import { useCreditReconciliation } from "@/hooks/billing/useCreditReconciliation";
 import { getCallSid } from "@/lib/twilio/twilio-call-params";
 import { KEYPAD_KEYS } from "@/lib/dtmf";
 import type {
@@ -174,6 +175,7 @@ export function useCallScreen() {
     householdMap,
     nextRecipient,
     setNextRecipient,
+    reconcileCredits,
   } = useWorkspaceRealtime({
     user: user as unknown as AppUser,
     init: {
@@ -208,6 +210,19 @@ export function useCallScreen() {
     predictiveState,
     isPredictive: campaign?.dial_type === "predictive",
     send: send as unknown as (action: { type: string }) => void,
+  });
+
+  // A missed ledger SSE event would leave the credit display stale after a
+  // billable call — converge on the server balance within 30s (#1234).
+  useCreditReconciliation({
+    workspaceId,
+    isTerminal:
+      displayState === "completed" ||
+      displayState === "failed" ||
+      displayState === "no-answer" ||
+      displayState === "voicemail",
+    credits: availableCredits,
+    reconcile: reconcileCredits,
   });
 
   const { begin, conference, setConference, creditsError: conferenceCreditsError } = useStartConferenceAndDial(

--- a/app/hooks/realtime/useWorkspaceRealtime.ts
+++ b/app/hooks/realtime/useWorkspaceRealtime.ts
@@ -84,6 +84,7 @@ export const useWorkspaceRealtime = ({
   const {
     credits: availableCredits,
     applyLedgerEntry: updateCredits,
+    reconcileFromServer: reconcileCredits,
   } = useCreditBalance(init.credits || 0);
 
   const callsListRef = useRef(callsList);
@@ -328,5 +329,6 @@ export const useWorkspaceRealtime = ({
     householdMap,
     setPhoneNumbers,
     availableCredits,
+    reconcileCredits,
   };
 };

--- a/docs/effects-inventory.md
+++ b/docs/effects-inventory.md
@@ -5,7 +5,7 @@
 > the state it depends on, and the side effects it performs. See
 > [effects-strictness.md](./effects-strictness.md).
 
-**112** documented / **114** total effects (2 grandfathered, ratcheting to 0).
+**113** documented / **115** total effects (2 grandfathered, ratcheting to 0).
 
 | File | Purpose | Depends on | Side effects | Why not a loader/fetcher |
 | --- | --- | --- | --- | --- |
@@ -29,6 +29,7 @@
 | `app/components/sms-ui/ChatInput.tsx` | KEEP: align the controlled From selection with available sender | initialFrom, workspaceNumbers (available sender option values) | setSelectedFrom only | selectedFrom is intentional user-controlled state; |
 | `app/components/sms-ui/ChatInput.tsx` | After a scheduled-send submission completes, clear the schedule | messageFetcher.data, messageFetcher.state (tracks the | setSendLater, setSendAtLocal only | Schedule UI state is client-controlled; we only |
 | `app/hooks/agent/useAgentStatus.ts` | Load the agent's current status on mount and send a heartbeat POST every 30s while mounted. | workspaceId, userId (guards + re-arms the heartbeat when either changes), refreshStatus | timer (setInterval heartbeat) + fetch (initial refreshStatus() and each heartbeat POST); interval cleared on unmount/dep change | The recurring heartbeat is live client-only polling a loader can't express; |
+| `app/hooks/billing/useCreditReconciliation.ts` | Poll the workspace balance endpoint after a terminal call until the credit display converges on the ledger. | isTerminal (call reached/left a terminal outcome), workspaceId | setInterval polling GET /api/workspaces/:workspaceId/credits (max 30s, 2s cadence); cleared on convergence, timeout, new dial, unmount | Convergence is a client-time bounded retry against a missed SSE event; a loader only runs on navigation/revalidation and cannot poll. |
 | `app/hooks/call/useCallAudioControls.ts` | Create a Web Audio API AudioContext on mount for DTMF tone | [] — intentionally mount-once; the AudioContext should be | dom (Web Audio API AudioContext construction/close) | Browser audio API object construction, not |
 | `app/hooks/call/useCallAudioControls.ts` | Enumerate audio devices on mount and subscribe to OS | refreshDevices (stable callback) | subscription (mediaDevices "devicechange" listener) | Browser hardware enumeration is a client-only API. |
 | `app/hooks/call/useCallAudioControls.ts` | Apply the selected microphone and speaker device IDs to the | device, microphone, output | dom (Twilio Device audio input/output routing) | Live Twilio audio routing follows user device picks. |

--- a/test/ui/use-credit-balance.test.tsx
+++ b/test/ui/use-credit-balance.test.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { useCreditBalance } from "@/hooks/billing/useCreditBalance";
+import type { PostgresChangePayload } from "@/lib/workspace-events.shared";
+
+function ledgerInsert(id: number, amount: number): PostgresChangePayload {
+  return {
+    eventType: "INSERT",
+    table: "transaction_history",
+    new: { id, amount },
+    old: null,
+  } as unknown as PostgresChangePayload;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useCreditBalance", () => {
+  test("applies ledger inserts and ignores duplicate or older ids", () => {
+    const { result } = renderHook(() => useCreditBalance(10));
+
+    act(() => result.current.applyLedgerEntry(ledgerInsert(5, -2)));
+    expect(result.current.credits).toBe(8);
+
+    act(() => result.current.applyLedgerEntry(ledgerInsert(5, -2)));
+    expect(result.current.credits).toBe(8);
+
+    act(() => result.current.applyLedgerEntry(ledgerInsert(4, -3)));
+    expect(result.current.credits).toBe(8);
+  });
+
+  test("duplicate ledger event after a snapshot does not re-apply (#1234)", () => {
+    const { result } = renderHook(() => useCreditBalance(10));
+
+    act(() => result.current.applyLedgerEntry(ledgerInsert(7, -4)));
+    expect(result.current.credits).toBe(6);
+
+    // Authoritative snapshot lands (e.g. reconciliation) with the same balance.
+    act(() => result.current.applySnapshot(6));
+    expect(result.current.credits).toBe(6);
+
+    // A duplicate SSE delivery of the already-applied event must be ignored —
+    // previously applySnapshot reset the watermark and this double-debited.
+    act(() => result.current.applyLedgerEntry(ledgerInsert(7, -4)));
+    expect(result.current.credits).toBe(6);
+  });
+
+  test("reconcileFromServer applies the fetched balance", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ credits: 42 }),
+      }),
+    );
+    const { result } = renderHook(() => useCreditBalance(10));
+
+    let applied: number | null = null;
+    await act(async () => {
+      applied = await result.current.reconcileFromServer("ws-1");
+    });
+
+    expect(applied).toBe(42);
+    expect(result.current.credits).toBe(42);
+    expect(fetch).toHaveBeenCalledWith("/api/workspaces/ws-1/credits");
+  });
+
+  test("reconcileFromServer skips a snapshot that raced a newer ledger event", async () => {
+    let resolveFetch!: (value: unknown) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(new Promise((resolve) => (resolveFetch = resolve))),
+    );
+    const { result } = renderHook(() => useCreditBalance(10));
+
+    let pending!: Promise<number | null>;
+    act(() => {
+      pending = result.current.reconcileFromServer("ws-1");
+    });
+
+    // A ledger debit arrives while the balance request is in flight; the
+    // response snapshot predates it and must not clobber the newer state.
+    act(() => result.current.applyLedgerEntry(ledgerInsert(9, -5)));
+    expect(result.current.credits).toBe(5);
+
+    let applied: number | null = 0;
+    await act(async () => {
+      resolveFetch({ ok: true, json: async () => ({ credits: 10 }) });
+      applied = await pending;
+    });
+
+    expect(applied).toBeNull();
+    expect(result.current.credits).toBe(5);
+  });
+
+  test("reconcileFromServer throws on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    const { result } = renderHook(() => useCreditBalance(10));
+
+    await expect(result.current.reconcileFromServer("ws-1")).rejects.toThrow(
+      "Failed to reconcile credits: 500",
+    );
+    expect(result.current.credits).toBe(10);
+  });
+});

--- a/test/ui/use-credit-reconciliation.test.tsx
+++ b/test/ui/use-credit-reconciliation.test.tsx
@@ -1,0 +1,130 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  useCreditReconciliation,
+  CREDIT_RECONCILE_INTERVAL_MS,
+  CREDIT_RECONCILE_WINDOW_MS,
+} from "@/hooks/billing/useCreditReconciliation";
+
+vi.mock("@/lib/logger.client", () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+type HookProps = {
+  isTerminal: boolean;
+  credits: number;
+  reconcile: (workspaceId: string) => Promise<number | null>;
+};
+
+function renderReconciliation(initial: Partial<HookProps> = {}) {
+  const reconcile = vi.fn().mockResolvedValue(null);
+  const utils = renderHook(
+    (props: HookProps) =>
+      useCreditReconciliation({ workspaceId: "ws-1", ...props }),
+    {
+      initialProps: {
+        isTerminal: false,
+        credits: 10,
+        reconcile,
+        ...initial,
+      },
+    },
+  );
+  return { ...utils, reconcile };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("useCreditReconciliation", () => {
+  test("does not poll while the call is not terminal", () => {
+    const { reconcile } = renderReconciliation();
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_WINDOW_MS));
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  test("polls every 2s once the call reaches a terminal state", () => {
+    const { rerender, reconcile } = renderReconciliation();
+
+    rerender({ isTerminal: true, credits: 10, reconcile });
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS * 3));
+
+    expect(reconcile).toHaveBeenCalledTimes(3);
+    expect(reconcile).toHaveBeenCalledWith("ws-1");
+  });
+
+  test("stops polling as soon as the balance moves", () => {
+    const { rerender, reconcile } = renderReconciliation({ isTerminal: true });
+
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS));
+    expect(reconcile).toHaveBeenCalledTimes(1);
+
+    // An SSE debit (or applied snapshot) changes the balance.
+    rerender({ isTerminal: true, credits: 9, reconcile });
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS * 5));
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  test("gives up after the 30s window", () => {
+    const { reconcile } = renderReconciliation({ isTerminal: true });
+
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_WINDOW_MS * 2));
+
+    // Ticks at 2s..28s fetch; the 30s tick observes the deadline and stops.
+    expect(reconcile).toHaveBeenCalledTimes(
+      CREDIT_RECONCILE_WINDOW_MS / CREDIT_RECONCILE_INTERVAL_MS - 1,
+    );
+  });
+
+  test("stops when a new dial starts (terminal state clears)", () => {
+    const { rerender, reconcile } = renderReconciliation({ isTerminal: true });
+
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS));
+    expect(reconcile).toHaveBeenCalledTimes(1);
+
+    rerender({ isTerminal: false, credits: 10, reconcile });
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS * 5));
+
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed poll is swallowed and the next tick retries", async () => {
+    const reconcile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValue(null);
+    renderReconciliation({ isTerminal: true, reconcile });
+
+    await act(async () => {
+      vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS);
+      await Promise.resolve();
+    });
+
+    expect(reconcile).toHaveBeenCalledTimes(2);
+  });
+
+  test("a fresh terminal call after a new dial restarts the window", () => {
+    const { rerender, reconcile } = renderReconciliation({ isTerminal: true });
+
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_WINDOW_MS * 2));
+    const firstWindowCalls = reconcile.mock.calls.length;
+
+    // New dial, then the next call ends.
+    rerender({ isTerminal: false, credits: 10, reconcile });
+    rerender({ isTerminal: true, credits: 10, reconcile });
+    act(() => vi.advanceTimersByTime(CREDIT_RECONCILE_INTERVAL_MS * 2));
+
+    expect(reconcile.mock.calls.length).toBe(firstWindowCalls + 2);
+  });
+});


### PR DESCRIPTION
Closes #1234

## What

Completes the last unwired piece of the campaign-call stability plan (KR4): the credit display now converges on the ledger balance within 30s after a terminal call even when the ledger SSE event is missed.

- **`useCreditBalance`**: `applySnapshot` no longer resets the ledger dedup watermark (a duplicate SSE delivery after a snapshot used to double-apply its amount). `reconcileFromServer` now skips applying a balance snapshot that raced a newer in-flight ledger event, and returns the applied balance.
- **New `useCreditReconciliation` hook**: when the campaign call screen shows a terminal outcome (completed / failed / no-answer / voicemail), polls `GET /api/workspaces/:workspaceId/credits` every 2s for up to 30s. Stops early as soon as the balance moves (SSE debit or applied snapshot), a new dial starts, or the screen unmounts.
- **Wiring**: `useWorkspaceRealtime` exposes `reconcileCredits`; `useCallScreen` drives the hook off `displayState` from `useCampaignCallFlow`.

## Why

The balance endpoint and `reconcileFromServer` landed earlier, but nothing called them — a missed ledger SSE event left the header/banner/dial-gate credits stale until reload. Billing stays server-authoritative; the browser never optimistically debits.

## Tests

- `test/ui/use-credit-balance.test.tsx`: dedup on duplicate/older ids, duplicate-after-snapshot regression, snapshot race skip, error propagation.
- `test/ui/use-credit-reconciliation.test.tsx`: no polling while non-terminal, 2s cadence, early stop on balance movement / new dial, 30s window expiry, error-swallow retry, window restart on next call.
- Full gates green: typecheck, lint, `check:effects` (inventory regenerated), `test:node`, `test:ui` (112 files / 677 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)