### PR TITLE
refactor(queue): QueueEntry transition table, drop dead shims (B1 of #1240)

### DIFF
--- a/app/lib/queue-status.ts
+++ b/app/lib/queue-status.ts
@@ -56,16 +56,6 @@ export type QueueStateLike = {
 const UUID_STATUS_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export const LEGACY_QUEUE_ASSIGNMENT_LIKE_PATTERN =
-  "________-____-____-____-____________";
-
-/**
- * Postgres OR filter for rows that should count as "completed" in queue progress.
- * `status` is not reliable on its own because Twilio/webhook updates can overwrite it,
- * while `dequeued_at` remains the durable marker that queue work is finished.
- */
-export const COMPLETED_QUEUE_COUNT_FILTER = `status.eq.${QUEUE_STATUS_DEQUEUED},dequeued_at.not.is.null`;
-
 function toQueueStateLike(
   value: QueueStateLike | string | null | undefined,
   dequeuedAt?: string | null | undefined,
@@ -231,60 +221,175 @@ export function matchesQueueStatusFilter(
   return getQueueDisplayState(value) === queueStatus;
 }
 
-export function buildQueuedQueueUpdate(options?: {
-  includeNormalizedFields?: boolean;
-}): Database["public"]["Tables"]["campaign_queue"]["Update"] {
-  void options;
-  return {
-    assigned_to_user_id: null,
-    dequeued_at: null,
-    dequeued_by: null,
-    dequeued_reason: null,
-    provider_status: null,
-    queue_state: QUEUE_STATUS_QUEUED,
-  };
+// ─── QueueEntry transition table ──────────────────────────────────────────
+//
+// This is the single source of truth for the QueueEntry lifecycle (queued →
+// assigned → dequeued/canceled, per CONTEXT.md "Queue Entry") on the TS
+// side. The plpgsql RPCs (claim_next_queue_contact and friends) implement
+// the same lifecycle independently, which is why four repair migrations
+// (20260716120000, 20260716130000, 20260722120000, 20260803120000) exist —
+// the two drifted. Issue #1240 tracks fixing that class of bug in two
+// parts: B1 (this table, TS-only) and B2 (generate/verify the RPCs'
+// column vocabularies against this table — not yet built). Keep this
+// section pure data + pure functions so B2 can import and consume it
+// without pulling in any DB client.
+
+/**
+ * Writable `campaign_queue.queue_state` values. `canceled`
+ * ({@link QUEUE_LIFECYCLE_CANCELED}) is intentionally excluded: it's a
+ * read-only value `getQueueLifecycle()` can report, but as of this census
+ * (2026-08, B1) no writer — TS or plpgsql RPC — ever sets queue_state to
+ * "canceled". Add it here once a real writer exists.
+ */
+export const QUEUE_ENTRY_STATES = [
+  QUEUE_STATUS_QUEUED,
+  QUEUE_LIFECYCLE_ASSIGNED,
+  QUEUE_STATUS_DEQUEUED,
+] as const;
+export type QueueEntryState = (typeof QUEUE_ENTRY_STATES)[number];
+
+/** campaign_queue columns a QueueEntry transition can write. */
+export type QueueEntryColumn =
+  | "queue_state"
+  | "assigned_to_user_id"
+  | "provider_status"
+  | "dequeued_at"
+  | "dequeued_by"
+  | "dequeued_reason";
+
+/**
+ * Named QueueEntry transitions. `provider_status` is not a distinct
+ * queue_state — it's a same-state update layering a Twilio/provider status
+ * onto an already-assigned row (queue_state stays "assigned") without
+ * touching assignment or dequeue columns.
+ */
+export type QueueEntryTransitionName =
+  | "queued"
+  | "assigned"
+  | "provider_status"
+  | "dequeued";
+
+export interface QueueEntryTransitionDef {
+  /** The queue_state value this transition writes. */
+  readonly queueState: QueueEntryState;
+  /**
+   * States a row must currently be in for this transition to be legal.
+   * "any" means no precondition — the existing callers below are
+   * context-free (they don't read current state before writing), so most
+   * transitions are permissive today. Tightening this is a future gate,
+   * not a B1 behavior change.
+   */
+  readonly legalFrom: readonly QueueEntryState[] | "any";
+  /** Exact set of campaign_queue columns this transition writes, every time (including nulling-out columns not relevant to the target state). */
+  readonly columns: readonly QueueEntryColumn[];
+}
+
+const QUEUE_ENTRY_FULL_COLUMN_SET: readonly QueueEntryColumn[] = [
+  "assigned_to_user_id",
+  "dequeued_at",
+  "dequeued_by",
+  "dequeued_reason",
+  "provider_status",
+  "queue_state",
+];
+
+export const QUEUE_ENTRY_TRANSITIONS: Record<
+  QueueEntryTransitionName,
+  QueueEntryTransitionDef
+> = {
+  queued: {
+    queueState: QUEUE_STATUS_QUEUED,
+    legalFrom: "any",
+    columns: QUEUE_ENTRY_FULL_COLUMN_SET,
+  },
+  assigned: {
+    queueState: QUEUE_LIFECYCLE_ASSIGNED,
+    legalFrom: "any",
+    columns: QUEUE_ENTRY_FULL_COLUMN_SET,
+  },
+  provider_status: {
+    queueState: QUEUE_LIFECYCLE_ASSIGNED,
+    legalFrom: [QUEUE_LIFECYCLE_ASSIGNED],
+    columns: ["provider_status", "queue_state"],
+  },
+  dequeued: {
+    queueState: QUEUE_STATUS_DEQUEUED,
+    legalFrom: "any",
+    columns: QUEUE_ENTRY_FULL_COLUMN_SET,
+  },
+};
+
+/**
+ * True when `name` is a legal transition out of `fromState`. `fromState` of
+ * `null`/`undefined` (unknown current state) is only legal for transitions
+ * whose `legalFrom` is "any".
+ */
+export function isLegalQueueEntryTransition(
+  name: QueueEntryTransitionName,
+  fromState: QueueEntryState | null | undefined,
+): boolean {
+  const def = QUEUE_ENTRY_TRANSITIONS[name];
+  if (def.legalFrom === "any") return true;
+  if (fromState == null) return false;
+  return def.legalFrom.includes(fromState);
+}
+
+type QueueEntryColumnValues = Partial<Record<QueueEntryColumn, unknown>>;
+
+/**
+ * Build the campaign_queue UPDATE payload for a named transition. Every
+ * column in the transition's {@link QueueEntryTransitionDef.columns} is
+ * always present on the returned object — explicit values from `values`
+ * win, everything else is nulled out except `queue_state`, which is always
+ * the transition's fixed target value.
+ */
+function buildQueueEntryUpdate(
+  name: QueueEntryTransitionName,
+  values: QueueEntryColumnValues,
+): Database["public"]["Tables"]["campaign_queue"]["Update"] {
+  const def = QUEUE_ENTRY_TRANSITIONS[name];
+  const update: QueueEntryColumnValues = {};
+  for (const column of def.columns) {
+    if (column === "queue_state") {
+      update.queue_state = def.queueState;
+    } else if (column in values) {
+      update[column] = values[column];
+    } else {
+      update[column] = null;
+    }
+  }
+  return update as Database["public"]["Tables"]["campaign_queue"]["Update"];
+}
+
+export function buildQueuedQueueUpdate(): Database["public"]["Tables"]["campaign_queue"]["Update"] {
+  return buildQueueEntryUpdate("queued", {});
 }
 
 export function buildAssignedQueueUpdate(
   assignedToUserId: string,
-  options?: { includeNormalizedFields?: boolean },
 ): Database["public"]["Tables"]["campaign_queue"]["Update"] {
-  void options;
-  return {
+  return buildQueueEntryUpdate("assigned", {
     assigned_to_user_id: assignedToUserId,
-    dequeued_at: null,
-    dequeued_by: null,
-    dequeued_reason: null,
-    provider_status: null,
-    queue_state: QUEUE_LIFECYCLE_ASSIGNED,
-  };
+  });
 }
 
 export function buildProviderStatusQueueUpdate(
   providerStatus: string,
-  options?: { includeNormalizedFields?: boolean },
 ): Database["public"]["Tables"]["campaign_queue"]["Update"] {
-  void options;
-  return {
+  return buildQueueEntryUpdate("provider_status", {
     provider_status: providerStatus,
-    queue_state: QUEUE_LIFECYCLE_ASSIGNED,
-  };
+  });
 }
 
 export function buildDequeuedQueueUpdate(
   dequeuedBy: string | null,
   dequeuedReason: string,
-  options?: { includeNormalizedFields?: boolean },
 ): Database["public"]["Tables"]["campaign_queue"]["Update"] {
-  void options;
-  return {
-    assigned_to_user_id: null,
+  return buildQueueEntryUpdate("dequeued", {
     dequeued_at: new Date().toISOString(),
     dequeued_by: dequeuedBy,
     dequeued_reason: dequeuedReason,
-    provider_status: null,
-    queue_state: QUEUE_STATUS_DEQUEUED,
-  };
+  });
 }
 
 // NOTE: releaseAssignedQueueForUser lives in @/lib/campaign-queue-db.server —

--- a/app/routes/api+/auto-dial/status.action.server.ts
+++ b/app/routes/api+/auto-dial/status.action.server.ts
@@ -274,7 +274,6 @@ const handleParticipantJoin = async (
           (typeof underCase.friendly_name === "string" ? underCase.friendly_name : null) ??
             (typeof underCase.conference_sid === "string" ? underCase.conference_sid : null) ??
             "in-progress",
-          { includeNormalizedFields: true },
         ),
       });
 

--- a/test/queue-status.test.ts
+++ b/test/queue-status.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "vitest";
-import { isDequeued, isQueued } from "@/lib/queue-status";
+import {
+  buildAssignedQueueUpdate,
+  buildDequeuedQueueUpdate,
+  buildProviderStatusQueueUpdate,
+  buildQueuedQueueUpdate,
+  isDequeued,
+  isLegalQueueEntryTransition,
+  isQueued,
+  QUEUE_ENTRY_TRANSITIONS,
+} from "@/lib/queue-status";
 
 describe("queue completion semantics", () => {
   test("treats dequeued_at and dequeued queue_state as completed", () => {
@@ -45,5 +54,109 @@ describe("queue completion semantics", () => {
         dequeued_at: null,
       }),
     ).toBe(false);
+  });
+});
+
+describe("QueueEntry transition table", () => {
+  test("queued/assigned/dequeued transitions have no precondition (legalFrom: any)", () => {
+    expect(isLegalQueueEntryTransition("queued", null)).toBe(true);
+    expect(isLegalQueueEntryTransition("queued", "assigned")).toBe(true);
+    expect(isLegalQueueEntryTransition("assigned", "dequeued")).toBe(true);
+    expect(isLegalQueueEntryTransition("dequeued", "queued")).toBe(true);
+  });
+
+  test("provider_status is only legal from an already-assigned row", () => {
+    expect(isLegalQueueEntryTransition("provider_status", "assigned")).toBe(true);
+    expect(isLegalQueueEntryTransition("provider_status", "queued")).toBe(false);
+    expect(isLegalQueueEntryTransition("provider_status", "dequeued")).toBe(false);
+    expect(isLegalQueueEntryTransition("provider_status", null)).toBe(false);
+    expect(isLegalQueueEntryTransition("provider_status", undefined)).toBe(false);
+  });
+
+  test("column sets match the transition table exactly", () => {
+    expect(QUEUE_ENTRY_TRANSITIONS.queued.columns.slice().sort()).toEqual(
+      [
+        "assigned_to_user_id",
+        "dequeued_at",
+        "dequeued_by",
+        "dequeued_reason",
+        "provider_status",
+        "queue_state",
+      ].sort(),
+    );
+    expect(QUEUE_ENTRY_TRANSITIONS.assigned.columns.slice().sort()).toEqual(
+      [
+        "assigned_to_user_id",
+        "dequeued_at",
+        "dequeued_by",
+        "dequeued_reason",
+        "provider_status",
+        "queue_state",
+      ].sort(),
+    );
+    expect(QUEUE_ENTRY_TRANSITIONS.provider_status.columns.slice().sort()).toEqual(
+      ["provider_status", "queue_state"].sort(),
+    );
+    expect(QUEUE_ENTRY_TRANSITIONS.dequeued.columns.slice().sort()).toEqual(
+      [
+        "assigned_to_user_id",
+        "dequeued_at",
+        "dequeued_by",
+        "dequeued_reason",
+        "provider_status",
+        "queue_state",
+      ].sort(),
+    );
+  });
+
+  test("buildQueuedQueueUpdate writes exactly the queued transition's columns", () => {
+    expect(buildQueuedQueueUpdate()).toEqual({
+      assigned_to_user_id: null,
+      dequeued_at: null,
+      dequeued_by: null,
+      dequeued_reason: null,
+      provider_status: null,
+      queue_state: "queued",
+    });
+  });
+
+  test("buildAssignedQueueUpdate writes exactly the assigned transition's columns", () => {
+    expect(buildAssignedQueueUpdate("user-123")).toEqual({
+      assigned_to_user_id: "user-123",
+      dequeued_at: null,
+      dequeued_by: null,
+      dequeued_reason: null,
+      provider_status: null,
+      queue_state: "assigned",
+    });
+  });
+
+  test("buildProviderStatusQueueUpdate writes only provider_status + queue_state (assignment untouched)", () => {
+    expect(buildProviderStatusQueueUpdate("in-progress")).toEqual({
+      provider_status: "in-progress",
+      queue_state: "assigned",
+    });
+  });
+
+  test("buildDequeuedQueueUpdate writes exactly the dequeued transition's columns", () => {
+    const before = Date.now();
+    const update = buildDequeuedQueueUpdate("user-456", "no answer");
+    const after = Date.now();
+
+    expect(update.assigned_to_user_id).toBeNull();
+    expect(update.dequeued_by).toBe("user-456");
+    expect(update.dequeued_reason).toBe("no answer");
+    expect(update.provider_status).toBeNull();
+    expect(update.queue_state).toBe("dequeued");
+    expect(typeof update.dequeued_at).toBe("string");
+    const dequeuedAtMs = new Date(update.dequeued_at as string).getTime();
+    expect(dequeuedAtMs).toBeGreaterThanOrEqual(before);
+    expect(dequeuedAtMs).toBeLessThanOrEqual(after);
+  });
+
+  test("buildDequeuedQueueUpdate accepts a null dequeuedBy (system-initiated dequeue)", () => {
+    const update = buildDequeuedQueueUpdate(null, "api");
+    expect(update.dequeued_by).toBeNull();
+    expect(update.dequeued_reason).toBe("api");
   });
 });


### PR DESCRIPTION
Part 1 of #1240 (B1). This PR covers B1 only — B2 (generated/verified RPC column vocabularies) and B3 (collapse the 3 dequeue mechanisms) are separate later items on the same issue.

## What

`app/lib/queue-status.ts` defined the QueueEntry lifecycle (queued → assigned → dequeued, per CONTEXT.md's "Queue Entry": normalized `queue_state` + `assigned_to_user_id` + `provider_status`, not the legacy overloaded `status` column) implicitly, spread across four `build*QueueUpdate` functions with independently-maintained column lists. This is the TS-side twin of the same lifecycle re-implemented in 8 plpgsql RPCs — the two drifted, which is why four repair migrations exist (20260716120000, 20260716130000, 20260722120000, 20260803120000).

This PR makes the TS side own one explicit transition table instead of four ad-hoc functions:

- **`QUEUE_ENTRY_TRANSITIONS`**: a `Record<QueueEntryTransitionName, QueueEntryTransitionDef>` (`queued` / `assigned` / `provider_status` / `dequeued`), each entry stating the `queue_state` it writes, which states it's legal to transition from (`legalFrom`), and the exact `campaign_queue` columns it writes.
- **`isLegalQueueEntryTransition(name, fromState)`**: pure function over the table.
- A single generic `buildQueueEntryUpdate(name, values)` that all four `build*QueueUpdate` functions now delegate to, so the column sets can't drift from each other the way they drifted from the RPCs.
- The table + functions are pure data/pure functions (no DB client import) specifically so **B2** can later import `QUEUE_ENTRY_TRANSITIONS` to generate/verify the RPCs' column vocabularies against it — noted in a comment in the module pointing at issue #1240 B2.

## Dead-code cleanup (part of B1's brief)

- Deleted `COMPLETED_QUEUE_COUNT_FILTER` and `LEGACY_QUEUE_ASSIGNMENT_LIKE_PATTERN` — both Supabase/PostgREST-era shims with **zero call sites** (verified by repo-wide grep before deleting).
- Dropped the `options?: { includeNormalizedFields?: boolean }` param from all four builders — it was immediately `void`d in every implementation. Its one caller (`auto-dial/status.action.server.ts:277`, which passed `{ includeNormalizedFields: true }`) is updated to drop the no-op argument.
- **Kept** `isUserAssignment` and the other legacy-status helpers (`getAssignedUserId`, `getProviderStatus`, `isQueued`, `isDequeued`, `isAssignedToUser`, `getQueueLifecycle`, `getQueueDisplayState`, `getQueueDisplayLabel`, `matchesQueueStatusFilter`) — census found live callers in `app/lib/campaign-queue-db.server.ts`, `app/lib/call-screen.server.ts`, `app/hooks/queue/useQueue.ts`, and `app/components/queue/QueueTable.tsx`. `isUserAssignment` itself has no external callers but is used internally by `getAssignedUserId`/`getProviderStatus`, which do.

## Behavior-preserving

The four `build*QueueUpdate` functions produce byte-identical UPDATE payloads to before — pinned down with new tests asserting the exact object shape per builder, including that a `provider_status` update only ever touches `provider_status` + `queue_state` (never nulls out assignment/dequeue columns). `campaign-queue-db.server.ts`'s dequeue mechanics are unchanged beyond adopting the new (behaviorally identical) builders — collapsing the 3 dequeue mechanisms is B3, out of scope here.

Also noted in the module: `QUEUE_LIFECYCLE_CANCELED` ("canceled") is a read-only `queue_state` value today — `getQueueLifecycle()` can report it, but no writer (TS or RPC, per this census) ever sets it. Left out of the writable transition table until a real writer exists.

## Testing

- `npm run typecheck` — clean
- `npx vitest run -c vitest.node.config.ts` on all queue-touching suites (`queue-status`, `db-rpc-claim-queue-entry`, `acd-queue-entry-states`, `campaign-queue.route`, `campaign-queue-db.claim`, `auto-dial.server`, `auto-dial-status`, `queues.route`, `campaign-settings-queue.route`, plus a broader sweep of routes that touch the queue) — all green
- `node scripts/check-handlers.mjs` — passes
- `npx eslint` on touched files — clean

Not merging this myself per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)