### PR TITLE
fix(campaign): stop conflating script attach with script editing

### DIFF
--- a/app/components/campaign/settings/script/CampaignSettings.Script.tsx
+++ b/app/components/campaign/settings/script/CampaignSettings.Script.tsx
@@ -14,12 +14,14 @@ type ScriptPageProps = {
   pageData: PageData;
   onPageDataChange: (data: PageData) => void;
   mediaNames: string[];
+  readOnly?: boolean;
 };
 
 export default function CampaignSettingsScript({
   pageData,
   onPageDataChange,
   mediaNames,
+  readOnly = false,
 }: ScriptPageProps) {
   const script = pageData.campaignDetails.script;
   const document = useMemo(() => scriptToDocument(script), [script]);
@@ -42,6 +44,7 @@ export default function CampaignSettingsScript({
       document={document}
       onChange={handleChange}
       mediaNames={mediaNames}
+      readOnly={readOnly}
     />
   );
 }

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.route.tsx
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.route.tsx
@@ -25,7 +25,10 @@ import {
 import type { Script } from "@/lib/types";
 import type { ScriptEditLoaderData } from "./edit.types";
 import { logger as loggerClient } from "@/lib/logger.client";
-import { normalizeScriptPageDataForComparison } from "@/lib/script-change";
+import {
+  normalizeScriptForComparison,
+  normalizeScriptPageDataForComparison,
+} from "@/lib/script-change";
 
 type LoaderData = ScriptEditLoaderData;
 type PageData = LoaderData["data"];
@@ -49,11 +52,32 @@ export default function ScriptEditor() {
   const [pageData, setPageData] = useState<PageData>(data);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  // The script preview is read-only until the user explicitly opts into
+  // editing — attaching a script and editing its content are different acts,
+  // and conflating them is what silently discarded attachments (#1124).
+  const [isEditingScript, setIsEditingScript] = useState(false);
   const isChanged = useHasChanges(
     pageData,
     initData,
     normalizeScriptPageDataForComparison,
   );
+  // Save-as-copy is only a meaningful question when the script's CONTENT
+  // changed. A selection-only change (attach/detach/switch) has nothing to
+  // copy, so compare against the pristine version of the CURRENTLY selected
+  // script: the loader's copy when the selection is unchanged, the dropdown
+  // list's copy when the user switched scripts.
+  const currentScript = pageData.campaignDetails.script ?? null;
+  const pristineScript =
+    currentScript == null
+      ? null
+      : currentScript.id === initData.campaignDetails.script?.id
+        ? initData.campaignDetails.script
+        : scripts.find((s) => s.id === currentScript.id) ?? null;
+  const scriptContentChanged =
+    currentScript != null &&
+    pristineScript != null &&
+    JSON.stringify(normalizeScriptForComparison(currentScript)) !==
+      JSON.stringify(normalizeScriptForComparison(pristineScript));
   useUnsavedChangesGuard(isChanged);
 
   const handleSaveUpdate = async (saveScriptAsCopy: boolean) => {
@@ -109,6 +133,7 @@ export default function ScriptEditor() {
       setPageData(savedPageData);
       setInitData(savedPageData);
       setShowSaveModal(false);
+      setIsEditingScript(false);
       toast.success(
         pageData.type === "message" ? "Message saved" : "Script saved",
       );
@@ -126,6 +151,7 @@ export default function ScriptEditor() {
 
   const handleReset = () => {
     setPageData(data);
+    setIsEditingScript(false);
   };
 
   const handlePageDataChange = (newPageData: PageData) => {
@@ -141,6 +167,11 @@ export default function ScriptEditor() {
       nextScriptId == null
         ? undefined
         : scripts.find((script) => String(script.id) === String(nextScriptId));
+
+    // Switching scripts replaces the draft with the pristine copy, so any
+    // in-flight content edits to the previous script are gone — leave edit
+    // mode rather than presenting the new script as already-being-edited.
+    setIsEditingScript(false);
 
     handlePageDataChange({
       ...pageData,
@@ -169,19 +200,38 @@ export default function ScriptEditor() {
     };
 
     return (
-      <CampaignSettingsScript
-        pageData={scriptPageData}
-        onPageDataChange={(newData) => {
-          handlePageDataChange({
-            ...pageData,
-            campaignDetails: {
-              ...pageData.campaignDetails,
-              script: newData.campaignDetails.script,
-            },
-          });
-        }}
-        mediaNames={scriptMediaNames}
-      />
+      <div className="space-y-2">
+        {!isEditingScript && (
+          <div className="flex items-center justify-between rounded-md border border-border bg-muted/40 px-3 py-2">
+            <p className="text-sm text-muted-foreground">
+              Previewing {pageData.campaignDetails.script.name}. The script is
+              attached when you save — editing is optional.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setIsEditingScript(true)}
+            >
+              Edit script
+            </Button>
+          </div>
+        )}
+        <CampaignSettingsScript
+          pageData={scriptPageData}
+          onPageDataChange={(newData) => {
+            handlePageDataChange({
+              ...pageData,
+              campaignDetails: {
+                ...pageData.campaignDetails,
+                script: newData.campaignDetails.script,
+              },
+            });
+          }}
+          mediaNames={scriptMediaNames}
+          readOnly={!isEditingScript}
+        />
+      </div>
     );
   };
 
@@ -196,7 +246,9 @@ export default function ScriptEditor() {
           isSaving={isSaving}
           onSave={() => {
             // Message campaigns have no script copy flow — save directly (#1115).
-            if (pageData.type === "message") {
+            // Selection-only changes save directly too: the save-as-copy
+            // question only applies when script content was edited (#1124).
+            if (pageData.type === "message" || !scriptContentChanged) {
               void handleSaveUpdate(false);
               return;
             }

--- a/test/ui/campaign-script-edit-route.test.tsx
+++ b/test/ui/campaign-script-edit-route.test.tsx
@@ -1,0 +1,206 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createElement } from "react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+
+// The route re-exports its loader/action from server-only modules; the
+// component under test never runs them, so stub them out to keep the DB out of
+// jsdom.
+vi.mock(
+  "../../app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.loader.server",
+  () => ({ loader: vi.fn() }),
+);
+vi.mock(
+  "../../app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.action.server",
+  () => ({ action: vi.fn() }),
+);
+
+// Stub the script editor body: expose whether it is read-only and offer a
+// button that dirties the script CONTENT through the real onPageDataChange
+// contract (#1124's distinction between attaching and editing).
+vi.mock("@/components/campaign/settings/script/CampaignSettings.Script", () => ({
+  default: ({
+    pageData,
+    onPageDataChange,
+    readOnly,
+  }: {
+    pageData: { campaignDetails: { script: { name: string; steps: unknown } } };
+    onPageDataChange: (next: unknown) => void;
+    readOnly?: boolean;
+  }) =>
+    createElement(
+      "div",
+      { "data-testid": "script-editor", "data-readonly": String(readOnly ?? false) },
+      createElement(
+        "button",
+        {
+          onClick: () =>
+            onPageDataChange({
+              campaignDetails: {
+                script: {
+                  ...pageData.campaignDetails.script,
+                  steps: { pages: { edited: true }, blocks: {} },
+                },
+              },
+            }),
+        },
+        "dirty the script content",
+      ),
+    ),
+}));
+
+// Radix Select is hostile to jsdom interaction; the dropdown's contract is
+// handleInputChange("script_id", value), so drive that directly.
+vi.mock(
+  "@/components/campaign/settings/detailed/CampaignDetailed.SelectScript",
+  () => ({
+    default: ({
+      handleInputChange,
+      selectedScript,
+    }: {
+      handleInputChange: (name: string, value: string | number | null) => void;
+      selectedScript: number | string | null;
+    }) =>
+      createElement(
+        "div",
+        null,
+        createElement("span", { "data-testid": "selected-script" }, String(selectedScript)),
+        createElement(
+          "button",
+          { onClick: () => handleInputChange("script_id", 9) },
+          "attach script nine",
+        ),
+      ),
+  }),
+);
+
+function makeScript(id: number, name: string) {
+  return {
+    id,
+    name,
+    steps: { pages: {}, blocks: {} },
+    type: "script",
+    workspace: "ws-1",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: null,
+    created_by: null,
+    updated_by: null,
+  };
+}
+
+const sampleScript = makeScript(7, "Sample script — customer check-in");
+const otherScript = makeScript(9, "Second script");
+
+function makeLoaderData(overrides: Record<string, unknown> = {}) {
+  return {
+    workspace_id: "ws-1",
+    selected_id: "1",
+    data: {
+      id: 1,
+      workspace: "ws-1",
+      type: "live_call",
+      campaignDetails: {
+        campaign_id: 1,
+        created_at: "2026-01-01T00:00:00.000Z",
+        id: 11,
+        script_id: 7,
+        workspace: "ws-1",
+        script: sampleScript,
+      },
+    },
+    mediaNames: [],
+    userRole: "admin",
+    scripts: [sampleScript, otherScript],
+    ...overrides,
+  };
+}
+
+async function renderRoute(loaderData = makeLoaderData()) {
+  const mod = await import(
+    "../../app/routes/workspaces+/$id/campaigns/$selected_id/script/edit.route"
+  );
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/workspaces/:id/campaigns/:selected_id/script/edit",
+        Component: mod.default,
+        loader: () => loaderData,
+      },
+    ],
+    { initialEntries: ["/workspaces/ws-1/campaigns/1/script/edit"] },
+  );
+  return render(createElement(RouterProvider, { router }));
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ script: otherScript }),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("campaign script edit route (#1124)", () => {
+  test("script preview starts read-only with an explicit edit affordance", async () => {
+    await renderRoute();
+
+    const editor = await screen.findByTestId("script-editor");
+    expect(editor).toHaveAttribute("data-readonly", "true");
+    expect(screen.getByRole("button", { name: "Edit script" })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit script" }));
+    expect(screen.getByTestId("script-editor")).toHaveAttribute("data-readonly", "false");
+  });
+
+  test("selection-only change saves directly — no save-as-copy modal", async () => {
+    await renderRoute();
+
+    await userEvent.click(await screen.findByRole("button", { name: "attach script nine" }));
+    await userEvent.click(await screen.findByRole("button", { name: /save changes/i }));
+
+    // No dialog asked about copying; the PATCH went straight out.
+    expect(
+      screen.queryByText(/save as a copy/i),
+    ).not.toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const body = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]?.body as FormData;
+    expect(body.get("saveScriptAsCopy")).toBe("false");
+    expect(
+      JSON.parse(String(body.get("campaignDetails"))).script_id,
+    ).toBe(9);
+  });
+
+  test("content edit still routes through the save-as-copy dialog", async () => {
+    await renderRoute();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Edit script" }));
+    await userEvent.click(screen.getByRole("button", { name: "dirty the script content" }));
+    await userEvent.click(await screen.findByRole("button", { name: /save changes/i }));
+
+    expect(await screen.findByText(/save as a copy/i)).toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Save as Copy" }));
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const body = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]?.body as FormData;
+    expect(body.get("saveScriptAsCopy")).toBe("true");
+  });
+
+  test("switching scripts leaves edit mode", async () => {
+    await renderRoute();
+
+    await userEvent.click(await screen.findByRole("button", { name: "Edit script" }));
+    expect(screen.getByTestId("script-editor")).toHaveAttribute("data-readonly", "false");
+
+    await userEvent.click(screen.getByRole("button", { name: "attach script nine" }));
+    expect(screen.getByTestId("script-editor")).toHaveAttribute("data-readonly", "true");
+  });
+});


### PR DESCRIPTION
Closes #1124

## Problem

On the campaign content step, attaching a script and editing its content shared one dirty state, one save button, and one save path. Selecting a script surfaced the "Save / Save as Copy" dialog — a question about *script content* — so users X'd out of it (they never meant to edit the script), hit the unsaved-changes browser prompt on Next, confirmed, and the attachment was silently discarded.

## What changed (a mix of the minimal fix and the issue's proposed redesign)

- **Read-only by default, edit is opt-in** (from the redesign): the script preview renders through `ScriptEditorShell`'s existing `readOnly` mode with a banner — "Previewing X. The script is attached when you save — editing is optional." — and an explicit **Edit script** button. Switching scripts, saving, or resetting leaves edit mode.
- **Selection-only saves skip the dialog** (the minimal fix): "Save changes" persists a selection change directly. The Save/Save-as-Copy dialog appears only when script *content* actually changed.
- **Content dirtiness is measured against the pristine copy of the currently selected script** (the loader's copy when unchanged, the dropdown list's copy after a switch), so switching scripts is never mistaken for a content edit — and an edit made *after* switching still gets the copy prompt rather than silently overwriting the newly chosen script.

Kept from today's UI (deviating from the issue's sketch): the script dropdown and SaveBar stay — no separate "use this script / don't use this script" buttons, so the step keeps the same interaction vocabulary as the rest of campaign settings.

## Tests

`test/ui/campaign-script-edit-route.test.tsx` (4 cases): preview starts read-only with the edit affordance; selection-only change saves directly with `saveScriptAsCopy=false` and the new `script_id`, no dialog; a content edit routes through the dialog and Save-as-Copy sends `saveScriptAsCopy=true`; switching scripts exits edit mode.

Gates green locally: typecheck, lint, type-safety/effects/DRY ratchets, full `test:ui` (669) twice consecutively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)