### PR TITLE
refactor(authz): make capability declarations mechanically enforced

### DIFF
--- a/app/lib/api-surface-internal-1.ts
+++ b/app/lib/api-surface-internal-1.ts
@@ -50,9 +50,24 @@ export const INTERNAL_API_SURFACE_1: readonly ApiSurfaceEntry[] = [
     docsGuide: GUIDE.data,
     workspaceScoped: true,
     operations: [
-      { method: "GET", handler: "loader", bodyType: "query" },
-      { method: "PATCH", handler: "action", bodyType: "form" },
-      { method: "DELETE", handler: "action", bodyType: "form" },
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",
+        capability: "campaigns.read",
+      },
+      {
+        method: "PATCH",
+        handler: "action",
+        bodyType: "form",
+        capability: "campaigns.write",
+      },
+      {
+        method: "DELETE",
+        handler: "action",
+        bodyType: "form",
+        capability: "campaigns.write",
+      },
     ],
   }),
   seed({

--- a/app/lib/capability-guard.server.ts
+++ b/app/lib/capability-guard.server.ts
@@ -4,7 +4,6 @@ import {
   requireActorCapability,
   type AuthorizationActor,
 } from "@chester-hill-solutions/auth";
-import { createRequireCapability } from "@chester-hill-solutions/auth-react-router";
 import type { RouterContextProvider, LoaderFunctionArgs } from "react-router";
 import {
   apiKeyActorFromScopes,
@@ -33,9 +32,10 @@ function capabilityDeniedResponse(error: CapabilityDeniedError): Response {
 
 /**
  * Resolve an AuthorizationActor for data-plane middleware context
- * (session membership role or API-key scope allowlist).
+ * (session membership role or API-key scope allowlist). Internal: routes go
+ * through {@link requireDataPlaneCapability}, which owns the denial shapes.
  */
-export async function resolveDataPlaneAuthorizationActor(
+async function resolveDataPlaneAuthorizationActor(
   auth: DataPlaneAuthContextValue,
 ): Promise<AuthorizationActor | Response> {
   if (auth.apiKey) {
@@ -222,9 +222,10 @@ export function defineDataPlaneListLoader<K extends string>(config: {
 }
 
 /**
- * Build an AuthorizationActor from a dual-auth result once workspaceId is known.
+ * Build an AuthorizationActor from a dual-auth result once workspaceId is
+ * known. Internal, for {@link requireDualAuthCapability}.
  */
-export async function resolveDualAuthAuthorizationActor(args: {
+async function resolveDualAuthAuthorizationActor(args: {
   auth: ApiKeyAuthResult | BearerSessionAuthResult | SessionAuthResult;
   workspaceId: string;
 }): Promise<AuthorizationActor | Response> {
@@ -275,31 +276,3 @@ export async function requireDualAuthCapability(args: {
   }
 }
 
-/**
- * Package factory wired to CallCaster data-plane actor resolution.
- * Prefer `requireDataPlaneCapability` for middleware-backed routes.
- */
-export function createDataPlaneRequireCapability(
-  capability: ProductCapabilityId,
-) {
-  return createRequireCapability({
-    capabilityId: asCapabilityId(capability),
-    resolveActor: async ({ workspaceId, userId }) => {
-      // Session path only — API keys should use requireDataPlaneCapability with
-      // full data-plane context (scopes live on the key, not userId).
-      const membership = await getUserRole({
-        user: { id: userId },
-        workspaceId,
-      });
-      if (!membership) {
-        return jsonError("Workspace not found", 404);
-      }
-      return sessionActorFromMembership({
-        userId,
-        workspaceId,
-        role: membership.role,
-      });
-    },
-    onDenied: capabilityDeniedResponse,
-  });
-}

--- a/app/lib/capability-guard.server.ts
+++ b/app/lib/capability-guard.server.ts
@@ -14,7 +14,7 @@ import type { ProductCapabilityId } from "@/lib/capabilities";
 import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
 import { getUserRole } from "@/lib/database/workspace.server";
 import { hasMinRole, type MemberRole } from "@/lib/member-role";
-import { defineLoader } from "@/lib/handler.server";
+import { defineLoader, withEnforcedCapability } from "@/lib/handler.server";
 import { jsonError, jsonResponse } from "@/lib/platform-api.server";
 import type { DataPlaneAuthContextValue } from "@/lib/route-context.server";
 import type {
@@ -110,9 +110,16 @@ export async function requireDataPlaneRouteCapability(
  * Handler-factory auth strategy for data-plane loaders/actions that only need
  * `workspaceId` + a product capability. Prefer this over inlining the same
  * workspaceId check + {@link requireDataPlaneRouteCapability} call.
+ *
+ * The strategy is branded with `capability` — the same value it hands to
+ * `requireActorCapability` — so the factory can propagate it to the handler
+ * and `check:handlers` can cross-check the API_SURFACE declaration against
+ * real enforcement instead of against a second, hand-written claim. Pass the
+ * strategy to `auth:` directly; wrapping it in `(args) => strategy(...)(args)`
+ * builds a fresh unbranded closure and breaks the link.
  */
 export function dataPlaneCapabilityAuth(capability: ProductCapabilityId) {
-  return async ({
+  return withEnforcedCapability(capability, async ({
     params,
     context,
   }: Pick<LoaderFunctionArgs, "params" | "context">) => {
@@ -121,7 +128,7 @@ export function dataPlaneCapabilityAuth(capability: ProductCapabilityId) {
       return jsonError("workspaceId is required", 400);
     }
     return requireDataPlaneRouteCapability(context, workspaceId, capability);
-  };
+  });
 }
 
 /**
@@ -167,13 +174,16 @@ export function dataPlaneSessionMinRoleAuth(minRole: MemberRole) {
 
 /**
  * Auth strategy that gates on a capability then attaches one extra route param.
+ * Carries the same capability brand as {@link dataPlaneCapabilityAuth}.
  */
 export function dataPlaneCapabilityAuthWithParam<P extends string>(
   capability: ProductCapabilityId,
   paramName: P,
 ) {
   const base = dataPlaneCapabilityAuth(capability);
-  return async (args: Pick<LoaderFunctionArgs, "params" | "context">) => {
+  return withEnforcedCapability(capability, async (
+    args: Pick<LoaderFunctionArgs, "params" | "context">,
+  ) => {
     const value = args.params[paramName];
     if (!value) {
       return jsonError(`workspaceId and ${paramName} are required`, 400);
@@ -181,12 +191,16 @@ export function dataPlaneCapabilityAuthWithParam<P extends string>(
     const gated = await base(args);
     if (gated instanceof Response) return gated;
     return Object.assign(gated, { [paramName]: value } as Record<P, string>);
-  };
+  });
 }
 
 type ListFail = { ok: false; error: string; status: number };
 
-/** Shared defineLoader shape for workspace-scoped list endpoints. */
+/**
+ * Shared defineLoader shape for workspace-scoped list endpoints. `capability`
+ * is forwarded straight into {@link dataPlaneCapabilityAuth}, so the loader it
+ * returns inherits the capability brand like any other strategy-built handler.
+ */
 export function defineDataPlaneListLoader<K extends string>(config: {
   capability: ProductCapabilityId;
   key: K;

--- a/app/lib/handler.server.ts
+++ b/app/lib/handler.server.ts
@@ -19,7 +19,62 @@
  */
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import type { z } from "zod";
+import type { ProductCapabilityId } from "@/lib/capabilities";
 import { createErrorResponse } from "@/lib/errors.server";
+
+/**
+ * Product capability linkage (issue #1242, D2).
+ *
+ * `sideEffects` is a *claim* the author writes down, which is why the gate
+ * cross-checks it against call signals. A capability declaration works the
+ * other way round: a route never states which capability it enforces, it
+ * enforces one, and the enforcement carries the id. The capability-carrying
+ * auth strategies in capability-guard.server.ts take the capability id as an
+ * argument, pass that exact value to `requireActorCapability`, and brand
+ * themselves with it here; the factory copies the brand onto the handler it
+ * builds. So `capabilityOf(loader)` returns the value the guard enforces —
+ * there is no second place to write it down and therefore nothing that can
+ * disagree with reality.
+ *
+ * `check:handlers` reads the same strategy call site statically and requires
+ * it to equal the `capability` field on the matching API_SURFACE operation
+ * (scripts/lib/capability-linkage.mjs).
+ */
+const ENFORCED_CAPABILITY = Symbol.for("callcaster.handler.enforcedCapability");
+
+type CapabilityBranded = { readonly [ENFORCED_CAPABILITY]: ProductCapabilityId };
+
+/**
+ * Brand an auth strategy with the capability it enforces. Call this only from
+ * the guard that actually performs the check, passing the same value — the
+ * brand is worthless if it is applied anywhere else.
+ */
+export function withEnforcedCapability<T extends object>(
+  capability: ProductCapabilityId,
+  strategy: T,
+): T & CapabilityBranded {
+  return Object.defineProperty(strategy, ENFORCED_CAPABILITY, {
+    value: capability,
+    enumerable: false,
+  }) as T & CapabilityBranded;
+}
+
+/** The capability an auth strategy — or a handler built from one — enforces. */
+export function capabilityOf(value: unknown): ProductCapabilityId | undefined {
+  if (typeof value !== "function" && (typeof value !== "object" || value === null)) {
+    return undefined;
+  }
+  const branded = (value as Partial<CapabilityBranded>)[ENFORCED_CAPABILITY];
+  return branded ?? undefined;
+}
+
+/** Propagate an auth strategy's capability brand onto the built handler. */
+function inheritCapability<T extends object>(handler: T, authFn: unknown): T {
+  const capability = capabilityOf(authFn);
+  return capability === undefined
+    ? handler
+    : withEnforcedCapability(capability, handler);
+}
 
 /** Declared side effects — the inventory/gate reads these. */
 export type SideEffect =
@@ -73,7 +128,7 @@ export function defineAction<A = undefined, I = undefined, R = unknown>(config: 
   sideEffects: SideEffect[];
   handler: (ctx: ActionCtx<A, I>) => Promise<R> | R;
 }) {
-  return (args: ActionFunctionArgs): Promise<R | FactoryResponse> =>
+  const handler = (args: ActionFunctionArgs): Promise<R | FactoryResponse> =>
     withGuards<ActionFunctionArgs, A, R>(args, config.auth, async (auth) => {
       let input = undefined as I;
       if (config.input) {
@@ -92,6 +147,7 @@ export function defineAction<A = undefined, I = undefined, R = unknown>(config: 
       }
       return config.handler({ ...args, auth, input });
     });
+  return inheritCapability(handler, config.auth);
 }
 
 export function defineLoader<A = undefined, R = unknown>(config: {
@@ -99,8 +155,9 @@ export function defineLoader<A = undefined, R = unknown>(config: {
   sideEffects: SideEffect[];
   handler: (ctx: LoaderCtx<A>) => Promise<R> | R;
 }) {
-  return (args: LoaderFunctionArgs): Promise<R | FactoryResponse> =>
+  const handler = (args: LoaderFunctionArgs): Promise<R | FactoryResponse> =>
     withGuards<LoaderFunctionArgs, A, R>(args, config.auth, (auth) =>
       config.handler({ ...args, auth }),
     );
+  return inheritCapability(handler, config.auth);
 }

--- a/app/routes/api+/workspaces+/$workspaceId/audience-uploads/$uploadId.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audience-uploads/$uploadId.loader.server.ts
@@ -6,8 +6,7 @@ import { dataPlaneCapabilityAuthWithParam } from "@/lib/capability-guard.server"
 import { defineLoader } from "@/lib/handler.server";
 
 export const loader = defineLoader({
-  auth: (args) =>
-    dataPlaneCapabilityAuthWithParam("campaigns.read", "uploadId")(args),
+  auth: dataPlaneCapabilityAuthWithParam("campaigns.read", "uploadId"),
   sideEffects: ["db-read"],
   handler: async ({ auth }) => {
     const result = await getAudienceUploadStatusApi(

--- a/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/audiences/$audienceId.loader.server.ts
@@ -6,8 +6,7 @@ import { dataPlaneCapabilityAuthWithParam } from "@/lib/capability-guard.server"
 import { defineLoader } from "@/lib/handler.server";
 
 export const loader = defineLoader({
-  auth: (args) =>
-    dataPlaneCapabilityAuthWithParam("campaigns.read", "audienceId")(args),
+  auth: dataPlaneCapabilityAuthWithParam("campaigns.read", "audienceId"),
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {
     const result = await getAudienceDetailApi(

--- a/app/routes/api+/workspaces+/$workspaceId/conversations/$contactNumber.loader.server.ts
+++ b/app/routes/api+/workspaces+/$workspaceId/conversations/$contactNumber.loader.server.ts
@@ -7,8 +7,7 @@ import { dataPlaneCapabilityAuthWithParam } from "@/lib/capability-guard.server"
 import { defineLoader } from "@/lib/handler.server";
 
 export const loader = defineLoader({
-  auth: (args) =>
-    dataPlaneCapabilityAuthWithParam("campaigns.read", "contactNumber")(args),
+  auth: dataPlaneCapabilityAuthWithParam("campaigns.read", "contactNumber"),
   sideEffects: ["db-read"],
   handler: async ({ auth, url }) => {
     const { workspaceId, contactNumber } = auth;

--- a/docs/handler-strictness.md
+++ b/docs/handler-strictness.md
@@ -127,6 +127,58 @@ The two credit gates are complementary layers, not duplicates:
   that can reach that mechanism (directly or via a worker job) is declared and
   inventoried.
 
+## The enforced capability IS the declaration
+
+`sideEffects` is a claim the author types, which is why the gate cross-checks it
+against call signals. Product capabilities work the other way round. A route
+never states which capability it enforces; it enforces one, and the enforcement
+carries the id:
+
+```ts
+export const loader = defineLoader({
+  auth: dataPlaneCapabilityAuth("campaigns.read"), // the argument IS the declaration
+  sideEffects: ["db-read"],
+  handler: async ({ auth }) => { /* auth.workspaceId is gated */ },
+});
+```
+
+`dataPlaneCapabilityAuth`, `dataPlaneCapabilityAuthWithParam` and
+`defineDataPlaneListLoader` pass that argument to `requireActorCapability` **and**
+brand the strategy with it (`withEnforcedCapability` in `handler.server.ts`); the
+factory copies the brand onto the handler, so `capabilityOf(loader)` returns the
+value the guard enforces rather than a second claim about it. Pass the strategy
+to `auth:` directly — `auth: (args) => dataPlaneCapabilityAuth("x")(args)` builds
+a fresh unbranded closure and severs the link.
+
+Grounding: 27 API_SURFACE operations declared a `capability` that no mechanism
+checked, and 23 of 38 data-plane modules called no capability guard at all
+(review for #1242).
+
+### The cross-check (bidirectional, ratcheted)
+
+`check:handlers` reads the same strategy call site statically
+(`scripts/lib/capability-linkage.mjs`) and compares it with the `capability`
+field on the matching API_SURFACE operation:
+
+| Direction | Rule | Escape hatch |
+| --- | --- | --- |
+| Linkage | Handler auth is a capability-carrying strategy → the operation must declare *exactly* that id (a different id and a missing id both fail) | none |
+| Linkage | Operation declares a capability enforced by a hand-rolled preamble instead | `scripts/capability-baseline.json` |
+| Truthfulness | Every declared capability must appear in the module defining the handler (no phantom declarations) | none |
+| Truthfulness | Every capability id a handler module references must be declared by at least one of the route's operations (no silently enforced capabilities) | none |
+
+The truthfulness pair does not care *how* the capability is enforced, so it
+covers the grandfathered preambles too — it caught `/api/audiences`, whose
+loader and action enforced `campaigns.read`/`campaigns.write` through
+`requireAudienceWorkspaceAccess` while the surface declared nothing.
+
+The baseline is a per-operation `{"GET /api/…": "campaigns.read"}` map, mirroring
+`scripts/effects-baseline.json`: new routes cannot join it (an unlisted unlinked
+declaration fails), and changing a grandfathered operation's capability fails
+until the baseline is regenerated with `npm run tools:capability:baseline`. It
+started at 21 operations across 19 modules and ratchets to zero as #1242 D3
+migrates the preambles onto strategies.
+
 ## Next strengthen step
 
 Type the signal table's coverage: billing helpers (`processCallStatusWebhook`,

--- a/openapi/complete-api.json
+++ b/openapi/complete-api.json
@@ -376,6 +376,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "session",
         "x-callcaster-docs-guide": "docs/api-data-management.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -438,6 +439,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "session",
         "x-callcaster-docs-guide": "docs/api-data-management.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -501,6 +503,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "session",
         "x-callcaster-docs-guide": "docs/api-data-management.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []

--- a/openapi/public-api.json
+++ b/openapi/public-api.json
@@ -372,6 +372,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "session",
         "x-callcaster-docs-guide": "docs/api-data-management.md",
+        "x-callcaster-capability": "campaigns.read",
         "security": [
           {
             "sessionCookie": []
@@ -434,6 +435,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "session",
         "x-callcaster-docs-guide": "docs/api-data-management.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []
@@ -497,6 +499,7 @@
         "x-callcaster-exposure": "sessionOnly",
         "x-callcaster-auth-class": "session",
         "x-callcaster-docs-guide": "docs/api-data-management.md",
+        "x-callcaster-capability": "campaigns.write",
         "security": [
           {
             "sessionCookie": []

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "check:dry": "node scripts/check-dry.mjs",
     "tools:dry:baseline": "node scripts/check-dry.mjs --update",
     "check:handlers": "node scripts/check-handlers.mjs",
+    "tools:capability:baseline": "node scripts/check-handlers.mjs --update-capability-baseline",
     "check:db-rpcs": "node scripts/check-db-rpcs.mjs",
     "ci:local": "npm run vendor:build && npm run typecheck && npm run lint && npm run test:node && npm run test:ui && npm run tools:routes:verify && npm run tools:api:surface:check && npm run check:route-server-leaks && npm run check:route-authz && npm run check:route-membership && npm run check:workspace-projection && npm run check:twilio-webhooks && npm run check:request-body-consumption && npm run check:middleware && npm run check:credit-writes && npm run check:dual-auth && npm run check:effects && npm run check:type-safety && npm run check:dry && npm run check:handlers && npm run check:db-rpcs && npm run db:ledger:check && npm run db:bootstrap:check && npm run db:orphans:check && npm run tools:check-file-size && npm run build && npm run check:client-bundle && npm run ci:codegen:verify",
     "test:e2e": "playwright test -c e2e/playwright.config.ts",

--- a/scripts/capability-baseline.json
+++ b/scripts/capability-baseline.json
@@ -1,0 +1,23 @@
+{
+  "DELETE /api/audiences": "campaigns.write",
+  "DELETE /api/contacts/:contactId": "campaigns.write",
+  "GET /api/audiences": "campaigns.read",
+  "GET /api/campaigns/:campaignId": "campaigns.read",
+  "GET /api/campaigns/:campaignId/queue": "campaigns.read",
+  "GET /api/contacts/:contactId": "campaigns.read",
+  "GET /api/scripts/:scriptId": "campaigns.read",
+  "GET /api/surveys/:surveyId": "campaigns.read",
+  "GET /api/surveys/:surveyId/responses": "campaigns.read",
+  "GET /api/workspaces/:workspaceId": "campaigns.read",
+  "GET /api/workspaces/:workspaceId/audiences/:audienceId/uploads": "campaigns.read",
+  "GET /api/workspaces/:workspaceId/audit-events": "audit.read",
+  "PATCH /api/audiences": "campaigns.write",
+  "PATCH /api/campaigns/:campaignId/queue": "campaigns.write",
+  "POST /api/campaigns/:campaignId": "campaigns.write",
+  "POST /api/campaigns/create-with-script": "campaigns.write",
+  "POST /api/chat_sms": "messages.send",
+  "POST /api/sms": "campaigns.dispatch",
+  "POST /api/workspaces/:workspaceId/calls/:callSid/disconnect": "calls.control",
+  "POST /api/workspaces/:workspaceId/campaigns/:campaignId/dialer/start": "calls.start",
+  "POST /api/workspaces/:workspaceId/members": "members.invite"
+}

--- a/scripts/check-handlers.mjs
+++ b/scripts/check-handlers.mjs
@@ -33,16 +33,28 @@
  * reading balances. The gate also emits docs/credit-handler-inventory.md;
  * ci:local's final `git diff --exit-code` catches a stale inventory.
  *
+ * Capability facet (BIDIRECTIONAL, ratcheted): a `capability` on an
+ * API_SURFACE operation must be the capability the route actually enforces.
+ * Unlike `sideEffects` there is no separate declaration to compare against —
+ * the capability-carrying auth strategies brand themselves with the id they
+ * enforce, so the strategy call site IS the declaration. See
+ * scripts/lib/capability-linkage.mjs for the two directions and
+ * scripts/capability-baseline.json for the hand-rolled preambles that still
+ * enforce a capability without that link (ratcheting to zero via #1242 D3).
+ *
  * Usage:
  *   node scripts/check-handlers.mjs
+ *   node scripts/check-handlers.mjs --update-capability-baseline
  */
 import fs from "node:fs";
 import path from "node:path";
+import { analyzeCapabilityLinkage } from "./lib/capability-linkage.mjs";
 
 const ROOT = process.cwd();
 const ROUTES_DIR = path.join(ROOT, "app", "routes");
 const SKIP_FILE = [/\.test\.[jt]sx?$/, /\.spec\.[jt]sx?$/];
 const CREDIT_INVENTORY_PATH = path.join(ROOT, "docs", "credit-handler-inventory.md");
+const CAPABILITY_BASELINE_PATH = path.join(ROOT, "scripts", "capability-baseline.json");
 
 function walk(dir, out = []) {
   if (!fs.existsSync(dir)) return out;
@@ -231,6 +243,31 @@ function writeCreditInventory(rows) {
   fs.writeFileSync(CREDIT_INVENTORY_PATH, lines.join("\n"));
 }
 
+/**
+ * Capability cross-check (self-contained section; all logic lives in
+ * scripts/lib/capability-linkage.mjs so this file stays a thin caller).
+ * Returns the violation lines to fold into the shared report.
+ */
+function capabilityViolations() {
+  const baseline = fs.existsSync(CAPABILITY_BASELINE_PATH)
+    ? JSON.parse(fs.readFileSync(CAPABILITY_BASELINE_PATH, "utf8"))
+    : {};
+  const result = analyzeCapabilityLinkage({ root: ROOT, baseline });
+
+  if (process.argv.includes("--update-capability-baseline")) {
+    fs.writeFileSync(
+      CAPABILITY_BASELINE_PATH,
+      `${JSON.stringify(result.suggestedBaseline, null, 2)}\n`,
+    );
+    console.log(
+      `Capability baseline written: ${Object.keys(result.suggestedBaseline).length} grandfathered operation(s).`,
+    );
+    process.exit(0);
+  }
+
+  return { lines: result.violations.map((v) => `  ${v}`), stats: result.stats };
+}
+
 const violations = [];
 const creditRows = [];
 for (const file of walk(ROUTES_DIR).sort()) {
@@ -266,6 +303,9 @@ for (const file of walk(ROUTES_DIR).sort()) {
 
 writeCreditInventory(creditRows);
 
+const capability = capabilityViolations();
+violations.push(...capability.lines);
+
 if (violations.length) {
   console.error("Handler strictness gate FAILED:\n");
   console.error(violations.join("\n"));
@@ -275,10 +315,17 @@ if (violations.length) {
       "docs/handler-strictness.md). The factory migration is complete; there is no\n" +
       "grandfather baseline. The credit facet is bidirectional: routes matching a\n" +
       "credit-write signal must declare \"credit\"; routes declaring \"credit\" must\n" +
-      "match a signal.",
+      "match a signal. The capability facet is bidirectional too: an API_SURFACE\n" +
+      "`capability` must equal the id the route's auth strategy enforces. If you\n" +
+      "removed a grandfathered preamble, run\n" +
+      "`node scripts/check-handlers.mjs --update-capability-baseline` to ratchet\n" +
+      "scripts/capability-baseline.json down.",
   );
   process.exit(1);
 }
 console.log(
   `Handler gate passed: every route action/loader goes through the handler factory, side-effect declarations match call signals, and ${creditRows.length} credit-ledger routes are inventoried.`,
+);
+console.log(
+  `Capability cross-check passed: ${capability.stats.declared} declared capabilities across ${capability.stats.operations} operations — ${capability.stats.linked} linked to a capability-carrying auth strategy, ${capability.stats.grandfathered} grandfathered preambles (ratcheting to 0).`,
 );

--- a/scripts/check-handlers.mjs
+++ b/scripts/check-handlers.mjs
@@ -315,12 +315,17 @@ if (violations.length) {
       "docs/handler-strictness.md). The factory migration is complete; there is no\n" +
       "grandfather baseline. The credit facet is bidirectional: routes matching a\n" +
       "credit-write signal must declare \"credit\"; routes declaring \"credit\" must\n" +
-      "match a signal. The capability facet is bidirectional too: an API_SURFACE\n" +
-      "`capability` must equal the id the route's auth strategy enforces. If you\n" +
-      "removed a grandfathered preamble, run\n" +
-      "`node scripts/check-handlers.mjs --update-capability-baseline` to ratchet\n" +
-      "scripts/capability-baseline.json down.",
+      "match a signal.",
   );
+  if (capability.lines.length > 0) {
+    console.error(
+      "\nThe capability facet is bidirectional too: an API_SURFACE `capability` must\n" +
+        "equal the id the route's auth strategy enforces, and nothing may enforce a\n" +
+        "capability the surface does not declare. If you migrated a grandfathered\n" +
+        "preamble onto a strategy, run `npm run tools:capability:baseline` to ratchet\n" +
+        "scripts/capability-baseline.json down.",
+    );
+  }
   process.exit(1);
 }
 console.log(

--- a/scripts/lib/capability-linkage.mjs
+++ b/scripts/lib/capability-linkage.mjs
@@ -1,0 +1,304 @@
+/**
+ * Capability linkage analysis — the data behind `check:handlers`' capability
+ * cross-check (issue #1242, D2).
+ *
+ * A route does not get to *say* which product capability it enforces. The
+ * capability-carrying auth strategies in app/lib/capability-guard.server.ts
+ * (`dataPlaneCapabilityAuth`, `dataPlaneCapabilityAuthWithParam`,
+ * `defineDataPlaneListLoader`) take the capability id as their argument and
+ * hand that same value to `requireActorCapability`, so the strategy call site
+ * IS the enforcement. This module reads that call site and cross-checks it
+ * against the `capability` field on the matching API_SURFACE operation.
+ *
+ * Two independent checks, mirroring the bidirectional credit facet:
+ *
+ *  1. LINKAGE (per operation, ratcheted via a baseline)
+ *     - handler auth is a capability-carrying strategy  → the operation's
+ *       declared capability must be exactly the strategy's argument, in both
+ *       directions (a wrong id and a missing id both fail).
+ *     - operation declares a capability but the handler enforces it by hand
+ *       (a preamble inside the auth function or the handler body) → the
+ *       declaration is not mechanically linked to enforcement, so it needs a
+ *       BASELINE entry. New routes cannot join the baseline; D3's preamble
+ *       migration ratchets it toward zero.
+ *
+ *  2. TRUTHFULNESS (per route, never baselined)
+ *     - every declared capability must actually appear in the module that
+ *       defines the handler (no phantom declarations), and
+ *     - every capability id the module references must be declared by at least
+ *       one of the route's operations (no silently enforced capabilities).
+ *     This dimension does not care HOW the capability is enforced, so it holds
+ *     for the grandfathered preambles too.
+ *
+ * Pure + parameterised on `root` so the fixture suite can point it at a tiny
+ * synthetic tree; see test/capability-linkage.test.ts.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+const SURFACE_FILE = /^api-surface-.+\.ts$/;
+/** Matches the seed(...) / platformSeed(...) entry blocks in the surface files. */
+const SEED_BLOCK = /[a-zA-Z]*[Ss]eed\(\{[\s\S]*?\}\)\s*[,;]/g;
+
+/** Auth-strategy constructors whose first argument IS the enforced capability. */
+const LINKED_STRATEGIES = "dataPlaneCapabilityAuthWithParam|dataPlaneCapabilityAuth";
+
+/** Read the product capability ids so the truthfulness scan can't guess. */
+export function readCapabilityIds(root) {
+  const src = readFileSync(join(root, "app", "lib", "capabilities.ts"), "utf8");
+  const block = src.match(/PRODUCT_CAPABILITIES\s*=\s*\{([\s\S]*?)\n\}/);
+  if (!block) throw new Error("capabilities.ts: PRODUCT_CAPABILITIES not found");
+  return new Set([...block[1].matchAll(/"([a-z][\w.]*)":/g)].map((m) => m[1]));
+}
+
+/** Parse every api-surface-*.ts entry into { path, routeModule, operations }. */
+export function readSurfaceEntries(root) {
+  const dir = join(root, "app", "lib");
+  const entries = [];
+  for (const file of readdirSync(dir).filter((f) => SURFACE_FILE.test(f)).sort()) {
+    const source = readFileSync(join(dir, file), "utf8");
+    for (const block of source.match(SEED_BLOCK) ?? []) {
+      const routeModule = block.match(/routeModule:\s*\n?\s*"([^"]+)"/)?.[1];
+      const path = block.match(/path:\s*"([^"]+)"/)?.[1];
+      if (!routeModule || !path) continue;
+      const operations = [];
+      const opsBlock = block.match(/operations:\s*\[([\s\S]*)\]/)?.[1];
+      for (const op of opsBlock?.matchAll(/\{([\s\S]*?)\}/g) ?? []) {
+        const method = op[1].match(/method:\s*"([^"]+)"/)?.[1];
+        const handler = op[1].match(/handler:\s*"(loader|action)"/)?.[1];
+        if (!method || !handler) continue;
+        operations.push({
+          method,
+          handler,
+          declared: op[1].match(/capability:\s*"([^"]+)"/)?.[1],
+        });
+      }
+      entries.push({ surfaceFile: file, path, routeModule, operations });
+    }
+  }
+  return entries;
+}
+
+function readIfExists(file) {
+  return existsSync(file) ? readFileSync(file, "utf8") : null;
+}
+
+function resolveImportSpec(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec);
+  for (const ext of [".ts", ".tsx", ".server.ts", "/index.ts"]) {
+    if (existsSync(base + ext)) return base + ext;
+  }
+  return existsSync(base) ? base : null;
+}
+
+/**
+ * Follow `export { loader } from "./x"` re-exports to the module that actually
+ * defines the handler. Route modules are thin barrels; enforcement lives in the
+ * sibling `.loader.server.ts` / `.action.server.ts`.
+ */
+export function resolveHandlerModule(absRouteModule, name, depth = 0) {
+  const src = readIfExists(absRouteModule);
+  if (src === null || depth > 4) return null;
+  const defines = new RegExp(
+    `export\\s+(?:const|let|async\\s+function|function)\\s+${name}\\b`,
+  );
+  if (defines.test(src)) return absRouteModule;
+  for (const m of src.matchAll(/export\s*\{([^}]*)\}\s*from\s*"([^"]+)"/g)) {
+    const exported = m[1]
+      .split(",")
+      .map((s) => s.trim().split(/\s+as\s+/).pop()?.trim())
+      .filter(Boolean);
+    if (!exported.includes(name)) continue;
+    const target = resolveImportSpec(absRouteModule, m[2]);
+    if (target) return resolveHandlerModule(target, name, depth + 1) ?? target;
+  }
+  return null;
+}
+
+/** Source slice from `export const <name> =` up to the next top-level export. */
+function exportRegion(src, name) {
+  const m = src.match(new RegExp(`export\\s+const\\s+${name}\\s*=`));
+  if (!m) return null;
+  const from = src.slice(m.index);
+  const next = from.slice(1).search(/\nexport\s/);
+  return next === -1 ? from : from.slice(0, next + 1);
+}
+
+/**
+ * The capability a handler enforces through a capability-carrying strategy, or
+ * null when it is enforced by hand (or not at all).
+ *
+ * Three accepted shapes — all of them place the capability id at the strategy
+ * call site, which is the value the guard passes to `requireActorCapability`:
+ *   auth: dataPlaneCapabilityAuth("campaigns.read")
+ *   auth: sharedStrategy            // const sharedStrategy = dataPlane...(...)
+ *   export const loader = defineDataPlaneListLoader({ capability: "..." })
+ */
+export function linkedCapability(src, name) {
+  const region = exportRegion(src, name);
+  if (!region) return null;
+  if (/=\s*defineDataPlaneListLoader\s*\(/.test(region)) {
+    return region.match(/capability:\s*"([^"]+)"/)?.[1] ?? null;
+  }
+  const direct = region.match(
+    new RegExp(`auth:\\s*(?:${LINKED_STRATEGIES})\\(\\s*"([^"]+)"`),
+  );
+  if (direct) return direct[1];
+  const alias = region.match(/auth:\s*([A-Za-z_$][\w$]*)\s*,/)?.[1];
+  if (alias) {
+    const decl = src.match(
+      new RegExp(
+        `(?:const|let)\\s+${alias}\\s*=\\s*(?:${LINKED_STRATEGIES})\\(\\s*"([^"]+)"`,
+      ),
+    );
+    if (decl) return decl[1];
+  }
+  return null;
+}
+
+/**
+ * Every product capability id the module mentions. Deliberately blunt: any
+ * occurrence of a real capability id in a route module is either an
+ * enforcement argument or a lie, and both are worth surfacing.
+ */
+export function referencedCapabilities(src, capabilityIds) {
+  const found = new Set();
+  for (const m of src.matchAll(/"([a-z][\w.]*)"/g)) {
+    if (capabilityIds.has(m[1])) found.add(m[1]);
+  }
+  return found;
+}
+
+export function operationKey(method, path) {
+  return `${method} ${path}`;
+}
+
+/**
+ * @param {{ root: string, baseline?: Record<string, string> }} args
+ * @returns {{
+ *   violations: string[],
+ *   linked: Array<{ key: string, capability: string, module: string }>,
+ *   unlinkedDeclared: Array<{ key: string, declared: string, module: string }>,
+ *   suggestedBaseline: Record<string, string>,
+ *   staleBaselineKeys: string[],
+ *   stats: { operations: number, declared: number, linked: number, grandfathered: number },
+ * }}
+ */
+export function analyzeCapabilityLinkage({ root, baseline = {} }) {
+  const capabilityIds = readCapabilityIds(root);
+  const entries = readSurfaceEntries(root);
+  const violations = [];
+  const linked = [];
+  const unlinkedDeclared = [];
+  const suggestedBaseline = {};
+  const usedBaselineKeys = new Set();
+  let operations = 0;
+  let declaredCount = 0;
+
+  for (const entry of entries) {
+    const modules = new Map();
+    const declaredForRoute = new Set();
+
+    for (const op of entry.operations) {
+      operations += 1;
+      const key = operationKey(op.method, entry.path);
+      if (op.declared) {
+        declaredCount += 1;
+        declaredForRoute.add(op.declared);
+      }
+
+      if (!modules.has(op.handler)) {
+        modules.set(
+          op.handler,
+          resolveHandlerModule(join(root, entry.routeModule), op.handler),
+        );
+      }
+      const module = modules.get(op.handler);
+      if (!module) {
+        if (op.declared) {
+          violations.push(
+            `${key}: declares "${op.declared}" but no module defining \`${op.handler}\` could be resolved from ${entry.routeModule}`,
+          );
+        }
+        continue;
+      }
+      const rel = relative(root, module);
+      const enforced = linkedCapability(readFileSync(module, "utf8"), op.handler);
+
+      if (enforced) {
+        linked.push({ key, capability: enforced, module: rel });
+        if (op.declared !== enforced) {
+          violations.push(
+            `${key}: auth strategy enforces "${enforced}" but API_SURFACE declares ` +
+              `${op.declared ? `"${op.declared}"` : "no capability"} (${rel})`,
+          );
+        }
+        continue;
+      }
+
+      if (op.declared) {
+        unlinkedDeclared.push({ key, declared: op.declared, module: rel });
+        suggestedBaseline[key] = op.declared;
+        if (baseline[key] === op.declared) {
+          usedBaselineKeys.add(key);
+        } else {
+          violations.push(
+            baseline[key]
+              ? `${key}: declares "${op.declared}" but the capability baseline grandfathers "${baseline[key]}" — re-run the baseline tool after an intentional change`
+              : `${key}: declares "${op.declared}" but nothing links the declaration to enforcement — use a capability-carrying auth strategy (dataPlaneCapabilityAuth) in ${rel}`,
+          );
+        }
+      }
+    }
+
+    // Truthfulness: compare declarations against every capability the handler
+    // modules reference, however they enforce it. Never baselined.
+    const referenced = new Set();
+    for (const module of modules.values()) {
+      if (!module) continue;
+      for (const cap of referencedCapabilities(
+        readFileSync(module, "utf8"),
+        capabilityIds,
+      )) {
+        referenced.add(cap);
+      }
+    }
+    for (const declared of declaredForRoute) {
+      if (!referenced.has(declared)) {
+        violations.push(
+          `${entry.path}: declares "${declared}" but no handler module for this route references it`,
+        );
+      }
+    }
+    for (const cap of referenced) {
+      if (!declaredForRoute.has(cap)) {
+        violations.push(
+          `${entry.path}: handler enforces "${cap}" but no operation in API_SURFACE declares it (${entry.surfaceFile})`,
+        );
+      }
+    }
+  }
+
+  const staleBaselineKeys = Object.keys(baseline)
+    .filter((key) => !usedBaselineKeys.has(key))
+    .sort();
+  for (const key of staleBaselineKeys) {
+    violations.push(
+      `${key}: capability baseline entry no longer applies — remove it (the ratchet only goes down)`,
+    );
+  }
+
+  return {
+    violations,
+    linked,
+    unlinkedDeclared,
+    suggestedBaseline: Object.fromEntries(Object.entries(suggestedBaseline).sort()),
+    staleBaselineKeys,
+    stats: {
+      operations,
+      declared: declaredCount,
+      linked: linked.length,
+      grandfathered: unlinkedDeclared.length,
+    },
+  };
+}

--- a/test/capability-linkage.test.ts
+++ b/test/capability-linkage.test.ts
@@ -1,0 +1,364 @@
+/**
+ * D2 (issue #1242) — the capability cross-check in `check:handlers`.
+ *
+ * `scripts/lib/capability-linkage.mjs` is a pure `analyze()` over a repo root,
+ * so every case here builds a throwaway tree in a temp dir and calls it
+ * directly — no child process, no snapshotting of the real surface. The last
+ * describe block runs it against the real tree with the committed baseline,
+ * which is the assertion that this PR did not ship a red gate.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- plain .mjs gate helper, deliberately untyped (see tsconfig)
+import { analyzeCapabilityLinkage } from "../scripts/lib/capability-linkage.mjs";
+
+const CAPABILITIES_TS = `export const PRODUCT_CAPABILITIES = {
+  "campaigns.read": "Read",
+  "campaigns.write": "Write",
+  "audit.read": "Audit",
+} as const;
+`;
+
+type Fixture = {
+  /** Contents of the single api-surface-fixture.ts file. */
+  surface: string;
+  /** repo-relative path -> file contents. */
+  files: Record<string, string>;
+};
+
+let root: string;
+
+function build({ surface, files }: Fixture) {
+  writeFile("app/lib/capabilities.ts", CAPABILITIES_TS);
+  writeFile("app/lib/api-surface-fixture.ts", surface);
+  for (const [rel, contents] of Object.entries(files)) writeFile(rel, contents);
+}
+
+function writeFile(rel: string, contents: string) {
+  const abs = join(root, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, contents);
+}
+
+function analyze(baseline: Record<string, string> = {}) {
+  return analyzeCapabilityLinkage({ root, baseline }) as {
+    violations: string[];
+    linked: Array<{ key: string; capability: string }>;
+    unlinkedDeclared: Array<{ key: string; declared: string }>;
+    suggestedBaseline: Record<string, string>;
+    stats: Record<string, number>;
+  };
+}
+
+/** One entry, one GET loader operation, at /api/thing. */
+function surfaceWith(capability: string | null, routeModule = "app/routes/api+/thing.route.tsx") {
+  return `import { seed } from "@/lib/api-surface-seeds";
+export const FIXTURE = [
+  seed({
+    path: "/api/thing",
+    routeModule: "${routeModule}",
+    authClass: "session",
+    ownerArea: "campaigns",
+    exposure: "sessionOnly",
+    docsGuide: "docs/x.md",
+    operations: [
+      {
+        method: "GET",
+        handler: "loader",
+        bodyType: "query",${capability ? `\n        capability: "${capability}",` : ""}
+      },
+    ],
+  }),
+];
+`;
+}
+
+const LINKED_LOADER = (capability: string) => `import { dataPlaneCapabilityAuth } from "@/lib/capability-guard.server";
+import { defineLoader } from "@/lib/handler.server";
+
+export const loader = defineLoader({
+  auth: dataPlaneCapabilityAuth("${capability}"),
+  sideEffects: ["db-read"],
+  handler: async ({ auth }) => auth,
+});
+`;
+
+const PREAMBLE_LOADER = (capability: string) => `import { requireDataPlaneCapability } from "@/lib/capability-guard.server";
+import { getDataPlaneRouteContext } from "@/lib/data-plane-route.server";
+import { defineLoader } from "@/lib/handler.server";
+
+export const loader = defineLoader({
+  auth: async ({ params, context }) => {
+    const auth = getDataPlaneRouteContext(context, params.workspaceId);
+    const gated = await requireDataPlaneCapability(auth, "${capability}");
+    if (gated instanceof Response) return gated;
+    return auth;
+  },
+  sideEffects: ["db-read"],
+  handler: async ({ auth }) => auth,
+});
+`;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "capability-linkage-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("linkage: strategy call site vs API_SURFACE", () => {
+  test("a matching declaration passes and is reported as linked", () => {
+    build({
+      surface: surfaceWith("campaigns.read"),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": LINKED_LOADER("campaigns.read"),
+      },
+    });
+
+    const result = analyze();
+    expect(result.violations).toEqual([]);
+    expect(result.linked).toEqual([
+      expect.objectContaining({ key: "GET /api/thing", capability: "campaigns.read" }),
+    ]);
+  });
+
+  test("declared X while the strategy enforces Y fails, and no baseline can hide it", () => {
+    build({
+      surface: surfaceWith("campaigns.write"),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": LINKED_LOADER("campaigns.read"),
+      },
+    });
+
+    const linkage = analyze().violations.filter((v) => v.startsWith("GET /api/thing"));
+    expect(linkage).toHaveLength(1);
+    expect(linkage[0]).toContain('enforces "campaigns.read"');
+    expect(linkage[0]).toContain('declares "campaigns.write"');
+
+    // The baseline only grandfathers *unlinked* declarations — trying to
+    // silence a strategy mismatch with one keeps the violation and adds a
+    // stale-entry complaint on top.
+    const withBaseline = analyze({ "GET /api/thing": "campaigns.write" }).violations;
+    expect(withBaseline).toEqual(expect.arrayContaining(linkage));
+    expect(withBaseline.join("\n")).toContain("no longer applies");
+  });
+
+  test("a strategy with no declaration at all fails", () => {
+    build({
+      surface: surfaceWith(null),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": LINKED_LOADER("campaigns.read"),
+      },
+    });
+
+    expect(analyze().violations.join("\n")).toContain("declares no capability");
+  });
+
+  test("defineDataPlaneListLoader carries the capability too", () => {
+    build({
+      surface: surfaceWith("campaigns.read"),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": `import { defineDataPlaneListLoader } from "@/lib/capability-guard.server";
+
+export const loader = defineDataPlaneListLoader({
+  capability: "campaigns.read",
+  key: "things",
+  list: async () => ({ ok: true as const, things: [] }),
+});
+`,
+      },
+    });
+
+    expect(analyze().violations).toEqual([]);
+    expect(analyze().stats.linked).toBe(1);
+  });
+
+  test("a module-scope alias to a strategy still counts as linked", () => {
+    build({
+      surface: surfaceWith("campaigns.read"),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": `import { dataPlaneCapabilityAuth } from "@/lib/capability-guard.server";
+import { defineLoader } from "@/lib/handler.server";
+
+const readGate = dataPlaneCapabilityAuth("campaigns.read");
+
+export const loader = defineLoader({
+  auth: readGate,
+  sideEffects: ["db-read"],
+  handler: async ({ auth }) => auth,
+});
+`,
+      },
+    });
+
+    expect(analyze().violations).toEqual([]);
+  });
+});
+
+describe("linkage: the baseline is a ratchet", () => {
+  const preambleFixture: Fixture = {
+    surface: surfaceWith("campaigns.read"),
+    files: {
+      "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+      "app/routes/api+/thing.loader.server.ts": PREAMBLE_LOADER("campaigns.read"),
+    },
+  };
+
+  test("a hand-rolled preamble fails without a baseline entry", () => {
+    build(preambleFixture);
+    const violations = analyze().violations;
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("nothing links the declaration to enforcement");
+  });
+
+  test("and passes with one", () => {
+    build(preambleFixture);
+    expect(analyze({ "GET /api/thing": "campaigns.read" }).violations).toEqual([]);
+    expect(analyze().suggestedBaseline).toEqual({ "GET /api/thing": "campaigns.read" });
+  });
+
+  test("changing a grandfathered capability fails until the baseline is regenerated", () => {
+    build({
+      ...preambleFixture,
+      surface: surfaceWith("campaigns.write"),
+      files: {
+        ...preambleFixture.files,
+        "app/routes/api+/thing.loader.server.ts": PREAMBLE_LOADER("campaigns.write"),
+      },
+    });
+
+    const violations = analyze({ "GET /api/thing": "campaigns.read" }).violations;
+    expect(violations.join("\n")).toContain("baseline grandfathers");
+  });
+
+  test("a baseline entry that no longer applies fails — the ratchet only goes down", () => {
+    build({
+      surface: surfaceWith("campaigns.read"),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": LINKED_LOADER("campaigns.read"),
+      },
+    });
+
+    const violations = analyze({ "GET /api/thing": "campaigns.read" }).violations;
+    expect(violations.join("\n")).toContain("no longer applies");
+  });
+});
+
+describe("truthfulness: never baselined, covers preambles too", () => {
+  test("a capability enforced but declared nowhere fails", () => {
+    build({
+      surface: surfaceWith(null),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": PREAMBLE_LOADER("audit.read"),
+      },
+    });
+
+    const violations = analyze({ "GET /api/thing": "audit.read" }).violations;
+    expect(violations.join("\n")).toContain('handler enforces "audit.read"');
+  });
+
+  test("a declared capability the handler module never references fails", () => {
+    build({
+      surface: surfaceWith("audit.read"),
+      files: {
+        "app/routes/api+/thing.route.tsx": `export { loader } from "./thing.loader.server";\n`,
+        "app/routes/api+/thing.loader.server.ts": `import { defineLoader } from "@/lib/handler.server";
+
+export const loader = defineLoader({
+  sideEffects: ["db-read"],
+  handler: async () => null,
+});
+`,
+      },
+    });
+
+    const violations = analyze({ "GET /api/thing": "audit.read" }).violations;
+    expect(violations.join("\n")).toContain("no handler module for this route references it");
+  });
+
+  test("an unresolvable handler module is reported, not silently skipped", () => {
+    build({
+      surface: surfaceWith("campaigns.read", "app/routes/api+/missing.route.tsx"),
+      files: {},
+    });
+
+    expect(analyze().violations.join("\n")).toContain(
+      "no module defining `loader` could be resolved",
+    );
+  });
+});
+
+describe("the real tree", () => {
+  test("passes with the committed baseline", async () => {
+    const { readFileSync } = await import("node:fs");
+    const repoRoot = join(import.meta.dirname, "..");
+    const baseline = JSON.parse(
+      readFileSync(join(repoRoot, "scripts", "capability-baseline.json"), "utf8"),
+    );
+    const result = analyzeCapabilityLinkage({ root: repoRoot, baseline }) as {
+      violations: string[];
+      stats: Record<string, number>;
+    };
+
+    expect(result.violations).toEqual([]);
+    expect(result.stats.linked).toBeGreaterThan(0);
+  });
+});
+
+describe("runtime: the brand the gate reads statically", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  test("a capability strategy brands itself and the factory propagates it", async () => {
+    vi.doMock("@/server/db", () => ({ db: {}, directPool: {} }));
+    vi.doMock("@/lib/database/workspace.server", () => ({
+      getUserRole: vi.fn(),
+      requireWorkspaceAccess: vi.fn(),
+    }));
+
+    const { capabilityOf, defineLoader } = await import("@/lib/handler.server");
+    const { dataPlaneCapabilityAuth, dataPlaneCapabilityAuthWithParam } = await import(
+      "@/lib/capability-guard.server"
+    );
+
+    expect(capabilityOf(dataPlaneCapabilityAuth("campaigns.read"))).toBe("campaigns.read");
+    expect(
+      capabilityOf(dataPlaneCapabilityAuthWithParam("campaigns.write", "audienceId")),
+    ).toBe("campaigns.write");
+
+    const loader = defineLoader({
+      auth: dataPlaneCapabilityAuth("audit.read"),
+      sideEffects: ["db-read"],
+      handler: async ({ auth }) => auth,
+    });
+    expect(capabilityOf(loader)).toBe("audit.read");
+  });
+
+  test("a handler with no capability strategy carries no brand", async () => {
+    const { capabilityOf, defineLoader } = await import("@/lib/handler.server");
+
+    expect(
+      capabilityOf(
+        defineLoader({
+          auth: () => ({ workspaceId: "w" }),
+          sideEffects: ["db-read"],
+          handler: async ({ auth }) => auth,
+        }),
+      ),
+    ).toBeUndefined();
+    expect(capabilityOf(undefined)).toBeUndefined();
+    expect(capabilityOf("campaigns.read")).toBeUndefined();
+  });
+});

--- a/test/capability-linkage.test.ts
+++ b/test/capability-linkage.test.ts
@@ -11,8 +11,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore -- plain .mjs gate helper, deliberately untyped (see tsconfig)
+// Plain .mjs gate helper — tsconfig excludes *.test.ts, so no shim is needed.
 import { analyzeCapabilityLinkage } from "../scripts/lib/capability-linkage.mjs";
 
 const CAPABILITIES_TS = `export const PRODUCT_CAPABILITIES = {


### PR DESCRIPTION
Part 2 of #1242 (D2), stacked on #1248.

> Base is `fix/1242-authclass-drift`, not `dev` — review the [5 commits after D1](https://github.com/chester-hill-solutions/callcaster/compare/fix/1242-authclass-drift...refactor/1242-capability-crosscheck).

The review found `capability` declared on 27 API_SURFACE operations and enforced by nothing. This makes the declaration mechanical: a route can no longer *state* a capability it does not enforce, and `check:handlers` fails when the two disagree.

## The design: the enforced value IS the declaration

The brief offered two shapes — a `capability:` field on the handler factory next to `sideEffects`, or deriving it from the auth strategy. I took the second, because the first is the bug we are fixing.

`sideEffects` is a claim the author types, which is why the gate has to cross-check it against call signals; a claim and a reality are two things and they drift. A `capability:` field on `defineLoader` would be the same shape: `capability: "campaigns.read"` next to `auth: dataPlaneCapabilityAuth("campaigns.write")` compiles fine and lies.

So there is no field. The capability-carrying strategies take the id as an argument, hand *that value* to `requireActorCapability`, and brand themselves with it:

```ts
export function dataPlaneCapabilityAuth(capability: ProductCapabilityId) {
  return withEnforcedCapability(capability, async ({ params, context }) => {
    …
    return requireDataPlaneRouteCapability(context, workspaceId, capability);
  });
}
```

`defineAction`/`defineLoader` copy the brand onto the handler they build, so `capabilityOf(loader)` returns the value the guard enforces rather than a claim about it. **There is no second place to write it down, so there is nothing that can disagree.** The gate reads the same call site statically; the runtime brand is what proves the static read corresponds to something real (`test/capability-linkage.test.ts`, last describe).

Three loaders reached the strategy through an `(args) => strategy(...)(args)` wrapper, which rebuilds an unbranded closure per request. Passing the strategy directly is equivalent and keeps the link — that alone moved 6 linked operations to 9.

## The gate

New pure analyzer `scripts/lib/capability-linkage.mjs`; `check-handlers.mjs` gains one function and two call lines. Two dimensions, in the existing `FACET_SIGNALS` spirit:

| Dimension | Rule | Baseline? |
| --- | --- | --- |
| Linkage | handler auth is a capability-carrying strategy → the operation must declare *exactly* that id (wrong id **and** missing id both fail) | no |
| Linkage | operation declares a capability enforced by a hand-rolled preamble instead | **yes** |
| Truthfulness | every declared capability must appear in the module defining the handler | no |
| Truthfulness | every capability id a handler module references must be declared by some operation of that route | no |

The truthfulness pair does not care *how* a capability is enforced, so it covers the 24 preambles too — that is what makes this useful before D3 lands. It found real drift: `/api/audiences` GET/PATCH/DELETE enforce `campaigns.read`/`campaigns.write` through `requireAudienceWorkspaceAccess` while the surface declared nothing. Declarations added (the only API_SURFACE content change; `x-callcaster-capability` on 3 operations in the regenerated specs).

**Why a baseline rather than accepting preambles as proof.** A preamble's capability call can be conditional — `members.action.server.ts` enforces `members.invite` inside `if (request.method === "POST")`, and `$workspaceId.action.server.ts` gates its loader but not its action. Text-scanning a handler body and calling the result "enforced" would reintroduce exactly the falsehood this PR removes. So only the strategy forms count as proof, and the rest are grandfathered honestly.

`scripts/capability-baseline.json` — **21 operations across 19 modules**, keyed `"GET /api/…": "campaigns.read"`, mirroring `effects-baseline.json`. New routes cannot join it (an unlisted unlinked declaration fails), changing a grandfathered capability fails until regenerated, and a stale key fails so the ratchet only goes down. `npm run tools:capability:baseline` regenerates. D3 empties it.

## Deleted

- `createDataPlaneRequireCapability` — no call sites; wrapped the package factory around a session-only actor resolver, duplicating `requireDataPlaneCapability` minus API-key scopes, and its own doc comment pointed callers at the other one. The `createRequireCapability` import went with it.
- `resolveDualAuthAuthorizationActor` and `resolveDataPlaneAuthorizationActor` un-exported (not deleted) — called only by the `require*` wrappers in the same module, which own the 403/404 shapes; exporting them invited a caller to resolve an actor and forget to check it.

Nine exports → seven. No further consolidation: the remaining ones are distinct entry points, and D3 will shrink usage anyway.

## Fixtures

`test/capability-linkage.test.ts`, 15 cases. `analyzeCapabilityLinkage()` is a pure function of a repo root, so each case builds a throwaway tree in a temp dir and calls it directly — **no child process**. The required one: a loader whose strategy enforces `campaigns.read` while the surface declares `campaigns.write` fails, and adding a baseline entry for it does not help (it keeps the violation and adds a stale-entry complaint). The real tree with the committed baseline is asserted clean, so a red gate cannot ship past the suite.

## Not in scope

The 24 hand-rolled preambles (D3) and a full surface regeneration (D4).

## Gates

`typecheck` · `lint` · `test:node` (351 files, 2581 passed) · `check:handlers` · `check:route-authz` · `check:middleware` · `check:dual-auth` · `check:dry` · `tools:api:surface:check` · `ci:codegen:verify` — all green, no unrelated failures.

```
Capability cross-check passed: 30 declared capabilities across 194 operations —
9 linked to a capability-carrying auth strategy, 21 grandfathered preambles (ratcheting to 0).
```

Conflict note: PR #1249 also edits `check-handlers.mjs`. This addition is one function plus two call lines, and the capability hint prints from its own guarded block rather than the shared failure text, so the overlap is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
