### PR TITLE
refactor(worker): migrate remaining job types onto defineJob (#1239 A2)

### DIFF
--- a/app/lib/worker/handlers.server.ts
+++ b/app/lib/worker/handlers.server.ts
@@ -12,8 +12,13 @@ import type { JobHandlers } from "@/lib/worker/poll-jobs.server";
 import {
   createTypedEnqueue,
   defineJob,
-  legacyJob,
+  legacyNullableStringParam,
   legacyNumericParam,
+  legacyObjectParam,
+  legacyRequiredNumberParam,
+  legacyRequiredObjectParam,
+  legacyRequiredStringParam,
+  legacyStringParam,
   type RegisteredJob,
 } from "@/lib/worker/job-registry.server";
 import {
@@ -28,6 +33,7 @@ import {
 import {
   callStatusSideEffectsHandler,
   recordingSideEffectsHandler,
+  sidAndTwilioParamsSchema,
   smsStatusSideEffectsHandler,
 } from "./handlers/webhook-adapters.server";
 import {
@@ -44,21 +50,20 @@ import { elevenlabsBatchTranscribeHandler } from "./handlers/elevenlabs-batch-tr
 export { enqueueWorkspaceComplianceJob };
 
 /**
- * The worker job registry (ADR-0007, #1239 A1).
+ * The worker job registry (ADR-0007, #1239).
  *
  * `jobHandlers`, `PAGING_JOB_TYPES`, and `SELF_SCHEDULING_JOB_TYPES` below are
  * all DERIVED from this one list instead of being maintained separately — see
- * `app/lib/worker/job-registry.server.ts` for the `defineJob`/`legacyJob`
- * mechanism and `test/job-registry.test.ts` for the drift guard.
+ * `app/lib/worker/job-registry.server.ts` for the `defineJob` mechanism and
+ * `test/job-registry.test.ts` for the drift guard.
  *
- * Three types are registered via `defineJob` as a proof of the mechanism:
- * `twilio_open_sync` and `elevenlabs_batch_transcribe` get real params
- * validation, and `billing_reconcile` demonstrates that a single call site
- * now covers what used to be entries in three separate lists (jobHandlers,
- * PAGING_JOB_TYPES, SELF_SCHEDULING_JOB_TYPES). Every other type is
- * registered via `legacyJob`, which carries paging/schedule metadata without
- * validating params — TODO(#1239 A2): migrate the rest and delete
- * `legacyJob`.
+ * Every job type is registered via `defineJob`: params are validated with a
+ * zod schema before the handler runs (#1239 A1 landed the mechanism plus
+ * three proof-of-concept types; A2 migrated the remaining twelve off the
+ * `legacyJob` escape hatch, which no longer exists). Each schema below is a
+ * direct translation of the hand-rolled `typeof`-narrowing its handler used
+ * to do — see the PR body for a per-type equivalence note (exactly-equivalent
+ * vs. deliberately-looser-than-the-old-narrowing, and why).
  */
 
 const twilioOpenSyncParams = z.object({
@@ -78,19 +83,154 @@ const elevenlabsBatchTranscribeParams = z.object({
   ),
 });
 
+/**
+ * `workspace_twilio_compliance` — `reason` defaulted to `"worker"` in the
+ * handler (`requireStringParam(params, "reason") ?? "worker"`); `workspaceId`
+ * and `actorUserId` are resolved against `job.workspace_id`/`job.user_id`
+ * first, so both stay optional here. Exactly equivalent.
+ */
+const workspaceTwilioComplianceParams = z.object({
+  workspaceId: legacyStringParam(),
+  reason: legacyStringParam().default("worker"),
+  actorUserId: legacyStringParam(),
+});
+
+/**
+ * `audience_upload` — the widest hand-rolled narrowing in the worker.
+ * `uploadId`/`audienceId` were `requireNumberParam(...)` then combined into a
+ * bundled `if (!uploadId || !audienceId || !workspaceId || !userId) throw`;
+ * split into per-field zod failures here (still rejects the same falsy
+ * values, including a coerced `0` — see `legacyRequiredNumberParam`).
+ * `workspaceId`/`userId` are still resolved against the job row in the
+ * handler, so they stay optional in the schema. `headerMapping` and
+ * `voterListSource` are DELIBERATELY LOOSER than a "real" schema would be:
+ * the old code only checked `typeof`, never validated `headerMapping`'s
+ * values are strings or that `voterListSource` is one of the six enum
+ * members it's typed as (see `normalizeVoterListSource`, which already runs
+ * at the one enqueue site) — this schema preserves that permissiveness so an
+ * already-queued row with a shape the old code would have blindly accepted
+ * doesn't dead-letter.
+ */
+const audienceUploadParams = z.object({
+  uploadId: legacyRequiredNumberParam("audience_upload: missing or invalid uploadId"),
+  audienceId: legacyRequiredNumberParam("audience_upload: missing or invalid audienceId"),
+  workspaceId: legacyStringParam(),
+  userId: legacyStringParam(),
+  fileContent: legacyStringParam().default(""),
+  headerMapping: legacyObjectParam<Record<string, string>>({}),
+  splitNameColumn: legacyNullableStringParam(),
+  voterListSource: legacyNullableStringParam(),
+});
+
+/**
+ * `campaign_schedule_sync` / `low_credit_notify` — neither handler ever reads
+ * `job.params`. `z.unknown()` accepts anything, matching that.
+ */
+const noParams = z.unknown();
+
+/**
+ * `twilio_webhook_audit` — `autoRepair` defaulted to `true` unless explicitly
+ * `false` (`params.autoRepair !== false`); the workspace fanout always runs
+ * across every workspace and never reads a `workspaceId` param. Exactly
+ * equivalent.
+ */
+const twilioWebhookAuditParams = z.object({
+  autoRepair: z.preprocess((value) => value !== false, z.boolean()),
+});
+
+/**
+ * `number_rental_billing` — only `workspaceId` is read, resolved against
+ * `job.workspace_id` first and never required (absence means "fan out across
+ * every workspace"). Exactly equivalent.
+ */
+const numberRentalBillingParams = z.object({
+  workspaceId: legacyStringParam(),
+});
+
+/**
+ * `campaign_export` — `campaignId`/`exportId`/`campaignType` were bundled
+ * into one `if (!x || !y...) throw "missing campaignId, exportId,
+ * workspaceId, or campaignType"` alongside `workspaceId`; split into
+ * per-field zod failures for the three pure-params fields (still rejects the
+ * same falsy values), `workspaceId` stays optional here since it's resolved
+ * against `job.workspace_id` in the handler. `campaignType`'s
+ * message/live_call/robocall restriction is business logic, not narrowing —
+ * it stays in the handler exactly as before (same "unsupported campaign
+ * type" error). Exactly equivalent.
+ */
+const campaignExportParams = z.object({
+  campaignId: legacyRequiredNumberParam("campaign_export: missing or invalid campaignId"),
+  exportId: legacyRequiredStringParam("campaign_export: missing exportId"),
+  campaignName: legacyStringParam().default(""),
+  campaignType: legacyRequiredStringParam("campaign_export: missing campaignType"),
+  workspaceId: legacyStringParam(),
+});
+
+/**
+ * `campaign_dispatch` — `campaignId` is a pure params field (required, same
+ * falsy-including-`0` rejection as the old bundled check); `workspaceId` and
+ * `userId` are resolved against the job row in the handler, exactly as
+ * before, including the separate "missing userId (launching actor)" error.
+ * Exactly equivalent.
+ */
+const campaignDispatchParams = z.object({
+  campaignId: legacyRequiredNumberParam("campaign_dispatch: missing or invalid campaignId"),
+  workspaceId: legacyStringParam(),
+  userId: legacyStringParam(),
+});
+
+/**
+ * `webhook_delivery` — `eventCategory`/`eventType`/`payload` were bundled
+ * into the same "missing workspaceId, eventCategory, eventType, or payload"
+ * check as `workspaceId`; split into per-field zod failures for the three
+ * pure-params fields, `workspaceId` stays optional (resolved against
+ * `job.workspace_id`). `eventType` is validated against the same two-value
+ * enum the old ternary checked (`"INSERT" | "UPDATE"`, anything else was
+ * already treated as missing). `optional` mirrors the old `=== true` check.
+ * Exactly equivalent.
+ */
+const webhookDeliveryParams = z.object({
+  workspaceId: legacyStringParam(),
+  eventCategory: legacyRequiredStringParam("webhook_delivery: missing eventCategory"),
+  eventType: z.enum(["INSERT", "UPDATE"]),
+  payload: legacyRequiredObjectParam("webhook_delivery: missing payload"),
+  optional: z.preprocess((value) => value === true, z.boolean()),
+});
+
+/**
+ * `call_status_side_effects` / `sms_status_side_effects` /
+ * `recording_side_effects` — all three used to call the same
+ * `requireSidAndTwilioParams(job, sidKey, label)` helper in
+ * webhook-adapters.server.ts; that's now `sidAndTwilioParamsSchema(sidKey,
+ * label)`, one shared factory instead of three copies. `twilioParams` is
+ * DELIBERATELY LOOSER than a "real" schema: the old code never validated its
+ * values are strings (just `typeof value === "object" && value !== null`),
+ * and neither does `legacyObjectParam`. Exactly equivalent otherwise.
+ */
+const callStatusSideEffectsParams = sidAndTwilioParamsSchema(
+  "callSid",
+  "call_status_side_effects",
+);
+const smsStatusSideEffectsParams = sidAndTwilioParamsSchema(
+  "messageSid",
+  "sms_status_side_effects",
+);
+const recordingSideEffectsParams = sidAndTwilioParamsSchema(
+  "callSid",
+  "recording_side_effects",
+);
+
 // Kept as its own (non-widened) tuple so `createTypedEnqueue` below can infer
-// each registration's literal `type` and its zod-inferred `Params` — combined
+// each registration's literal `type` and its zod-inferred `Params` — spread
 // into `jobRegistry` as plain `RegisteredJob`s further down.
-const typedRegistrations = [
+const registrations = [
   defineJob({
     type: "twilio_open_sync",
     params: twilioOpenSyncParams,
     // Only entry with non-empty seed params: matches the boot-time seed row
     // ensure-scheduled-jobs.server.ts used to hand-maintain for this type.
     schedule: { seedParams: { callLimit: 50, messageLimit: 50, maxAgeMinutes: 120 } },
-    // Params are validated but the handler still derives its own values —
-    // that deeper migration is TODO(#1239 A2), same as the legacy types.
-    handler: (job) => twilioOpenSyncHandler(job),
+    handler: (job, params) => twilioOpenSyncHandler(job, params),
   }),
   defineJob({
     type: "billing_reconcile",
@@ -104,87 +244,91 @@ const typedRegistrations = [
     params: elevenlabsBatchTranscribeParams,
     handler: (job) => elevenlabsBatchTranscribeHandler(job),
   }),
-] as const;
-
-const legacyRegistrations = [
-  legacyJob({
+  defineJob({
     type: WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
-    handler: workspaceTwilioComplianceHandler,
+    params: workspaceTwilioComplianceParams,
     pages: true,
+    handler: (job, params) => workspaceTwilioComplianceHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: "campaign_schedule_sync",
-    handler: campaignScheduleSyncHandler,
+    params: noParams,
     schedule: true,
+    handler: (job) => campaignScheduleSyncHandler(job),
   }),
-  legacyJob({
+  defineJob({
     type: "number_rental_billing",
-    handler: numberRentalBillingHandler,
+    params: numberRentalBillingParams,
     pages: true,
     schedule: true,
+    handler: (job, params) => numberRentalBillingHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: "audience_upload",
-    handler: audienceUploadHandler,
+    params: audienceUploadParams,
+    handler: (job, params) => audienceUploadHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: "low_credit_notify",
-    handler: lowCreditNotifyHandler,
+    params: noParams,
     schedule: true,
+    handler: (job) => lowCreditNotifyHandler(job),
   }),
-  legacyJob({
+  defineJob({
     type: TWILIO_WEBHOOK_AUDIT_JOB_TYPE,
-    handler: twilioWebhookAuditHandler,
+    params: twilioWebhookAuditParams,
     schedule: true,
+    handler: (job, params) => twilioWebhookAuditHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: CALL_STATUS_SIDE_EFFECTS_JOB_TYPE,
-    handler: callStatusSideEffectsHandler,
+    params: callStatusSideEffectsParams,
     pages: true,
+    handler: (job, params) => callStatusSideEffectsHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: SMS_STATUS_SIDE_EFFECTS_JOB_TYPE,
-    handler: smsStatusSideEffectsHandler,
+    params: smsStatusSideEffectsParams,
     pages: true,
+    handler: (job, params) => smsStatusSideEffectsHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: RECORDING_SIDE_EFFECTS_JOB_TYPE,
-    handler: recordingSideEffectsHandler,
+    params: recordingSideEffectsParams,
+    handler: (job, params) => recordingSideEffectsHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: CAMPAIGN_EXPORT_JOB_TYPE,
-    handler: campaignExportHandler,
+    params: campaignExportParams,
+    handler: (job, params) => campaignExportHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: CAMPAIGN_DISPATCH_JOB_TYPE,
-    handler: campaignDispatchHandler,
+    params: campaignDispatchParams,
+    handler: (job, params) => campaignDispatchHandler(job, params),
   }),
-  legacyJob({
+  defineJob({
     type: WEBHOOK_DELIVERY_JOB_TYPE,
-    handler: webhookDeliveryHandler,
+    params: webhookDeliveryParams,
+    handler: (job, params) => webhookDeliveryHandler(job, params),
   }),
 ] as const;
 
-export const jobRegistry: RegisteredJob[] = [
-  ...typedRegistrations,
-  ...legacyRegistrations,
-];
+export const jobRegistry: RegisteredJob[] = [...registrations];
 
 export const jobHandlers: JobHandlers = Object.fromEntries(
   jobRegistry.map((registration) => [registration.type, registration.jobHandler]),
 );
 
 /**
- * Typed `enqueueJob`, narrowed to the job types registered via `defineJob`
- * (`twilio_open_sync`, `billing_reconcile`, `elevenlabs_batch_transcribe`):
- * `type` is a literal union instead of `string`, and `params` must match that
- * type's zod schema — an enqueue-time typo or shape mismatch is now a
- * compile error (or a `ZodError` at call time) instead of a dead-lettered job
- * discovered later. Wraps `enqueueJob`; existing untyped callers are
- * unaffected. TODO(#1239 A2): as more types move onto `defineJob`, they gain
- * this for free.
+ * Typed `enqueueJob`, narrowed to every registered job type: `type` is a
+ * literal union instead of `string`, and `params` must match that type's zod
+ * schema — an enqueue-time typo or shape mismatch is now a compile error (or
+ * a `ZodError` at call time) instead of a dead-lettered job discovered later.
+ * Wraps `enqueueJob`; existing untyped callers are unaffected. No call site
+ * has been migrated onto this yet — that's #1239 A3.
  */
-export const enqueueRegisteredJob = createTypedEnqueue(typedRegistrations);
+export const enqueueRegisteredJob = createTypedEnqueue(registrations);
 
 /**
  * Job types whose permanent failure warrants waking someone: the two billing

--- a/app/lib/worker/handlers/campaign.server.ts
+++ b/app/lib/worker/handlers/campaign.server.ts
@@ -17,71 +17,65 @@ import { createTenantDb } from "@/server/tenant-db";
 import { DISPATCH_TICK_MS } from "@/lib/throughput-config";
 import { logger } from "@/lib/logger.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
-import {
-  requireNumberParam,
-  requireRecordParam,
-  requireStringParam,
-} from "./shared.server";
+import type { VoterListSource } from "@/lib/audience-upload-process.server";
 
 export const WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE = "workspace_twilio_compliance";
 
-export async function audienceUploadHandler(job: ClaimedJobRow): Promise<unknown> {
-  const params = (job.params ?? {}) as Record<string, unknown>;
-  const uploadId = requireNumberParam(params, "uploadId");
-  const audienceId = requireNumberParam(params, "audienceId");
-  const workspaceId =
-    job.workspace_id ?? requireStringParam(params, "workspaceId");
-  const userId = job.user_id ?? requireStringParam(params, "userId");
-  const fileContent =
-    typeof params.fileContent === "string" ? params.fileContent : "";
-  const headerMapping =
-    typeof params.headerMapping === "object" && params.headerMapping !== null
-      ? (params.headerMapping as Record<string, string>)
-      : {};
-  const splitNameColumn =
-    typeof params.splitNameColumn === "string" ? params.splitNameColumn : null;
-  const voterListSource =
-    typeof params.voterListSource === "string"
-      ? (params.voterListSource as
-          | "liberalist"
-          | "van"
-          | "elections_canada"
-          | "elections_ontario"
-          | "manual"
-          | "other"
-          | null)
-      : null;
+export type AudienceUploadParams = {
+  uploadId: number;
+  audienceId: number;
+  workspaceId: string | undefined;
+  userId: string | undefined;
+  fileContent: string;
+  headerMapping: Record<string, string>;
+  splitNameColumn: string | null;
+  voterListSource: string | null;
+};
 
-  if (!uploadId || !audienceId || !workspaceId || !userId) {
-    throw new Error("Missing required audience upload parameters");
+export async function audienceUploadHandler(
+  job: ClaimedJobRow,
+  params: AudienceUploadParams,
+): Promise<unknown> {
+  const workspaceId = job.workspace_id ?? params.workspaceId;
+  const userId = job.user_id ?? params.userId;
+
+  if (!workspaceId || !userId) {
+    throw new Error("audience_upload: missing workspaceId or userId");
   }
 
   await processAudienceUpload(
-    uploadId,
-    audienceId,
+    params.uploadId,
+    params.audienceId,
     workspaceId,
     userId,
-    fileContent,
-    headerMapping,
-    splitNameColumn,
+    params.fileContent,
+    params.headerMapping,
+    params.splitNameColumn,
     undefined,
-    voterListSource,
+    // Same blind cast the old narrowing did — voterListSource was never
+    // validated against the enum at this layer (see legacyNullableStringParam
+    // in job-registry.server.ts for why that stays true post-migration).
+    params.voterListSource as VoterListSource | null,
   );
-  return { ok: true, uploadId, audienceId };
+  return { ok: true, uploadId: params.uploadId, audienceId: params.audienceId };
 }
+
+export type WorkspaceTwilioComplianceParams = {
+  workspaceId: string | undefined;
+  reason: string;
+  actorUserId: string | undefined;
+};
 
 export async function workspaceTwilioComplianceHandler(
   job: ClaimedJobRow,
+  params: WorkspaceTwilioComplianceParams,
 ): Promise<unknown> {
-  const params = (job.params ?? {}) as Record<string, unknown>;
-  const workspaceId =
-    job.workspace_id ?? requireStringParam(params, "workspaceId");
+  const workspaceId = job.workspace_id ?? params.workspaceId;
   if (!workspaceId) {
     throw new Error("Missing workspaceId for workspace_twilio_compliance job");
   }
-  const reason = requireStringParam(params, "reason") ?? "worker";
-  const actorUserId =
-    job.user_id ?? requireStringParam(params, "actorUserId") ?? null;
+  const reason = params.reason;
+  const actorUserId = job.user_id ?? params.actorUserId ?? null;
 
   await runWorkspaceTwilioComplianceJob({ workspaceId, reason, actorUserId });
   return { ok: true, workspaceId, reason };
@@ -115,19 +109,23 @@ export async function enqueueWorkspaceComplianceJob(
   });
 }
 
-export async function campaignExportHandler(job: ClaimedJobRow): Promise<unknown> {
-  const params = (job.params ?? {}) as Record<string, unknown>;
-  const campaignId = requireNumberParam(params, "campaignId");
-  const exportId = requireStringParam(params, "exportId");
-  const campaignName = requireStringParam(params, "campaignName") ?? "";
-  const campaignType = requireStringParam(params, "campaignType");
-  const workspaceId =
-    job.workspace_id ?? requireStringParam(params, "workspaceId");
+export type CampaignExportParams = {
+  campaignId: number;
+  exportId: string;
+  campaignName: string;
+  campaignType: string;
+  workspaceId: string | undefined;
+};
 
-  if (!campaignId || !exportId || !workspaceId || !campaignType) {
-    throw new Error(
-      "campaign_export: missing campaignId, exportId, workspaceId, or campaignType",
-    );
+export async function campaignExportHandler(
+  job: ClaimedJobRow,
+  params: CampaignExportParams,
+): Promise<unknown> {
+  const { campaignId, exportId, campaignName, campaignType } = params;
+  const workspaceId = job.workspace_id ?? params.workspaceId;
+
+  if (!workspaceId) {
+    throw new Error("campaign_export: missing workspaceId");
   }
 
   if (campaignType === "message") {
@@ -182,16 +180,24 @@ async function enqueueDispatchSuccessor(args: {
   });
 }
 
-export async function campaignDispatchHandler(job: ClaimedJobRow): Promise<unknown> {
-  const params = (job.params ?? {}) as Record<string, unknown>;
-  const campaignId = requireNumberParam(params, "campaignId");
-  const workspaceId = job.workspace_id ?? requireStringParam(params, "workspaceId");
+export type CampaignDispatchParams = {
+  campaignId: number;
+  workspaceId: string | undefined;
+  userId: string | undefined;
+};
+
+export async function campaignDispatchHandler(
+  job: ClaimedJobRow,
+  params: CampaignDispatchParams,
+): Promise<unknown> {
+  const { campaignId } = params;
+  const workspaceId = job.workspace_id ?? params.workspaceId;
   // The launching actor. Required: dequeues and outreach attempts are
   // attributed to a real user, never a synthetic "system" id.
-  const userId = job.user_id ?? requireStringParam(params, "userId");
+  const userId = job.user_id ?? params.userId;
 
-  if (!campaignId || !workspaceId) {
-    throw new Error("campaign_dispatch: missing campaignId or workspaceId");
+  if (!workspaceId) {
+    throw new Error("campaign_dispatch: missing workspaceId");
   }
   if (!userId) {
     throw new Error("campaign_dispatch: missing userId (launching actor)");
@@ -297,33 +303,29 @@ export async function campaignDispatchHandler(job: ClaimedJobRow): Promise<unkno
   }
 }
 
-export async function webhookDeliveryHandler(job: ClaimedJobRow): Promise<unknown> {
-  const params = (job.params ?? {}) as Record<string, unknown>;
-  const workspaceId =
-    job.workspace_id ?? requireStringParam(params, "workspaceId");
-  const eventCategory = requireStringParam(params, "eventCategory");
-  const eventType =
-    params.eventType === "INSERT" || params.eventType === "UPDATE"
-      ? params.eventType
-      : undefined;
-  const payload =
-    typeof params.payload === "object" && params.payload !== null
-      ? (params.payload as Record<string, unknown>)
-      : undefined;
-  const optional = params.optional === true;
+export type WebhookDeliveryParams = {
+  workspaceId: string | undefined;
+  eventCategory: string;
+  eventType: "INSERT" | "UPDATE";
+  payload: Record<string, unknown>;
+  optional: boolean;
+};
 
-  if (!workspaceId || !eventCategory || !eventType || !payload) {
-    throw new Error(
-      "webhook_delivery: missing workspaceId, eventCategory, eventType, or payload",
-    );
+export async function webhookDeliveryHandler(
+  job: ClaimedJobRow,
+  params: WebhookDeliveryParams,
+): Promise<unknown> {
+  const workspaceId = job.workspace_id ?? params.workspaceId;
+  if (!workspaceId) {
+    throw new Error("webhook_delivery: missing workspaceId");
   }
 
   const result = await sendWorkspaceWebhookNotification({
     workspaceId,
-    eventCategory,
-    eventType,
-    payload,
-    optional,
+    eventCategory: params.eventCategory,
+    eventType: params.eventType,
+    payload: params.payload,
+    optional: params.optional,
   });
 
   if (!result.success) {

--- a/app/lib/worker/handlers/cron.server.ts
+++ b/app/lib/worker/handlers/cron.server.ts
@@ -15,7 +15,7 @@ import {
 import { listAllWorkspacesOrdered } from "@/lib/workspace-members-db.server";
 import { logger } from "@/lib/logger.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
-import { withReschedule, requireNumberParam, requireStringParam } from "./shared.server";
+import { withReschedule } from "./shared.server";
 
 const LOW_CREDIT_NOTIFY_RESCHEDULE_MS = 24 * 60 * 60 * 1000;
 const TWILIO_OPEN_SYNC_RESCHEDULE_MS = 5 * 60 * 1000;
@@ -66,12 +66,12 @@ async function withOptionalWorkspaceFanout<T>(args: {
   return args.runOne(args.workspaceId);
 }
 
-export async function twilioOpenSyncHandler(job: ClaimedJobRow): Promise<unknown> {
-  const params = (job.params ?? {}) as Record<string, unknown>;
+export async function twilioOpenSyncHandler(
+  job: ClaimedJobRow,
+  params: { callLimit: number; messageLimit: number; maxAgeMinutes: number },
+): Promise<unknown> {
   const workspaceId = resolveWorkspaceId(job) ?? "";
-  const callLimit = requireNumberParam(params, "callLimit") ?? 50;
-  const messageLimit = requireNumberParam(params, "messageLimit") ?? 50;
-  const maxAgeMinutes = requireNumberParam(params, "maxAgeMinutes") ?? 120;
+  const { callLimit, messageLimit, maxAgeMinutes } = params;
 
   return withReschedule(
     {
@@ -146,8 +146,9 @@ export async function billingReconcileHandler(job: ClaimedJobRow): Promise<unkno
 
 export async function numberRentalBillingHandler(
   job: ClaimedJobRow,
+  params: { workspaceId: string | undefined },
 ): Promise<unknown> {
-  const workspaceId = resolveWorkspaceId(job);
+  const workspaceId = job.workspace_id ?? params.workspaceId;
 
   return withReschedule(
     {
@@ -239,21 +240,21 @@ export async function campaignScheduleSyncHandler(job: ClaimedJobRow): Promise<u
 /**
  * Scheduled Twilio webhook audit + optional auto-repair. Self-re-enqueuing.
  */
-export async function twilioWebhookAuditHandler(job: ClaimedJobRow): Promise<unknown> {
+export async function twilioWebhookAuditHandler(
+  job: ClaimedJobRow,
+  params: { autoRepair: boolean },
+): Promise<unknown> {
   return withReschedule(
     {
       type: TWILIO_WEBHOOK_AUDIT_JOB_TYPE,
       delayMs: TWILIO_WEBHOOK_AUDIT_RESCHEDULE_MS,
       completedJobId: job.id,
     },
-    () => runTwilioWebhookAudit(job),
+    () => runTwilioWebhookAudit(params.autoRepair),
   );
 }
 
-async function runTwilioWebhookAudit(job: ClaimedJobRow): Promise<unknown> {
-  const params = (job.params ?? {}) as Record<string, unknown>;
-  const autoRepair = params.autoRepair !== false;
-
+async function runTwilioWebhookAudit(autoRepair: boolean): Promise<unknown> {
   const workspaces = await listAllWorkspacesOrdered();
   const results: TwilioWebhookAuditWorkspaceResult[] = [];
 

--- a/app/lib/worker/handlers/shared.server.ts
+++ b/app/lib/worker/handlers/shared.server.ts
@@ -68,38 +68,15 @@ export async function rescheduleJob(
   }
 }
 
+// requireStringParam is the last hand-rolled params narrowing left in this
+// file: every other job type's params narrowing now lives in a zod schema
+// next to its `defineJob` registration in handlers.server.ts (#1239 A2). This
+// one is still used by elevenlabs-batch-transcribe.server.ts's handler, which
+// wasn't part of that migration.
 export function requireStringParam(
   params: Record<string, unknown>,
   key: string,
 ): string | undefined {
   const value = params[key];
   return typeof value === "string" ? value : undefined;
-}
-
-export function requireNumberParam(
-  params: Record<string, unknown>,
-  key: string,
-): number | undefined {
-  const value = params[key];
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  // Tenant-db rows serialize serial/bigint ids as strings, and those ids get
-  // enqueued into jsonb job params verbatim. Rejecting "12" here dead-ended
-  // every audience upload job with "Missing required parameters" (#1078).
-  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
-    return Number(value.trim());
-  }
-  return undefined;
-}
-
-export function requireRecordParam(
-  params: Record<string, unknown>,
-  key: string,
-): Record<string, string> | undefined {
-  const value = params[key];
-  if (typeof value === "object" && value !== null) {
-    return value as Record<string, string>;
-  }
-  return undefined;
 }

--- a/app/lib/worker/handlers/webhook-adapters.server.ts
+++ b/app/lib/worker/handlers/webhook-adapters.server.ts
@@ -1,54 +1,78 @@
+import { z } from "zod";
 import {
   runCallStatusSideEffects,
   runRecordingSideEffects,
   runSmsStatusSideEffects,
 } from "@/lib/worker/webhook-side-effects.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
-import { requireRecordParam, requireStringParam } from "./shared.server";
+import { legacyObjectParam, legacyStringParam } from "@/lib/worker/job-registry.server";
 
-function requireSidAndTwilioParams(
-  job: ClaimedJobRow,
+export type SidAndTwilioParams = {
+  sid: string;
+  twilioParams: Record<string, string>;
+};
+
+/**
+ * Shared params schema for the three Twilio webhook fast-ack side-effect job
+ * types (#1239 A2): each one used to re-implement the same
+ * `requireSidAndTwilioParams` narrowing (sid key differs, everything else is
+ * identical). One factory, parameterized on the sid field name and the label
+ * used in the error message, replaces all three copies.
+ *
+ * Both `callSid` and `messageSid` are read from `job.params` regardless of
+ * which one this job type actually uses — matching the old code, which read
+ * `job.params[sidKey]` and simply never looked at the other key.
+ */
+export function sidAndTwilioParamsSchema(
   sidKey: "callSid" | "messageSid",
   label: string,
-): { sid: string; twilioParams: Record<string, string> } {
-  const params = (job.params ?? {}) as Record<string, unknown>;
-  const sid = requireStringParam(params, sidKey);
-  const twilioParams = requireRecordParam(params, "twilioParams");
-  if (!sid || !twilioParams) {
-    throw new Error(`${label}: missing ${sidKey} or twilioParams`);
-  }
-  return { sid, twilioParams };
+): z.ZodType<SidAndTwilioParams> {
+  return z
+    .object({
+      callSid: legacyStringParam(),
+      messageSid: legacyStringParam(),
+      twilioParams: legacyObjectParam<Record<string, string> | undefined>(undefined),
+    })
+    .transform((value, ctx) => {
+      const sid = sidKey === "callSid" ? value.callSid : value.messageSid;
+      const twilioParams = value.twilioParams;
+      if (!sid || !twilioParams) {
+        ctx.addIssue({
+          code: "custom",
+          message: `${label}: missing ${sidKey} or twilioParams`,
+        });
+        return z.NEVER;
+      }
+      return { sid, twilioParams };
+    });
 }
 
 export async function callStatusSideEffectsHandler(
   job: ClaimedJobRow,
+  params: SidAndTwilioParams,
 ): Promise<unknown> {
-  const { sid, twilioParams } = requireSidAndTwilioParams(
-    job,
-    "callSid",
-    "call_status_side_effects",
-  );
-  return runCallStatusSideEffects({ callSid: sid, twilioParams });
+  return runCallStatusSideEffects({
+    callSid: params.sid,
+    twilioParams: params.twilioParams,
+  });
 }
 
 export async function smsStatusSideEffectsHandler(
   job: ClaimedJobRow,
+  params: SidAndTwilioParams,
 ): Promise<unknown> {
-  const { sid, twilioParams } = requireSidAndTwilioParams(
-    job,
-    "messageSid",
-    "sms_status_side_effects",
-  );
-  return runSmsStatusSideEffects({ messageSid: sid, twilioParams });
+  return runSmsStatusSideEffects({
+    messageSid: params.sid,
+    twilioParams: params.twilioParams,
+  });
 }
 
 export async function recordingSideEffectsHandler(
   job: ClaimedJobRow,
+  params: SidAndTwilioParams,
 ): Promise<unknown> {
-  const { sid, twilioParams } = requireSidAndTwilioParams(
-    job,
-    "callSid",
-    "recording_side_effects",
-  );
-  return runRecordingSideEffects({ callSid: sid, twilioParams });
+  return runRecordingSideEffects({
+    callSid: params.sid,
+    twilioParams: params.twilioParams,
+  });
 }

--- a/app/lib/worker/job-registry.server.ts
+++ b/app/lib/worker/job-registry.server.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/worker/enqueue-job.server";
 
 /**
- * Job registry mechanism (ADR-0007 worker, part 1 of #1239).
+ * Job registry mechanism (ADR-0007 worker, #1239).
  *
  * Before this, a job type's identity was scattered across ~6 hand-maintained
  * lists that could each drift independently: `job-types.server.ts` (constants
@@ -16,20 +16,24 @@ import {
  * `PAGING_JOB_TYPES`, `ensure-scheduled-jobs.server.ts`'s
  * `SELF_SCHEDULING_JOB_TYPES`, plus every enqueue call site. A typo in any one
  * of them compiles fine and only surfaces at runtime as a dead-lettered job
- * ("No handler registered for job type: X").
+ * ("No handler registered for job type: X"). Each handler also hand-rolled
+ * its own `job.params` narrowing (a `typeof` check per field, sometimes
+ * duplicated across handlers), which failed the same way: silently, at
+ * runtime, as a dead letter.
  *
- * `defineJob` lets a job type declare its params shape, paging behaviour, and
- * self-scheduling behaviour in one place, next to its handler. The actual
- * registry (`app/lib/worker/handlers.server.ts`) assembles every job type's
+ * `defineJob` lets a job type declare its params shape (a zod schema,
+ * validated before the handler runs), paging behaviour, and self-scheduling
+ * behaviour in one place, next to its handler. The actual registry
+ * (`app/lib/worker/handlers.server.ts`) assembles every job type's
  * registration into one list; `jobHandlers`, the paging set, and the
  * self-scheduling set are all DERIVED from that list rather than
  * hand-maintained separately — see `test/job-registry.test.ts` for the
  * equality guard against the sets this replaced.
  *
- * This is the registry MECHANISM only. Only a few job types are registered
- * via `defineJob` so far; the rest go through `legacyJob`, which registers a
- * type's paging/schedule metadata without validating its params (that
- * migration is TODO(#1239 A2)).
+ * A1 landed the mechanism plus three proof-of-concept types, with the rest on
+ * a `legacyJob` escape hatch (no params validation). A2 migrated the
+ * remaining twelve onto `defineJob` and deleted `legacyJob` — every
+ * registered job type now validates its params.
  */
 
 /** Self-re-enqueuing behaviour for a job type, or `false` if it doesn't. */
@@ -92,34 +96,10 @@ export function defineJob<Type extends string, Params>(
 }
 
 /**
- * Register a job type WITHOUT param validation — an adapter for types not
- * yet migrated onto `defineJob`. `handler` keeps its existing
- * `(job: ClaimedJobRow) => Promise<unknown>` shape and continues deriving its
- * own params from `job.params` internally, exactly as it does today.
- *
- * TODO(#1239 A2): migrate every `legacyJob` registration onto `defineJob`
- * with a real params schema, then delete this function.
- */
-export function legacyJob<Type extends string>(def: {
-  type: Type;
-  handler: JobHandler;
-  pages?: boolean;
-  schedule?: JobSchedule | true;
-}): RegisteredJob<Type, unknown> {
-  return {
-    type: def.type,
-    pages: def.pages ?? false,
-    schedule: normalizeSchedule(def.schedule),
-    params: z.unknown(),
-    jobHandler: def.handler,
-  };
-}
-
-/**
- * Numeric job param with the coercion `requireNumberParam` (shared.server.ts)
- * has always applied: a finite number, or a non-negative-integer string
- * (tenant-db rows serialize bigint/serial ids as strings — see #1078),
- * falling back to `fallback` for anything else, including absence.
+ * Numeric job param with the coercion job handlers used to apply by hand: a
+ * finite number, or a non-negative-integer string (tenant-db rows serialize
+ * bigint/serial ids as strings — see #1078), falling back to `fallback` for
+ * anything else, including absence.
  */
 export function legacyNumericParam(fallback: number): z.ZodType<number> {
   return z.preprocess((value) => {
@@ -129,6 +109,100 @@ export function legacyNumericParam(fallback: number): z.ZodType<number> {
     }
     return undefined;
   }, z.number().default(fallback));
+}
+
+/**
+ * Numeric job param that's REQUIRED instead of defaulted: same finite-number
+ * / non-negative-integer-string coercion as `legacyNumericParam`, but a
+ * missing, non-numeric, or zero value fails validation with `message` instead
+ * of silently falling back. Zero is rejected on purpose — every hand-rolled
+ * narrowing this replaces (`if (!uploadId) throw ...`) treated a coerced `0`
+ * as "missing" too, since `0` is falsy in JS. Negative numbers are NOT
+ * rejected, matching that same falsy check (`!(-5)` is `false`).
+ */
+export function legacyRequiredNumberParam(message: string): z.ZodType<number> {
+  return z.preprocess((value) => {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+      return Number(value.trim());
+    }
+    return 0;
+  }, z.number().refine((value) => value !== 0, { message }));
+}
+
+/**
+ * String job param with the coercion `requireStringParam` (shared.server.ts)
+ * has always applied: the value as-is if it's a string, else `undefined`
+ * (including absence). Chain `.default(x)` for params that fell back to a
+ * literal default instead of staying `undefined` (e.g. `reason ?? "worker"`).
+ */
+export function legacyStringParam(): z.ZodType<string | undefined> {
+  return z.preprocess(
+    (value) => (typeof value === "string" ? value : undefined),
+    z.string().optional(),
+  );
+}
+
+/**
+ * String job param that's REQUIRED (and non-empty): same string-or-nothing
+ * coercion as `legacyStringParam`, but missing/non-string/empty-string fails
+ * validation with `message` instead of passing `undefined` through. Matches
+ * every hand-rolled `if (!x) throw ...` guard on a `requireStringParam`
+ * result — an empty string is falsy in JS, same as `undefined`.
+ */
+export function legacyRequiredStringParam(message: string): z.ZodType<string> {
+  return z.preprocess(
+    (value) => (typeof value === "string" ? value : ""),
+    z.string().min(1, message),
+  );
+}
+
+/**
+ * Nullable string job param for params whose hand-rolled narrowing fell back
+ * to `null` (not `undefined`) on anything but a string — e.g.
+ * `audience_upload`'s `splitNameColumn` and `voterListSource`. Deliberately
+ * does NOT validate against an enum even where the field's TS type implies
+ * one (`voterListSource`'s `VoterListSource | null`): the original narrowing
+ * only ever checked `typeof value === "string"` and cast, so an
+ * already-queued row with an out-of-enum string must keep processing rather
+ * than dead-letter.
+ */
+export function legacyNullableStringParam(): z.ZodType<string | null> {
+  return z.preprocess(
+    (value) => (typeof value === "string" ? value : null),
+    z.string().nullable(),
+  );
+}
+
+/**
+ * Object/record job param with the coercion `requireRecordParam` used to
+ * apply: the value as-is (no shape validation — arrays pass through
+ * unchanged too, matching the old `typeof value === "object" && value !==
+ * null` check) if it's a non-null object, else `fallback`. Pass `undefined`
+ * as `fallback` for params that were required (no default) in the old code.
+ */
+export function legacyObjectParam<T>(fallback: T): z.ZodType<T> {
+  return z.preprocess(
+    (value) => (typeof value === "object" && value !== null ? value : fallback),
+    z.custom<T>(() => true),
+  );
+}
+
+/**
+ * Object/record job param that's REQUIRED: same non-null-object coercion as
+ * `legacyObjectParam`, but missing/non-object fails validation with
+ * `message` instead of passing a fallback through.
+ */
+export function legacyRequiredObjectParam(
+  message: string,
+): z.ZodType<Record<string, unknown>> {
+  return z.preprocess(
+    (value) => (typeof value === "object" && value !== null ? value : undefined),
+    z.custom<Record<string, unknown>>(
+      (value) => typeof value === "object" && value !== null,
+      { message },
+    ),
+  );
 }
 
 type ParamsOf<R> = R extends RegisteredJob<string, infer Params> ? Params : never;
@@ -150,9 +224,9 @@ export type TypedEnqueueArgs<Type extends string, Params> = Omit<
  * time). Wraps the existing untyped `enqueueJob` — every current caller of
  * that function is untouched.
  *
- * Only job types registered via `defineJob` (not `legacyJob`) get a real
- * `Params` type; the rest stay on the untyped `enqueueJob` path until #1239
- * A2 migrates them.
+ * Every registered job type gets a real `Params` type as of #1239 A2. No
+ * enqueue call site has been migrated onto this yet — that's #1239 A3;
+ * `enqueueJob` remains the only path every current caller uses.
  */
 export function createTypedEnqueue<const Regs extends readonly RegisteredJob<string, unknown>[]>(
   registrations: Regs,

--- a/test/campaign-dispatch-worker.test.ts
+++ b/test/campaign-dispatch-worker.test.ts
@@ -59,7 +59,10 @@ vi.mock("@/lib/twilio-compliance-job.server", () => ({
   runWorkspaceTwilioComplianceJob: vi.fn(),
 }));
 
-import { campaignDispatchHandler } from "@/lib/worker/handlers/campaign.server";
+import {
+  campaignDispatchHandler as realCampaignDispatchHandler,
+  type CampaignDispatchParams,
+} from "@/lib/worker/handlers/campaign.server";
 import { launchCampaign } from "@/lib/campaign-execution.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
 
@@ -77,6 +80,14 @@ function makeJob(overrides?: Partial<ClaimedJobRow>): ClaimedJobRow {
     max_attempts: 3,
     ...overrides,
   };
+}
+
+// The registry (handlers.server.ts) now validates `job.params` with a zod
+// schema before calling the handler with the parsed result (#1239 A2). Every
+// fixture in this file is already well-typed, so casting stands in for that
+// parse without pulling in handlers.server.ts's much larger dependency graph.
+function campaignDispatchHandler(job: ClaimedJobRow) {
+  return realCampaignDispatchHandler(job, job.params as CampaignDispatchParams);
 }
 
 function runningMessageCampaign(overrides?: Record<string, unknown>) {

--- a/test/job-registry.test.ts
+++ b/test/job-registry.test.ts
@@ -158,3 +158,131 @@ describe("job registry — defineJob params validation (proof migrations)", () =
     ).toEqual({ workspaceId: "ws_1" });
   });
 });
+
+describe("job registry — defineJob params validation (#1239 A2 migrations)", () => {
+  test("audience_upload rejects a coerced-zero uploadId/audienceId like the old bundled falsy check", () => {
+    const registration = jobRegistry.find((r) => r.type === "audience_upload");
+    expect(registration).toBeDefined();
+
+    // 0 is falsy in JS — the old `if (!uploadId || !audienceId || ...) throw`
+    // treated a coerced 0 as "missing", same as an absent field.
+    expect(() => registration!.params.parse({ uploadId: 0, audienceId: 5 })).toThrowError(
+      "audience_upload: missing or invalid uploadId",
+    );
+    expect(() => registration!.params.parse({ uploadId: 5, audienceId: "not-a-number" })).toThrowError(
+      "audience_upload: missing or invalid audienceId",
+    );
+
+    // Numeric-string ids coerce (tenant-db bigint-as-string, #1078); optional
+    // fields fall back exactly like the old `typeof` narrowing.
+    expect(
+      registration!.params.parse({ uploadId: "12", audienceId: "34" }),
+    ).toEqual({
+      uploadId: 12,
+      audienceId: 34,
+      workspaceId: undefined,
+      userId: undefined,
+      fileContent: "",
+      headerMapping: {},
+      splitNameColumn: null,
+      voterListSource: null,
+    });
+
+    // voterListSource is NOT enum-validated (deliberately looser — see
+    // legacyNullableStringParam's doc comment): an out-of-enum string that
+    // the old blind cast would have accepted must still pass.
+    expect(
+      registration!.params.parse({
+        uploadId: 1,
+        audienceId: 2,
+        voterListSource: "not_a_real_source",
+        headerMapping: ["array", "not", "object"],
+      }).voterListSource,
+    ).toBe("not_a_real_source");
+    expect(
+      registration!.params.parse({ uploadId: 1, audienceId: 2, headerMapping: ["a", "b"] })
+        .headerMapping,
+    ).toEqual(["a", "b"]);
+  });
+
+  test("call/sms/recording side-effect job types share one schema factory and reject the same shapes requireSidAndTwilioParams did", () => {
+    const callStatus = jobRegistry.find((r) => r.type === "call_status_side_effects");
+    const smsStatus = jobRegistry.find((r) => r.type === "sms_status_side_effects");
+    const recording = jobRegistry.find((r) => r.type === "recording_side_effects");
+    expect(callStatus).toBeDefined();
+    expect(smsStatus).toBeDefined();
+    expect(recording).toBeDefined();
+
+    expect(() => callStatus!.params.parse({})).toThrowError(
+      "call_status_side_effects: missing callSid or twilioParams",
+    );
+    expect(() => smsStatus!.params.parse({ messageSid: "SM1" })).toThrowError(
+      "sms_status_side_effects: missing messageSid or twilioParams",
+    );
+    expect(() => recording!.params.parse({ callSid: "CA1", twilioParams: "not-an-object" })).toThrowError(
+      "recording_side_effects: missing callSid or twilioParams",
+    );
+
+    // A row queued for call_status_side_effects only ever has `callSid` set;
+    // a stray `messageSid` from an unrelated job shape must be ignored, same
+    // as the old code reading only `params[sidKey]`.
+    expect(
+      callStatus!.params.parse({
+        callSid: "CA1",
+        messageSid: "SM_should_be_ignored",
+        twilioParams: { CallStatus: "completed" },
+      }),
+    ).toEqual({ sid: "CA1", twilioParams: { CallStatus: "completed" } });
+  });
+
+  test("webhook_delivery requires a valid eventType and rejects the same falsy payload/eventCategory the old bundled check did", () => {
+    const registration = jobRegistry.find((r) => r.type === "webhook_delivery");
+    expect(registration).toBeDefined();
+
+    expect(() =>
+      registration!.params.parse({
+        eventCategory: "call",
+        eventType: "DELETE",
+        payload: { a: 1 },
+      }),
+    ).toThrow();
+    expect(() =>
+      registration!.params.parse({ eventCategory: "call", eventType: "INSERT" }),
+    ).toThrowError("webhook_delivery: missing payload");
+    expect(() =>
+      registration!.params.parse({ eventType: "INSERT", payload: { a: 1 } }),
+    ).toThrowError("webhook_delivery: missing eventCategory");
+
+    expect(
+      registration!.params.parse({
+        eventCategory: "call",
+        eventType: "UPDATE",
+        payload: { a: 1 },
+      }),
+    ).toEqual({
+      workspaceId: undefined,
+      eventCategory: "call",
+      eventType: "UPDATE",
+      payload: { a: 1 },
+      optional: false,
+    });
+  });
+
+  test("campaign_export and campaign_dispatch reject a coerced-zero campaignId like the old falsy check, but accept negative ids", () => {
+    const exportReg = jobRegistry.find((r) => r.type === "campaign_export");
+    const dispatchReg = jobRegistry.find((r) => r.type === "campaign_dispatch");
+    expect(exportReg).toBeDefined();
+    expect(dispatchReg).toBeDefined();
+
+    expect(() =>
+      exportReg!.params.parse({ campaignId: 0, exportId: "exp_1", campaignType: "message" }),
+    ).toThrowError("campaign_export: missing or invalid campaignId");
+    expect(() => dispatchReg!.params.parse({ campaignId: 0 })).toThrowError(
+      "campaign_dispatch: missing or invalid campaignId",
+    );
+
+    // Negative numbers are truthy in JS, so the old `!campaignId` check never
+    // rejected them — only an exact falsy 0 (or a non-numeric value).
+    expect(dispatchReg!.params.parse({ campaignId: -5 }).campaignId).toBe(-5);
+  });
+});

--- a/test/worker-cron-handlers.server.test.ts
+++ b/test/worker-cron-handlers.server.test.ts
@@ -56,10 +56,30 @@ vi.mock("@/lib/campaign-schedule-sync.server", () => ({
 import {
   billingReconcileHandler,
   campaignScheduleSyncHandler,
-  numberRentalBillingHandler,
-  twilioOpenSyncHandler,
+  numberRentalBillingHandler as realNumberRentalBillingHandler,
+  twilioOpenSyncHandler as realTwilioOpenSyncHandler,
 } from "@/lib/worker/handlers/cron.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
+
+// The registry (handlers.server.ts) now validates `job.params` with a zod
+// schema before calling the handler with the parsed result (#1239 A2). These
+// wrappers stand in for that parse (same defaulting/coercion the real schemas
+// apply) without pulling in handlers.server.ts's much larger dependency graph.
+function twilioOpenSyncHandler(job: ClaimedJobRow) {
+  const params = (job.params ?? {}) as Record<string, unknown>;
+  return realTwilioOpenSyncHandler(job, {
+    callLimit: typeof params.callLimit === "number" ? params.callLimit : 50,
+    messageLimit: typeof params.messageLimit === "number" ? params.messageLimit : 50,
+    maxAgeMinutes: typeof params.maxAgeMinutes === "number" ? params.maxAgeMinutes : 120,
+  });
+}
+
+function numberRentalBillingHandler(job: ClaimedJobRow) {
+  const params = (job.params ?? {}) as Record<string, unknown>;
+  return realNumberRentalBillingHandler(job, {
+    workspaceId: typeof params.workspaceId === "string" ? params.workspaceId : undefined,
+  });
+}
 
 function makeJob(overrides: Partial<ClaimedJobRow> = {}): ClaimedJobRow {
   return {


### PR DESCRIPTION
Part 2 of #1239 (A2), stacked on #1247 (base branch: `refactor/1239-define-job-registry`).

## What this does

Migrates every remaining `legacyJob` registration in `app/lib/worker/handlers.server.ts` onto `defineJob`, translating each handler's hand-rolled `job.params` narrowing into a zod schema, then deletes `legacyJob` entirely (nothing uses it anymore). Also finishes the inline `TODO(#1239 A2)` on `twilio_open_sync`'s handler (uses its already-validated params directly instead of re-deriving them).

Does **not** migrate any enqueue call site onto `enqueueRegisteredJob` (that's A3) and does not touch poll-jobs.server.ts mechanics.

## Per-type schema table

Every schema is **exactly equivalent** to the old narrowing unless noted **looser** — never stricter, since production `job` rows were enqueued under the old code and must not dead-letter under the new schema.

| Job type | Old narrowing | New schema | Equivalence |
|---|---|---|---|
| `workspace_twilio_compliance` | `requireStringParam` x3, `reason ?? "worker"` default | `legacyStringParam()` x2 + `.default("worker")` | Exact |
| `campaign_schedule_sync` | never reads `job.params` | `z.unknown()` | Exact |
| `number_rental_billing` | `job.workspace_id ?? requireStringParam(...)`, no throw | `legacyStringParam()` | Exact |
| `audience_upload` | bundled `if (!uploadId \|\| !audienceId \|\| !workspaceId \|\| !userId) throw` + blind casts for `headerMapping`/`splitNameColumn`/`voterListSource` | per-field `legacyRequiredNumberParam` (rejects coerced `0`, same as the old falsy check) for the two pure-params fields; `legacyObjectParam`/`legacyNullableStringParam` for the rest | **Looser on purpose**: `headerMapping` accepts any non-null object (arrays included) and `voterListSource` is not enum-validated — the old code never validated either, only `typeof`-checked and cast. Validating here would risk dead-lettering an already-queued row with a shape the old code silently accepted. |
| `low_credit_notify` | never reads `job.params` | `z.unknown()` | Exact |
| `twilio_webhook_audit` | `params.autoRepair !== false` | `z.preprocess(v => v !== false, z.boolean())` | Exact |
| `call_status_side_effects` / `sms_status_side_effects` / `recording_side_effects` | shared `requireSidAndTwilioParams(job, sidKey, label)` helper (3 call sites, `requireRecordParam` never validates `twilioParams`' values) | one shared `sidAndTwilioParamsSchema(sidKey, label)` factory | `twilioParams` **deliberately looser**: no value-shape validation, matching the old `typeof value === "object" && value !== null` check (arrays pass too) |
| `campaign_export` | bundled `if (!campaignId \|\| !exportId \|\| !workspaceId \|\| !campaignType) throw`; unsupported-type branch throws separately | per-field required checks for the 3 pure-params fields; `campaignType`'s message/live_call/robocall branching stays in the handler (business logic, not narrowing) | Exact |
| `campaign_dispatch` | bundled campaignId/workspaceId throw + separate userId throw | `legacyRequiredNumberParam` for `campaignId`; workspaceId/userId merge with the job row and stay in the handler | Exact |
| `webhook_delivery` | bundled 4-field throw; `eventType` ternary against 2 literals | per-field checks; `eventType: z.enum(["INSERT", "UPDATE"])` | Exact (an invalid eventType dead-letters either way, just with a different — still informative — message) |
| `twilio_open_sync` (bonus, already `defineJob` since A1) | handler re-derived `callLimit`/`messageLimit`/`maxAgeMinutes` via `requireNumberParam` despite already-validated params | handler now uses the validated params directly | Exact — same defaults, applied once instead of twice |

Where an old check bundled multiple fields into one message (e.g. `"campaign_export: missing campaignId, exportId, workspaceId, or campaignType"`), pure-params fields (no `job.workspace_id`/`job.user_id` merge) now fail individually with a field-specific zod message — more precise, not less informative. Fields that merge with the job row (`workspaceId`, `userId`) can't be validated inside a pure `job.params` schema, so their required-ness check stays in the handler, same as before.

## Shared schemas extracted

- `sidAndTwilioParamsSchema(sidKey, label)` in `webhook-adapters.server.ts` replaces the `requireSidAndTwilioParams` helper that all three webhook side-effect handlers called — one factory instead of three near-identical call sites.
- New general-purpose helpers in `job-registry.server.ts`, alongside A1's `legacyNumericParam`: `legacyRequiredNumberParam`, `legacyStringParam`, `legacyRequiredStringParam`, `legacyNullableStringParam`, `legacyObjectParam`, `legacyRequiredObjectParam` — each is a direct zod translation of one repeated `typeof`-narrowing pattern.

## What was deleted

- `legacyJob` (job-registry.server.ts) — no longer referenced anywhere.
- `requireNumberParam` and `requireRecordParam` (handlers/shared.server.ts) — fully dead after migration. `requireStringParam` stays; `elevenlabs-batch-transcribe.server.ts`'s handler (not touched by this PR) still uses it.
- The hand-rolled narrowing blocks inside every migrated handler body.

`job-types.server.ts`'s exported constants (`CALL_STATUS_SIDE_EFFECTS_JOB_TYPE`, `CAMPAIGN_EXPORT_JOB_TYPE`, etc.) are all still imported by non-worker code (routes, `campaign-execution.server.ts`, `twilio-open-sync.server.ts`) as enqueue-time constants — kept, per the note that enqueue call sites are out of scope for this PR.

## Test/gate results (all green at HEAD)

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run -c vitest.node.config.ts` — 350/350 files, 2560 passed, 3 skipped
- `test/job-registry.test.ts` — all pre-existing `EXPECTED_*` drift-guard assertions pass **unchanged** (derived sets did not change — confirms this is behavior-preserving), plus new schema tests for the four trickiest migrations (`audience_upload`'s falsy-zero rejection + deliberate looseness, the shared sid/twilioParams schema, `webhook_delivery`'s enum + split messages, `campaign_export`/`campaign_dispatch`'s zero-vs-negative campaignId handling)
- `npm run check:handlers` — passed
- `npm run check:type-safety` — passed (93 escape hatches, at/under baseline)
- `npm run check:dry` — passed, duplication count went **down** (232/3230 vs baseline 233/3252) from consolidating the sid-extraction triplicate
- `npm run check:effects` — passed
- `npm run check:db-rpcs` — passed

Local node is v25 (CI runs 22) — no version-sensitive code touched here, nothing to flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
