### PR TITLE
feat(campaign): auto-transition running↔waiting around calling hours

### DIFF
--- a/app/lib/campaign-schedule-sync.server.ts
+++ b/app/lib/campaign-schedule-sync.server.ts
@@ -5,7 +5,6 @@ import { checkSchedule } from "@/lib/database/campaign.server";
 import { updateCampaignStatusInWorkspace } from "@/lib/campaign-ivr.server";
 import { ACTIVE_CAMPAIGN_STATUSES } from "@/lib/campaign-status";
 import { logger } from "@/lib/logger.server";
-import type { Campaign } from "@/lib/types";
 
 export type CampaignScheduleSyncResult = {
   scanned: number;
@@ -53,9 +52,7 @@ export async function runCampaignScheduleSync(): Promise<CampaignScheduleSyncRes
     if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) continue;
     if (now < start || now > end) continue;
 
-    const target = checkSchedule(row as unknown as Campaign)
-      ? "running"
-      : "waiting";
+    const target = checkSchedule(row) ? "running" : "waiting";
     if (row.status === target) continue;
 
     try {

--- a/app/lib/campaign-schedule-sync.server.ts
+++ b/app/lib/campaign-schedule-sync.server.ts
@@ -1,0 +1,84 @@
+import { and, inArray, isNotNull, ne } from "drizzle-orm";
+import { campaign as campaignTable } from "@/db/schema";
+import { adminDb } from "@/server/admin-db";
+import { checkSchedule } from "@/lib/database/campaign.server";
+import { updateCampaignStatusInWorkspace } from "@/lib/campaign-ivr.server";
+import { ACTIVE_CAMPAIGN_STATUSES } from "@/lib/campaign-status";
+import { logger } from "@/lib/logger.server";
+import type { Campaign } from "@/lib/types";
+
+export type CampaignScheduleSyncResult = {
+  scanned: number;
+  transitioned: number;
+};
+
+/**
+ * Flip voice campaigns between `running` and `waiting` to match their calling
+ * hours (#1168). `waiting` means "live but outside the schedule": dialing is
+ * already gated by checkSchedule regardless of status, so this sync only keeps
+ * the displayed status truthful — it never grants or revokes dialability.
+ *
+ * Scope:
+ * - Voice campaigns only. Message campaigns are excluded because their
+ *   dispatch chain owns their status (`campaign_dispatch` skips anything that
+ *   is not `running`) and their send window is a separate mechanism.
+ * - Only campaigns inside their start/end date range. Expiry is owned by the
+ *   launch/complete flows; a campaign past its end date keeps whatever status
+ *   it has rather than parking on "Waiting" forever.
+ */
+export async function runCampaignScheduleSync(): Promise<CampaignScheduleSyncResult> {
+  const candidates = await adminDb.query.campaign.findMany({
+    where: and(
+      inArray(campaignTable.status, [...ACTIVE_CAMPAIGN_STATUSES]),
+      ne(campaignTable.type, "message"),
+      isNotNull(campaignTable.workspace),
+    ),
+    columns: {
+      id: true,
+      workspace: true,
+      status: true,
+      schedule: true,
+      start_date: true,
+      end_date: true,
+    },
+  });
+
+  let transitioned = 0;
+  const now = new Date();
+
+  for (const row of candidates) {
+    if (!row.workspace || !row.start_date || !row.end_date) continue;
+    const start = new Date(row.start_date);
+    const end = new Date(row.end_date);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) continue;
+    if (now < start || now > end) continue;
+
+    const target = checkSchedule(row as unknown as Campaign)
+      ? "running"
+      : "waiting";
+    if (row.status === target) continue;
+
+    try {
+      await updateCampaignStatusInWorkspace(row.workspace, row.id, {
+        status: target,
+      });
+      transitioned += 1;
+      logger.info("campaign_schedule_sync.transitioned", {
+        campaignId: row.id,
+        workspaceId: row.workspace,
+        from: row.status,
+        to: target,
+      });
+    } catch (error) {
+      // One campaign's failed flip must not stop the sweep — the next tick
+      // retries it anyway.
+      logger.error("campaign_schedule_sync.update_failed", {
+        campaignId: row.id,
+        workspaceId: row.workspace,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { scanned: candidates.length, transitioned };
+}

--- a/app/lib/database/campaign.server.ts
+++ b/app/lib/database/campaign.server.ts
@@ -673,7 +673,16 @@ export async function getCampaignQueueById({campaign_id,
   });
 }
 
-export function checkSchedule(campaignData: Campaign) {
+/** The subset of campaign fields the schedule check actually reads — callers
+ * with partial rows (e.g. the worker's schedule sweep) need not fake a full
+ * Campaign. */
+export type ScheduleCheckInput = {
+  start_date?: string | null;
+  end_date?: string | null;
+  schedule?: unknown;
+};
+
+export function checkSchedule(campaignData: ScheduleCheckInput) {
   if (!campaignData) return false;
   const { start_date, end_date, schedule } = campaignData;
   if (!schedule) return false;

--- a/app/lib/worker/ensure-scheduled-jobs.server.ts
+++ b/app/lib/worker/ensure-scheduled-jobs.server.ts
@@ -21,6 +21,7 @@ export const SELF_SCHEDULING_JOB_TYPES = [
   "twilio_open_sync",
   "billing_reconcile",
   "number_rental_billing",
+  "campaign_schedule_sync",
 ] as const;
 
 export type SelfSchedulingJobType = (typeof SELF_SCHEDULING_JOB_TYPES)[number];

--- a/app/lib/worker/handlers.server.ts
+++ b/app/lib/worker/handlers.server.ts
@@ -10,6 +10,7 @@ import {
 import type { JobHandlers } from "@/lib/worker/poll-jobs.server";
 import {
   billingReconcileHandler,
+  campaignScheduleSyncHandler,
   lowCreditNotifyHandler,
   numberRentalBillingHandler,
   twilioOpenSyncHandler,
@@ -38,6 +39,7 @@ export const jobHandlers: JobHandlers = {
   twilio_open_sync: twilioOpenSyncHandler,
   [WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE]: workspaceTwilioComplianceHandler,
   billing_reconcile: billingReconcileHandler,
+  campaign_schedule_sync: campaignScheduleSyncHandler,
   number_rental_billing: numberRentalBillingHandler,
   audience_upload: audienceUploadHandler,
   low_credit_notify: lowCreditNotifyHandler,

--- a/app/lib/worker/handlers/cron.server.ts
+++ b/app/lib/worker/handlers/cron.server.ts
@@ -5,6 +5,7 @@ import { runCronWorkspaceFanout } from "@/lib/cron-workspace-fanout.server";
 import { readTwilioWorkspaceCredentials } from "@/lib/twilio-workspace-credentials";
 import { loadWorkspaceTwilioData } from "@/lib/merge-workspace-twilio-data.server";
 import { runLowCreditNotify } from "@/lib/low-credit-notify.server";
+import { runCampaignScheduleSync } from "@/lib/campaign-schedule-sync.server";
 import { pruneExpiredIdempotencyRecords } from "@/lib/platform-idempotency.server";
 import { pruneCompletedJobs, pruneWorkspaceEvents } from "@/lib/worker/job-retention.server";
 import {
@@ -21,6 +22,10 @@ const TWILIO_OPEN_SYNC_RESCHEDULE_MS = 5 * 60 * 1000;
 const BILLING_RECONCILE_RESCHEDULE_MS = 24 * 60 * 60 * 1000;
 const NUMBER_RENTAL_BILLING_RESCHEDULE_MS = 24 * 60 * 60 * 1000;
 const TWILIO_WEBHOOK_AUDIT_RESCHEDULE_MS = 6 * 60 * 60 * 1000;
+// Minute cadence: the status flip should land within a minute of a calling
+// window opening or closing, and the sweep is a single indexed read when no
+// campaign needs a transition.
+const CAMPAIGN_SCHEDULE_SYNC_RESCHEDULE_MS = 60 * 1000;
 
 export const TWILIO_WEBHOOK_AUDIT_JOB_TYPE = "twilio_webhook_audit";
 
@@ -213,6 +218,21 @@ export async function lowCreditNotifyHandler(job: ClaimedJobRow): Promise<unknow
 
       return result;
     },
+  );
+}
+
+/**
+ * Keep voice campaign statuses truthful around calling hours (#1168):
+ * running ↔ waiting per checkSchedule. Self-re-enqueuing every minute.
+ */
+export async function campaignScheduleSyncHandler(job: ClaimedJobRow): Promise<unknown> {
+  return withReschedule(
+    {
+      type: "campaign_schedule_sync",
+      delayMs: CAMPAIGN_SCHEDULE_SYNC_RESCHEDULE_MS,
+      completedJobId: job.id,
+    },
+    () => runCampaignScheduleSync(),
   );
 }
 

--- a/test/campaign-schedule-sync.server.test.ts
+++ b/test/campaign-schedule-sync.server.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
+});
+
+const mocks = vi.hoisted(() => ({
+  findMany: vi.fn(async () => [] as unknown[]),
+  updateCampaignStatusInWorkspace: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/server/admin-db", () => ({
+  adminDb: {
+    query: {
+      campaign: {
+        findMany: (...args: unknown[]) => mocks.findMany(...args),
+      },
+    },
+  },
+}));
+vi.mock("@/lib/campaign-ivr.server", () => ({
+  updateCampaignStatusInWorkspace: (...args: unknown[]) =>
+    mocks.updateCampaignStatusInWorkspace(...args),
+}));
+vi.mock("@/lib/logger.server", () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { runCampaignScheduleSync } from "@/lib/campaign-schedule-sync.server";
+
+// 2026-08-12 is a Wednesday; freeze the sweep at 15:00 UTC.
+const NOW = new Date("2026-08-12T15:00:00.000Z");
+
+const OPEN_WEDNESDAY = {
+  wednesday: { active: true, intervals: [{ start: "09:00", end: "21:00" }] },
+};
+const CLOSED_WEDNESDAY = {
+  wednesday: { active: true, intervals: [{ start: "16:00", end: "21:00" }] },
+};
+
+function makeCampaign(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    workspace: "ws-1",
+    status: "running",
+    schedule: OPEN_WEDNESDAY,
+    start_date: "2026-08-01T00:00:00.000Z",
+    end_date: "2026-08-31T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("runCampaignScheduleSync", () => {
+  test("running campaign inside its window is left alone", async () => {
+    mocks.findMany.mockResolvedValueOnce([makeCampaign()]);
+
+    const result = await runCampaignScheduleSync();
+
+    expect(result).toEqual({ scanned: 1, transitioned: 0 });
+    expect(mocks.updateCampaignStatusInWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("running campaign outside its window flips to waiting", async () => {
+    mocks.findMany.mockResolvedValueOnce([
+      makeCampaign({ schedule: CLOSED_WEDNESDAY }),
+    ]);
+
+    const result = await runCampaignScheduleSync();
+
+    expect(result.transitioned).toBe(1);
+    expect(mocks.updateCampaignStatusInWorkspace).toHaveBeenCalledWith(
+      "ws-1",
+      1,
+      { status: "waiting" },
+    );
+  });
+
+  test("waiting campaign inside its window flips back to running", async () => {
+    mocks.findMany.mockResolvedValueOnce([makeCampaign({ status: "waiting" })]);
+
+    const result = await runCampaignScheduleSync();
+
+    expect(result.transitioned).toBe(1);
+    expect(mocks.updateCampaignStatusInWorkspace).toHaveBeenCalledWith(
+      "ws-1",
+      1,
+      { status: "running" },
+    );
+  });
+
+  test("campaign outside its date range is never flipped", async () => {
+    mocks.findMany.mockResolvedValueOnce([
+      makeCampaign({
+        schedule: CLOSED_WEDNESDAY,
+        start_date: "2026-07-01T00:00:00.000Z",
+        end_date: "2026-07-31T00:00:00.000Z",
+      }),
+    ]);
+
+    const result = await runCampaignScheduleSync();
+
+    expect(result.transitioned).toBe(0);
+    expect(mocks.updateCampaignStatusInWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("campaign with a schedule missing today reads as outside the window", async () => {
+    mocks.findMany.mockResolvedValueOnce([
+      makeCampaign({ schedule: { monday: { active: true, intervals: [] } } }),
+    ]);
+
+    const result = await runCampaignScheduleSync();
+
+    expect(mocks.updateCampaignStatusInWorkspace).toHaveBeenCalledWith(
+      "ws-1",
+      1,
+      { status: "waiting" },
+    );
+    expect(result.transitioned).toBe(1);
+  });
+
+  test("one failed update does not stop the sweep", async () => {
+    mocks.findMany.mockResolvedValueOnce([
+      makeCampaign({ id: 1, schedule: CLOSED_WEDNESDAY }),
+      makeCampaign({ id: 2, schedule: CLOSED_WEDNESDAY }),
+    ]);
+    mocks.updateCampaignStatusInWorkspace
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({});
+
+    const result = await runCampaignScheduleSync();
+
+    expect(mocks.updateCampaignStatusInWorkspace).toHaveBeenCalledTimes(2);
+    expect(result.transitioned).toBe(1);
+  });
+
+  test("rows missing workspace or dates are skipped", async () => {
+    mocks.findMany.mockResolvedValueOnce([
+      makeCampaign({ workspace: null }),
+      makeCampaign({ start_date: null }),
+      makeCampaign({ end_date: "not-a-date" }),
+    ]);
+
+    const result = await runCampaignScheduleSync();
+
+    expect(result.transitioned).toBe(0);
+    expect(mocks.updateCampaignStatusInWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/test/worker-cron-handlers.server.test.ts
+++ b/test/worker-cron-handlers.server.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   readTwilioWorkspaceCredentials: vi.fn(() => ({ sid: "AC_test" })),
   triggerTwilioOpenSync: vi.fn(async () => ({ ok: true, message: "synced" })),
   runNumberRentalBilling: vi.fn(async () => ({ ok: true, processed: 1 })),
+  runCampaignScheduleSync: vi.fn(async () => ({ scanned: 0, transitioned: 0 })),
 }));
 
 // Mock the enqueue layer rather than rescheduleJob: the handlers go through
@@ -47,9 +48,14 @@ vi.mock("@/lib/number-rental-billing.server", () => ({
   runNumberRentalBilling: (...args: unknown[]) =>
     mocks.runNumberRentalBilling(...args),
 }));
+vi.mock("@/lib/campaign-schedule-sync.server", () => ({
+  runCampaignScheduleSync: (...args: unknown[]) =>
+    mocks.runCampaignScheduleSync(...args),
+}));
 
 import {
   billingReconcileHandler,
+  campaignScheduleSyncHandler,
   numberRentalBillingHandler,
   twilioOpenSyncHandler,
 } from "@/lib/worker/handlers/cron.server";
@@ -93,6 +99,24 @@ describe("cron handler self-reschedule gating", () => {
       workspaceId: "ws-1",
       source: "cron",
     });
+  });
+
+  test("campaign_schedule_sync runs the sweep and self-reschedules", async () => {
+    await campaignScheduleSyncHandler(makeJob({ type: "campaign_schedule_sync" }));
+    expect(mocks.runCampaignScheduleSync).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "campaign_schedule_sync" }),
+    );
+  });
+
+  test("campaign_schedule_sync still reschedules when the sweep throws", async () => {
+    mocks.runCampaignScheduleSync.mockRejectedValueOnce(new Error("db down"));
+    await expect(
+      campaignScheduleSyncHandler(makeJob({ type: "campaign_schedule_sync" })),
+    ).rejects.toThrow("db down");
+    expect(mocks.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "campaign_schedule_sync" }),
+    );
   });
 
   test("coordinator twilio_open_sync self-reschedules", async () => {


### PR DESCRIPTION
Completes the remaining scope of #1168 — the `waiting` status and its display treatment landed earlier, but nothing transitioned campaigns automatically; the status was set manually.

## What

New self-scheduling worker job `campaign_schedule_sync` (same chain pattern as `low_credit_notify` et al., minute cadence): sweeps campaigns in `running`/`waiting` and flips each to match `checkSchedule` — `waiting` while outside calling hours, back to `running` when the window opens. Status updates go through the existing tenant-scoped `updateCampaignStatusInWorkspace`, so the campaign SSE event fires and open UIs refresh.

## Scope guards (from auditing the landed `waiting` work)

- **Display-truth only.** Dialing is already gated by `checkSchedule` on the server regardless of status, so the flip never grants or revokes dialability — it only stops the UI showing "Running" at 11pm.
- **Voice campaigns only.** The message-campaign dispatch chain owns its own status (`campaign_dispatch` skips non-`running` campaigns), and SMS has a separate send-window mechanism; excluded via `type != 'message'`.
- **Date range respected.** Campaigns outside their start/end dates are never flipped — expiry semantics stay with the launch/complete flows, so an ended campaign doesn't park on "Waiting" forever.

## Tests

- `test/campaign-schedule-sync.server.test.ts`: flip out-of-window → waiting, back in-window → running, no-op inside window, date-range exclusion, schedule-missing-today counts as closed, one failed update doesn't stop the sweep, malformed rows skipped.
- `test/worker-cron-handlers.server.test.ts`: self-reschedule on success and on a throwing sweep.
- Seeding coverage is dynamic over `SELF_SCHEDULING_JOB_TYPES`, so the new type is exercised by the existing `ensure-scheduled-jobs` tests.

Part of #1168 (leaves the issue open for @sai-sy's verification pass, per the "flagging to check" comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)