### PR TITLE
feat(worker): job registry mechanism — defineJob, derived sets, typed enqueue (#1239 A1)

### DIFF
--- a/app/lib/worker/ensure-scheduled-jobs.server.ts
+++ b/app/lib/worker/ensure-scheduled-jobs.server.ts
@@ -13,28 +13,17 @@
 
 import { logger } from "@/lib/logger.server";
 import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import {
+  SELF_SCHEDULING_JOB_TYPES,
+  SELF_SCHEDULING_SEED_PARAMS,
+} from "@/lib/worker/handlers.server";
 
-/** Job types that re-enqueue themselves and therefore need a first row. */
-export const SELF_SCHEDULING_JOB_TYPES = [
-  "low_credit_notify",
-  "twilio_webhook_audit",
-  "twilio_open_sync",
-  "billing_reconcile",
-  "number_rental_billing",
-  "campaign_schedule_sync",
-] as const;
+// Re-exported for backwards compatibility: both are now DERIVED from the job
+// registry (see handlers.server.ts / job-registry.server.ts, #1239 A1)
+// instead of being hand-maintained here.
+export { SELF_SCHEDULING_JOB_TYPES };
 
 export type SelfSchedulingJobType = (typeof SELF_SCHEDULING_JOB_TYPES)[number];
-
-const SELF_SCHEDULING_SEED_PARAMS: Partial<
-  Record<SelfSchedulingJobType, Record<string, unknown>>
-> = {
-  twilio_open_sync: {
-    callLimit: 50,
-    messageLimit: 50,
-    maxAgeMinutes: 120,
-  },
-};
 
 export async function ensureSelfSchedulingJobsSeeded(): Promise<{
   seeded: SelfSchedulingJobType[];

--- a/app/lib/worker/handlers.server.ts
+++ b/app/lib/worker/handlers.server.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import {
   CALL_STATUS_SIDE_EFFECTS_JOB_TYPE,
   CAMPAIGN_DISPATCH_JOB_TYPE,
@@ -8,6 +9,13 @@ import {
   ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE,
 } from "@/lib/worker/job-types.server";
 import type { JobHandlers } from "@/lib/worker/poll-jobs.server";
+import {
+  createTypedEnqueue,
+  defineJob,
+  legacyJob,
+  legacyNumericParam,
+  type RegisteredJob,
+} from "@/lib/worker/job-registry.server";
 import {
   billingReconcileHandler,
   campaignScheduleSyncHandler,
@@ -35,20 +43,176 @@ import { elevenlabsBatchTranscribeHandler } from "./handlers/elevenlabs-batch-tr
 
 export { enqueueWorkspaceComplianceJob };
 
-export const jobHandlers: JobHandlers = {
-  twilio_open_sync: twilioOpenSyncHandler,
-  [WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE]: workspaceTwilioComplianceHandler,
-  billing_reconcile: billingReconcileHandler,
-  campaign_schedule_sync: campaignScheduleSyncHandler,
-  number_rental_billing: numberRentalBillingHandler,
-  audience_upload: audienceUploadHandler,
-  low_credit_notify: lowCreditNotifyHandler,
-  [TWILIO_WEBHOOK_AUDIT_JOB_TYPE]: twilioWebhookAuditHandler,
-  [CALL_STATUS_SIDE_EFFECTS_JOB_TYPE]: callStatusSideEffectsHandler,
-  [SMS_STATUS_SIDE_EFFECTS_JOB_TYPE]: smsStatusSideEffectsHandler,
-  [RECORDING_SIDE_EFFECTS_JOB_TYPE]: recordingSideEffectsHandler,
-  [CAMPAIGN_EXPORT_JOB_TYPE]: campaignExportHandler,
-  [CAMPAIGN_DISPATCH_JOB_TYPE]: campaignDispatchHandler,
-  [WEBHOOK_DELIVERY_JOB_TYPE]: webhookDeliveryHandler,
-  [ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE]: elevenlabsBatchTranscribeHandler,
-};
+/**
+ * The worker job registry (ADR-0007, #1239 A1).
+ *
+ * `jobHandlers`, `PAGING_JOB_TYPES`, and `SELF_SCHEDULING_JOB_TYPES` below are
+ * all DERIVED from this one list instead of being maintained separately — see
+ * `app/lib/worker/job-registry.server.ts` for the `defineJob`/`legacyJob`
+ * mechanism and `test/job-registry.test.ts` for the drift guard.
+ *
+ * Three types are registered via `defineJob` as a proof of the mechanism:
+ * `twilio_open_sync` and `elevenlabs_batch_transcribe` get real params
+ * validation, and `billing_reconcile` demonstrates that a single call site
+ * now covers what used to be entries in three separate lists (jobHandlers,
+ * PAGING_JOB_TYPES, SELF_SCHEDULING_JOB_TYPES). Every other type is
+ * registered via `legacyJob`, which carries paging/schedule metadata without
+ * validating params — TODO(#1239 A2): migrate the rest and delete
+ * `legacyJob`.
+ */
+
+const twilioOpenSyncParams = z.object({
+  callLimit: legacyNumericParam(50),
+  messageLimit: legacyNumericParam(50),
+  maxAgeMinutes: legacyNumericParam(120),
+});
+
+const billingReconcileParams = z.object({
+  workspaceId: z.string().optional(),
+});
+
+const elevenlabsBatchTranscribeParams = z.object({
+  callSid: z.preprocess(
+    (value) => (typeof value === "string" ? value : ""),
+    z.string().min(1, "elevenlabs_batch_transcribe: missing callSid"),
+  ),
+});
+
+// Kept as its own (non-widened) tuple so `createTypedEnqueue` below can infer
+// each registration's literal `type` and its zod-inferred `Params` — combined
+// into `jobRegistry` as plain `RegisteredJob`s further down.
+const typedRegistrations = [
+  defineJob({
+    type: "twilio_open_sync",
+    params: twilioOpenSyncParams,
+    // Only entry with non-empty seed params: matches the boot-time seed row
+    // ensure-scheduled-jobs.server.ts used to hand-maintain for this type.
+    schedule: { seedParams: { callLimit: 50, messageLimit: 50, maxAgeMinutes: 120 } },
+    // Params are validated but the handler still derives its own values —
+    // that deeper migration is TODO(#1239 A2), same as the legacy types.
+    handler: (job) => twilioOpenSyncHandler(job),
+  }),
+  defineJob({
+    type: "billing_reconcile",
+    params: billingReconcileParams,
+    pages: true,
+    schedule: true,
+    handler: (job) => billingReconcileHandler(job),
+  }),
+  defineJob({
+    type: ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE,
+    params: elevenlabsBatchTranscribeParams,
+    handler: (job) => elevenlabsBatchTranscribeHandler(job),
+  }),
+] as const;
+
+const legacyRegistrations = [
+  legacyJob({
+    type: WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
+    handler: workspaceTwilioComplianceHandler,
+    pages: true,
+  }),
+  legacyJob({
+    type: "campaign_schedule_sync",
+    handler: campaignScheduleSyncHandler,
+    schedule: true,
+  }),
+  legacyJob({
+    type: "number_rental_billing",
+    handler: numberRentalBillingHandler,
+    pages: true,
+    schedule: true,
+  }),
+  legacyJob({
+    type: "audience_upload",
+    handler: audienceUploadHandler,
+  }),
+  legacyJob({
+    type: "low_credit_notify",
+    handler: lowCreditNotifyHandler,
+    schedule: true,
+  }),
+  legacyJob({
+    type: TWILIO_WEBHOOK_AUDIT_JOB_TYPE,
+    handler: twilioWebhookAuditHandler,
+    schedule: true,
+  }),
+  legacyJob({
+    type: CALL_STATUS_SIDE_EFFECTS_JOB_TYPE,
+    handler: callStatusSideEffectsHandler,
+    pages: true,
+  }),
+  legacyJob({
+    type: SMS_STATUS_SIDE_EFFECTS_JOB_TYPE,
+    handler: smsStatusSideEffectsHandler,
+    pages: true,
+  }),
+  legacyJob({
+    type: RECORDING_SIDE_EFFECTS_JOB_TYPE,
+    handler: recordingSideEffectsHandler,
+  }),
+  legacyJob({
+    type: CAMPAIGN_EXPORT_JOB_TYPE,
+    handler: campaignExportHandler,
+  }),
+  legacyJob({
+    type: CAMPAIGN_DISPATCH_JOB_TYPE,
+    handler: campaignDispatchHandler,
+  }),
+  legacyJob({
+    type: WEBHOOK_DELIVERY_JOB_TYPE,
+    handler: webhookDeliveryHandler,
+  }),
+] as const;
+
+export const jobRegistry: RegisteredJob[] = [
+  ...typedRegistrations,
+  ...legacyRegistrations,
+];
+
+export const jobHandlers: JobHandlers = Object.fromEntries(
+  jobRegistry.map((registration) => [registration.type, registration.jobHandler]),
+);
+
+/**
+ * Typed `enqueueJob`, narrowed to the job types registered via `defineJob`
+ * (`twilio_open_sync`, `billing_reconcile`, `elevenlabs_batch_transcribe`):
+ * `type` is a literal union instead of `string`, and `params` must match that
+ * type's zod schema — an enqueue-time typo or shape mismatch is now a
+ * compile error (or a `ZodError` at call time) instead of a dead-lettered job
+ * discovered later. Wraps `enqueueJob`; existing untyped callers are
+ * unaffected. TODO(#1239 A2): as more types move onto `defineJob`, they gain
+ * this for free.
+ */
+export const enqueueRegisteredJob = createTypedEnqueue(typedRegistrations);
+
+/**
+ * Job types whose permanent failure warrants waking someone: the two billing
+ * debit paths, the two recurring money jobs, and compliance provisioning.
+ * Everything else (exports, uploads, webhook delivery, notifications) is
+ * log-only — a customer reports those. DERIVED from `jobRegistry` — see
+ * `poll-jobs.server.ts`, which consumes this to decide whether a
+ * dead-lettered job pages on-call.
+ */
+export const PAGING_JOB_TYPES: ReadonlySet<string> = new Set(
+  jobRegistry.filter((registration) => registration.pages).map((registration) => registration.type),
+);
+
+/**
+ * Job types that re-enqueue themselves and therefore need a boot-time seed
+ * row (see `ensure-scheduled-jobs.server.ts`). DERIVED from `jobRegistry`.
+ */
+export const SELF_SCHEDULING_JOB_TYPES: readonly string[] = jobRegistry
+  .filter((registration) => registration.schedule !== false)
+  .map((registration) => registration.type);
+
+/** Seed params for each self-scheduling type, keyed by type. DERIVED from `jobRegistry`. */
+export const SELF_SCHEDULING_SEED_PARAMS: Readonly<Record<string, Record<string, unknown>>> =
+  Object.fromEntries(
+    jobRegistry
+      .filter((registration) => registration.schedule !== false)
+      .map((registration) => [
+        registration.type,
+        (registration.schedule as { seedParams?: Record<string, unknown> }).seedParams ?? {},
+      ]),
+  );

--- a/app/lib/worker/job-registry.server.ts
+++ b/app/lib/worker/job-registry.server.ts
@@ -1,0 +1,177 @@
+import { z } from "zod";
+import type { ClaimedJobRow, JobHandler } from "@/lib/worker/poll-jobs.server";
+import {
+  enqueueJob,
+  type EnqueueJobArgs,
+  type EnqueueJobResult,
+} from "@/lib/worker/enqueue-job.server";
+
+/**
+ * Job registry mechanism (ADR-0007 worker, part 1 of #1239).
+ *
+ * Before this, a job type's identity was scattered across ~6 hand-maintained
+ * lists that could each drift independently: `job-types.server.ts` (constants
+ * for a handful of types), `handlers.server.ts`'s `jobHandlers` object
+ * (mixing constants and bare string literals), `poll-jobs.server.ts`'s
+ * `PAGING_JOB_TYPES`, `ensure-scheduled-jobs.server.ts`'s
+ * `SELF_SCHEDULING_JOB_TYPES`, plus every enqueue call site. A typo in any one
+ * of them compiles fine and only surfaces at runtime as a dead-lettered job
+ * ("No handler registered for job type: X").
+ *
+ * `defineJob` lets a job type declare its params shape, paging behaviour, and
+ * self-scheduling behaviour in one place, next to its handler. The actual
+ * registry (`app/lib/worker/handlers.server.ts`) assembles every job type's
+ * registration into one list; `jobHandlers`, the paging set, and the
+ * self-scheduling set are all DERIVED from that list rather than
+ * hand-maintained separately — see `test/job-registry.test.ts` for the
+ * equality guard against the sets this replaced.
+ *
+ * This is the registry MECHANISM only. Only a few job types are registered
+ * via `defineJob` so far; the rest go through `legacyJob`, which registers a
+ * type's paging/schedule metadata without validating its params (that
+ * migration is TODO(#1239 A2)).
+ */
+
+/** Self-re-enqueuing behaviour for a job type, or `false` if it doesn't. */
+export type JobSchedule =
+  | {
+      /** Extra params merged into the boot-time seed row for this type. */
+      seedParams?: Record<string, unknown>;
+    }
+  | false;
+
+function normalizeSchedule(schedule: JobSchedule | true | undefined): JobSchedule {
+  if (schedule === true) return {};
+  return schedule ?? false;
+}
+
+export type JobDefinition<Type extends string, Params> = {
+  /** The `job.type` column value this registration handles. */
+  type: Type;
+  /** Zod schema `job.params` is parsed against before the handler runs. */
+  params: z.ZodType<Params>;
+  /**
+   * Dead-lettering this type pages on-call (see `PAGING_JOB_TYPES` derivation
+   * in `poll-jobs.server.ts`'s consumer, `handlers.server.ts`).
+   */
+  pages?: boolean;
+  /** Self-re-enqueuing type that needs a boot-time seed row. Pass `true` for no extra seed params. */
+  schedule?: JobSchedule | true;
+  handler: (job: ClaimedJobRow, params: Params) => Promise<unknown>;
+};
+
+export type RegisteredJob<Type extends string = string, Params = unknown> = {
+  type: Type;
+  pages: boolean;
+  schedule: JobSchedule;
+  /** The zod schema this registration validates `job.params` against. */
+  params: z.ZodType<Params>;
+  /** The `(job) => Promise<unknown>` shape `jobHandlers`/the poll loop expects. */
+  jobHandler: JobHandler;
+};
+
+/**
+ * Register a job type through the registry: params are validated with zod
+ * before the handler runs, and paging/scheduling metadata live next to the
+ * handler instead of in separate hand-maintained lists.
+ */
+export function defineJob<Type extends string, Params>(
+  def: JobDefinition<Type, Params>,
+): RegisteredJob<Type, Params> {
+  const jobHandler: JobHandler = async (job: ClaimedJobRow) => {
+    const params = def.params.parse(job.params ?? {});
+    return def.handler(job, params);
+  };
+  return {
+    type: def.type,
+    pages: def.pages ?? false,
+    schedule: normalizeSchedule(def.schedule),
+    params: def.params,
+    jobHandler,
+  };
+}
+
+/**
+ * Register a job type WITHOUT param validation — an adapter for types not
+ * yet migrated onto `defineJob`. `handler` keeps its existing
+ * `(job: ClaimedJobRow) => Promise<unknown>` shape and continues deriving its
+ * own params from `job.params` internally, exactly as it does today.
+ *
+ * TODO(#1239 A2): migrate every `legacyJob` registration onto `defineJob`
+ * with a real params schema, then delete this function.
+ */
+export function legacyJob<Type extends string>(def: {
+  type: Type;
+  handler: JobHandler;
+  pages?: boolean;
+  schedule?: JobSchedule | true;
+}): RegisteredJob<Type, unknown> {
+  return {
+    type: def.type,
+    pages: def.pages ?? false,
+    schedule: normalizeSchedule(def.schedule),
+    params: z.unknown(),
+    jobHandler: def.handler,
+  };
+}
+
+/**
+ * Numeric job param with the coercion `requireNumberParam` (shared.server.ts)
+ * has always applied: a finite number, or a non-negative-integer string
+ * (tenant-db rows serialize bigint/serial ids as strings — see #1078),
+ * falling back to `fallback` for anything else, including absence.
+ */
+export function legacyNumericParam(fallback: number): z.ZodType<number> {
+  return z.preprocess((value) => {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+      return Number(value.trim());
+    }
+    return undefined;
+  }, z.number().default(fallback));
+}
+
+type ParamsOf<R> = R extends RegisteredJob<string, infer Params> ? Params : never;
+type TypeOf<R> = R extends RegisteredJob<infer Type, unknown> ? Type : never;
+
+export type TypedEnqueueArgs<Type extends string, Params> = Omit<
+  EnqueueJobArgs,
+  "type" | "params"
+> & {
+  type: Type;
+  params: Params;
+};
+
+/**
+ * Build a typed `enqueueJob` scoped to a fixed list of `defineJob`
+ * registrations: `type` is narrowed to one of the registered literal types,
+ * and `params` must match that type's zod-inferred shape (parsed again here,
+ * so a bad caller-supplied value fails at enqueue time instead of dequeue
+ * time). Wraps the existing untyped `enqueueJob` — every current caller of
+ * that function is untouched.
+ *
+ * Only job types registered via `defineJob` (not `legacyJob`) get a real
+ * `Params` type; the rest stay on the untyped `enqueueJob` path until #1239
+ * A2 migrates them.
+ */
+export function createTypedEnqueue<const Regs extends readonly RegisteredJob<string, unknown>[]>(
+  registrations: Regs,
+) {
+  type Reg = Regs[number];
+  type ParamsMap = { [R in Reg as TypeOf<R>]: ParamsOf<R> };
+
+  return async function enqueueRegisteredJob<Type extends keyof ParamsMap & string>(
+    args: TypedEnqueueArgs<Type, ParamsMap[Type]>,
+  ): Promise<EnqueueJobResult> {
+    const registration = registrations.find(
+      (candidate): candidate is Reg => candidate.type === args.type,
+    );
+    if (!registration) {
+      throw new Error(
+        `enqueueRegisteredJob: no defineJob registration for type "${args.type}"`,
+      );
+    }
+    const parsed = registration.params.parse(args.params) as Record<string, unknown>;
+    return enqueueJob({ ...args, params: parsed });
+  };
+}

--- a/app/lib/worker/poll-jobs.server.ts
+++ b/app/lib/worker/poll-jobs.server.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger.server";
 import { runWithRequestContext } from "@/lib/request-context.server";
 import { captureException } from "@/lib/sentry.server";
 import { notifyOps } from "@/lib/ops-alert.server";
+import { PAGING_JOB_TYPES } from "@/lib/worker/handlers.server";
 
 export type ClaimedJobRow = {
   id: number;
@@ -35,20 +36,6 @@ function getJobRequestId(job: ClaimedJobRow): string {
   }
   return `job-${job.id}`;
 }
-
-/**
- * Job types whose permanent failure warrants waking someone: the two billing
- * debit paths, the two recurring money jobs, and compliance provisioning.
- * Everything else (exports, uploads, webhook delivery, notifications) is
- * log-only — a customer reports those.
- */
-const PAGING_JOB_TYPES = new Set([
-  "call_status_side_effects",
-  "sms_status_side_effects",
-  "billing_reconcile",
-  "number_rental_billing",
-  "workspace_twilio_compliance",
-]);
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;

--- a/test/ensure-scheduled-jobs.test.ts
+++ b/test/ensure-scheduled-jobs.test.ts
@@ -43,7 +43,10 @@ describe("ensureSelfSchedulingJobsSeeded", () => {
 
     const result = await ensureSelfSchedulingJobsSeeded();
 
-    expect(result.seeded).toEqual(["low_credit_notify"]);
+    // Position-based, not identity-based: whichever type is first in the
+    // (now registry-derived, #1239 A1) SELF_SCHEDULING_JOB_TYPES order gets
+    // the one seed the mock allows through.
+    expect(result.seeded).toEqual([SELF_SCHEDULING_JOB_TYPES[0]]);
   });
 
   test("a failed seed does not abort the remaining types", async () => {
@@ -57,6 +60,8 @@ describe("ensureSelfSchedulingJobsSeeded", () => {
     expect(enqueueJobMock).toHaveBeenCalledTimes(
       SELF_SCHEDULING_JOB_TYPES.length,
     );
-    expect(result.seeded).toEqual(["twilio_webhook_audit"]);
+    // First type's seed rejects (and must not abort the loop), second
+    // type's seed succeeds.
+    expect(result.seeded).toEqual([SELF_SCHEDULING_JOB_TYPES[1]]);
   });
 });

--- a/test/job-registry.test.ts
+++ b/test/job-registry.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "vitest";
+import {
+  jobHandlers,
+  jobRegistry,
+  PAGING_JOB_TYPES,
+  SELF_SCHEDULING_JOB_TYPES,
+  SELF_SCHEDULING_SEED_PARAMS,
+} from "@/lib/worker/handlers.server";
+
+/**
+ * Drift guard for #1239 A1: `jobHandlers`, `PAGING_JOB_TYPES`, and
+ * `SELF_SCHEDULING_JOB_TYPES` are now DERIVED from the `jobRegistry` list in
+ * handlers.server.ts instead of being hand-maintained independently. These
+ * tests pin them to the exact sets that existed before the registry
+ * landed — a snapshot of what poll-jobs.server.ts's `PAGING_JOB_TYPES` and
+ * ensure-scheduled-jobs.server.ts's `SELF_SCHEDULING_JOB_TYPES` used to
+ * hardcode. If this test needs to change, it means a job type's paging or
+ * scheduling behaviour changed, not just its registration mechanism — that
+ * should be a deliberate, reviewed diff, not silent drift between the lists
+ * this registry replaced.
+ */
+
+// The exact `jobHandlers` key set that existed in handlers.server.ts before
+// the registry landed (job-types.server.ts constants + bare string literals).
+const EXPECTED_JOB_TYPES = [
+  "twilio_open_sync",
+  "workspace_twilio_compliance",
+  "billing_reconcile",
+  "campaign_schedule_sync",
+  "number_rental_billing",
+  "audience_upload",
+  "low_credit_notify",
+  "twilio_webhook_audit",
+  "call_status_side_effects",
+  "sms_status_side_effects",
+  "recording_side_effects",
+  "campaign_export",
+  "campaign_dispatch",
+  "webhook_delivery",
+  "elevenlabs_batch_transcribe",
+].sort();
+
+// The exact set poll-jobs.server.ts hand-maintained as `PAGING_JOB_TYPES`.
+const EXPECTED_PAGING_JOB_TYPES = [
+  "call_status_side_effects",
+  "sms_status_side_effects",
+  "billing_reconcile",
+  "number_rental_billing",
+  "workspace_twilio_compliance",
+].sort();
+
+// The exact set ensure-scheduled-jobs.server.ts hand-maintained as
+// `SELF_SCHEDULING_JOB_TYPES`.
+const EXPECTED_SELF_SCHEDULING_JOB_TYPES = [
+  "low_credit_notify",
+  "twilio_webhook_audit",
+  "twilio_open_sync",
+  "billing_reconcile",
+  "number_rental_billing",
+  "campaign_schedule_sync",
+].sort();
+
+// The exact seed params map ensure-scheduled-jobs.server.ts hand-maintained
+// (only twilio_open_sync had non-empty seed params; every other
+// self-scheduling type seeded with `{}`).
+const EXPECTED_SEED_PARAMS: Record<string, Record<string, unknown>> = {
+  low_credit_notify: {},
+  twilio_webhook_audit: {},
+  twilio_open_sync: { callLimit: 50, messageLimit: 50, maxAgeMinutes: 120 },
+  billing_reconcile: {},
+  number_rental_billing: {},
+  campaign_schedule_sync: {},
+};
+
+describe("job registry — derived-set equality guard (#1239 A1)", () => {
+  test("jobRegistry has exactly one entry per job type (no duplicates, no gaps)", () => {
+    const types = jobRegistry.map((registration) => registration.type);
+    expect(new Set(types).size).toBe(types.length);
+    expect([...types].sort()).toEqual(EXPECTED_JOB_TYPES);
+  });
+
+  test("jobHandlers keys match the hand-maintained object literal it replaced", () => {
+    expect(Object.keys(jobHandlers).sort()).toEqual(EXPECTED_JOB_TYPES);
+  });
+
+  test("every jobHandlers entry is callable", () => {
+    for (const type of EXPECTED_JOB_TYPES) {
+      expect(typeof jobHandlers[type]).toBe("function");
+    }
+  });
+
+  test("PAGING_JOB_TYPES matches poll-jobs.server.ts's former hardcoded set", () => {
+    expect([...PAGING_JOB_TYPES].sort()).toEqual(EXPECTED_PAGING_JOB_TYPES);
+  });
+
+  test("SELF_SCHEDULING_JOB_TYPES matches ensure-scheduled-jobs.server.ts's former hardcoded set", () => {
+    expect([...SELF_SCHEDULING_JOB_TYPES].sort()).toEqual(
+      EXPECTED_SELF_SCHEDULING_JOB_TYPES,
+    );
+  });
+
+  test("SELF_SCHEDULING_SEED_PARAMS matches ensure-scheduled-jobs.server.ts's former hardcoded map", () => {
+    for (const type of EXPECTED_SELF_SCHEDULING_JOB_TYPES) {
+      expect(SELF_SCHEDULING_SEED_PARAMS[type]).toEqual(EXPECTED_SEED_PARAMS[type]);
+    }
+    expect(Object.keys(SELF_SCHEDULING_SEED_PARAMS).sort()).toEqual(
+      EXPECTED_SELF_SCHEDULING_JOB_TYPES,
+    );
+  });
+});
+
+describe("job registry — defineJob params validation (proof migrations)", () => {
+  test("twilio_open_sync defaults missing/invalid numeric params exactly like the old requireNumberParam helper", async () => {
+    const registration = jobRegistry.find((r) => r.type === "twilio_open_sync");
+    expect(registration).toBeDefined();
+
+    // Missing params -> defaults (50, 50, 120), matching the old `?? 50` etc.
+    expect(registration!.params.parse({})).toEqual({
+      callLimit: 50,
+      messageLimit: 50,
+      maxAgeMinutes: 120,
+    });
+
+    // Numeric-string params coerce, matching requireNumberParam's tenant-db
+    // bigint-as-string handling (#1078).
+    expect(
+      registration!.params.parse({ callLimit: "10", messageLimit: "20", maxAgeMinutes: "30" }),
+    ).toEqual({ callLimit: 10, messageLimit: 20, maxAgeMinutes: 30 });
+
+    // Garbage falls back to default rather than throwing, matching the old
+    // `requireNumberParam(...) ?? default` behaviour.
+    expect(registration!.params.parse({ callLimit: "not-a-number" })).toEqual({
+      callLimit: 50,
+      messageLimit: 50,
+      maxAgeMinutes: 120,
+    });
+  });
+
+  test("elevenlabs_batch_transcribe rejects a missing callSid with the original error message", () => {
+    const registration = jobRegistry.find(
+      (r) => r.type === "elevenlabs_batch_transcribe",
+    );
+    expect(registration).toBeDefined();
+    expect(() => registration!.params.parse({})).toThrowError(
+      "elevenlabs_batch_transcribe: missing callSid",
+    );
+    expect(registration!.params.parse({ callSid: "CA123" })).toEqual({
+      callSid: "CA123",
+    });
+  });
+
+  test("billing_reconcile accepts an optional workspaceId and ignores unknown keys", () => {
+    const registration = jobRegistry.find((r) => r.type === "billing_reconcile");
+    expect(registration).toBeDefined();
+    expect(registration!.params.parse({})).toEqual({});
+    expect(
+      registration!.params.parse({ workspaceId: "ws_1", requestId: "req_1" }),
+    ).toEqual({ workspaceId: "ws_1" });
+  });
+});


### PR DESCRIPTION
Part 1 of #1239 (A1). This delivers the registry **mechanism** only — it does not migrate every handler (that's A2) and does not touch A3.

## Problem

The worker's job types are tracked by ~6 hand-maintained lists that can drift independently: `job-types.server.ts` constants, `handlers.server.ts`'s `jobHandlers` object literal (mixing constants and bare string literals), `poll-jobs.server.ts`'s `PAGING_JOB_TYPES`, `ensure-scheduled-jobs.server.ts`'s `SELF_SCHEDULING_JOB_TYPES`, plus every enqueue call site. A typo in any one of them compiles fine and only surfaces at runtime as a dead-lettered job ("No handler registered for job type: X"). `ClaimedJobRow.params` is `unknown`, so every handler re-derives its own params shape by hand.

## What this PR does

1. **`defineJob({ type, params, pages?, schedule?, handler })`** (`app/lib/worker/job-registry.server.ts`) — validates `job.params` with zod before the handler runs, and declares a type's paging/self-scheduling behaviour next to its handler instead of in separate lists. `legacyJob({ type, handler, pages?, schedule? })` is the adapter for types not yet migrated — no params validation, same handler shape as today.
2. **One registry, three derived artifacts** (`app/lib/worker/handlers.server.ts`) — `jobRegistry` is a single list combining `defineJob`/`legacyJob` registrations for all 15 job types. `jobHandlers`, `PAGING_JOB_TYPES`, `SELF_SCHEDULING_JOB_TYPES`, and `SELF_SCHEDULING_SEED_PARAMS` are all **derived** from it via `.filter()`/`.map()` — no more separately hand-typed sets. `poll-jobs.server.ts` and `ensure-scheduled-jobs.server.ts` now import these derived values under their existing exported names/shapes, so nothing downstream had to change.
3. **Typed `enqueueRegisteredJob`** — a wrapper around the existing `enqueueJob` scoped to the `defineJob`-registered types: `type` is a literal union and `params` must match that type's zod-inferred shape (validated again at enqueue time). The existing untyped `enqueueJob` is untouched; no current caller was changed.
4. **Three proof migrations** onto `defineJob`: `twilio_open_sync` (numeric params with the same coercion/defaults `requireNumberParam` used, plus its self-scheduling seed params), `billing_reconcile` (paging **and** self-scheduling — one call site now covers what used to be entries in three separate lists), and `elevenlabs_batch_transcribe` (required-string param, same error message as the original manual check). Their handler bodies are untouched — the wrapper validates params before delegating, so behavior is identical.
5. Everything else stays on `legacyJob` with a `TODO(#1239 A2)` marker.

## Test: derived-set equality guard

`test/job-registry.test.ts` pins `jobHandlers`' keys, `PAGING_JOB_TYPES`, `SELF_SCHEDULING_JOB_TYPES`, and `SELF_SCHEDULING_SEED_PARAMS` against the exact values the old hand-maintained lists had, plus asserts every job type has exactly one registration. This is the drift guard until A2 deletes the old lists' successors for good. It also exercises the three `defineJob` params schemas directly against the original derivation logic they replace (numeric coercion/defaults, required-string error message, optional field).

`test/ensure-scheduled-jobs.test.ts` had two assertions that hardcoded specific job type names tied to array position (an artifact of the old literal list's incidental order); updated to reference `SELF_SCHEDULING_JOB_TYPES[0]`/`[1]` by position instead — job seeding has no ordering contract, so this isn't a behavior change.

## Constraints honored

- No behavior change to job execution: migrated handler bodies are untouched; params validation happens in the wrapper before delegating.
- No new dependencies: zod was already a dependency (`^4.4.3`, imported as `"zod"`).
- Derived sets are exactly equal to the sets they replace (see test above).

## Gate results

- `npm run typecheck` — clean
- `npx vitest run -c vitest.node.config.ts` — 350 files / 2548 tests passed, 11 skipped (full node suite)
- `bun test test/server-runtime.test.ts test/twilio-webhook-prehandler.test.ts vendor/scriptkit/scriptkit-call-script-core/src/` — 22 passed
- `node scripts/check-handlers.mjs` — passed
- `npm run check:client-bundle` / `check:route-server-leaks` / `check:effects` / `check:type-safety` / `check:dry` / `check:db-rpcs` / `check:credit-writes` — all passed (`check:dry` baseline improved slightly: 231/3224 vs baseline 233/3252, from removing duplicated lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)