### PR TITLE
refactor(queue): collapse dequeue call sites behind dequeueQueueEntry

### DIFF
--- a/app/lib/auto-dial.server.ts
+++ b/app/lib/auto-dial.server.ts
@@ -8,11 +8,14 @@ import { createTenantDb, type TenantDb } from "@/server/tenant-db";
 import { eq } from "drizzle-orm";
 import {
   rpcCreateOutreachAttempt,
-  rpcDequeueContact,
   rpcResetStaleCampaignQueueClaims,
   rpcTryCompleteCampaignIfDrained,
 } from "@/lib/db-rpc.server";
-import { claimNextQueueContact, requeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import {
+  claimNextQueueContact,
+  dequeueQueueEntry,
+  requeueCampaignQueueById,
+} from "@/lib/campaign-queue-db.server";
 import { updateCallBySid } from "@/lib/telephony-db.server";
 import { recipientCallingWindowStatus } from "@/lib/recipient-calling-window";
 import { db } from "@/server/db";
@@ -315,13 +318,19 @@ export async function runAutoDialerTurn(
               contactId: contactRecord.contact_id,
               outreachAttemptId: outreach_attempt_id,
             });
-            await rpcDequeueContact(tdb, {
-              contactId: contactRecord.contact_id,
+            await dequeueQueueEntry({
+              by: { contactId: contactRecord.contact_id },
               workspaceId: workspace_id,
-              groupOnHousehold: false,
-              dequeuedById: user_id,
-              dequeuedReasonText:
+              // false, not omitted: the guarded RPC path, not plain Drizzle
+              // — deliberately parks only this one row (no household
+              // fan-out) and no-ops rather than requeue-and-retry if the
+              // row isn't currently queued/null. See dequeueQueueEntry's
+              // doc comment for why this differs from the Drizzle default.
+              household: false,
+              userId: user_id,
+              reason:
                 "Ambiguous dial failure — call may exist at Twilio; parked for review, not redialed",
+              exec: tdb,
             });
           }
         } catch (revertError) {
@@ -333,12 +342,13 @@ export async function runAutoDialerTurn(
         throw dialError;
       }
 
-      await rpcDequeueContact(tdb, {
-        contactId: contactRecord.contact_id,
+      await dequeueQueueEntry({
+        by: { contactId: contactRecord.contact_id },
         workspaceId: workspace_id,
-        groupOnHousehold: true,
-        dequeuedById: user_id,
-        dequeuedReasonText: "Predictive Dialer called contact",
+        household: true,
+        userId: user_id,
+        reason: "Predictive Dialer called contact",
+        exec: tdb,
       });
 
       // `call.dateUpdated`/`startTime`/`endTime` are `Date` in the Twilio SDK's

--- a/app/lib/campaign-queue-db.server.ts
+++ b/app/lib/campaign-queue-db.server.ts
@@ -13,8 +13,9 @@ import {
   contact as contactTable,
 } from "@/db/schema";
 import { db } from "@/server/db";
-import type { TenantDb } from "@/server/tenant-db";
+import { createTenantDb, type TenantDb } from "@/server/tenant-db";
 import { emitQueueEvent } from "@/lib/workspace-events.server";
+import { rpcDequeueContact, type RpcExecutor } from "@/lib/db-rpc.server";
 
 export type ClaimedQueueContact = {
   contact_id: number;
@@ -319,7 +320,13 @@ export async function requeueCampaignQueueById(queueId: number, workspaceId?: st
   });
 }
 
-export async function dequeueCampaignQueueById(args: {
+/**
+ * Internal mechanism — plain Drizzle UPDATE, unconditional on the row's
+ * current queue_state. Not exported: call {@link dequeueQueueEntry} instead
+ * (see the note there for why this file, not the caller, owns the mechanism
+ * choice).
+ */
+async function dequeueCampaignQueueById(args: {
   queueId: number;
   userId: string;
   reason: string;
@@ -450,10 +457,12 @@ export async function resolveContactWorkspaceIdFromQueue(
 }
 
 /**
- * Dequeue campaign_queue rows for a contact (optionally scoped to one campaign).
- * `userId` may be null for system-initiated dequeues (e.g. inbound SMS STOP).
+ * Internal mechanism — plain Drizzle UPDATE, unconditional on the row's
+ * current queue_state, optionally scoped to one campaign. `userId` may be
+ * null for system-initiated dequeues (e.g. inbound SMS STOP). Not exported:
+ * call {@link dequeueQueueEntry} instead.
  */
-export async function dequeueCampaignQueueByContact(args: {
+async function dequeueCampaignQueueByContact(args: {
   contactId: number;
   campaignId?: number | null;
   userId: string | null;
@@ -471,6 +480,98 @@ export async function dequeueCampaignQueueByContact(args: {
   return updateCampaignQueueAndEmit({
     conditions,
     set: buildDequeuedQueueUpdate(args.userId, args.reason),
+    workspaceId: args.workspaceId,
+  });
+}
+
+/**
+ * The single QueueEntry dequeue entry point (issue #1240, part B3). Every
+ * caller in the app routes through here — which of the three underlying
+ * mechanisms actually runs is an implementation detail this function owns:
+ *
+ *  - `by: { id }` (a campaign_queue row id) always uses the plain-Drizzle
+ *    mechanism ({@link dequeueCampaignQueueById}): unconditional on the
+ *    row's current queue_state, optionally workspace-scoped. There's no
+ *    contact to key a household lookup off of, so `household` must be
+ *    omitted for this target.
+ *
+ *  - `by: { contactId, campaignId? }` with `household` omitted uses the
+ *    plain-Drizzle mechanism ({@link dequeueCampaignQueueByContact}): same
+ *    unconditional semantics, optionally scoped to one campaign.
+ *
+ *  - `by: { contactId }` with `household` set (`true` or `false`) uses the
+ *    household-aware `dequeue_contact` Postgres RPC
+ *    (`rpcDequeueContact` in db-rpc.server — kept per ADR-0003, concurrency)
+ *    via a tenant-scoped executor (`exec`, or one built from `workspaceId`
+ *    if omitted). `household: true` fans the dequeue out to every contact
+ *    sharing the source contact's household_id — "household is the unit of
+ *    contact" per CONTEXT.md. `household: false` is a real, distinct third
+ *    mode, not a no-op alias for the Drizzle path: the RPC only touches rows
+ *    currently `queued`/null (see the WHERE clause added in
+ *    client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql),
+ *    so it's a *guarded*, single-contact dequeue that silently no-ops on a
+ *    row in any other queue_state (e.g. `assigned`). As of the B3 census
+ *    (2026-08) exactly one call site relies on that guard —
+ *    app/lib/auto-dial.server.ts's ambiguous-dial-park path, which
+ *    deliberately avoids requeue-and-retry semantics — so `household: false`
+ *    is preserved as a distinct, explicit choice rather than folded into the
+ *    Drizzle default.
+ *
+ * Behavior-preserving refactor: this function does not change what any
+ * existing call site does, only where the mechanism selection lives.
+ */
+export async function dequeueQueueEntry(
+  args:
+    | {
+        by: { id: number };
+        userId: string;
+        reason: string;
+        workspaceId?: string;
+        household?: undefined;
+      }
+    | {
+        by: { contactId: number; campaignId?: number | null };
+        userId: string | null;
+        reason: string;
+        workspaceId?: string;
+        household?: boolean;
+        exec?: RpcExecutor;
+      },
+): Promise<void> {
+  if ("id" in args.by) {
+    await dequeueCampaignQueueById({
+      queueId: args.by.id,
+      userId: args.userId,
+      reason: args.reason,
+      workspaceId: args.workspaceId,
+    });
+    return;
+  }
+
+  const { contactId, campaignId } = args.by;
+
+  if (args.household !== undefined) {
+    if (!args.workspaceId) {
+      throw new Error(
+        "dequeueQueueEntry: workspaceId is required for the household-aware RPC mechanism",
+      );
+    }
+    const exec = args.exec ?? createTenantDb(args.workspaceId);
+    await rpcDequeueContact(exec, {
+      contactId,
+      workspaceId: args.workspaceId,
+      groupOnHousehold: args.household,
+      dequeuedById: args.userId,
+      dequeuedReasonText: args.reason,
+    });
+    return;
+  }
+
+  await dequeueCampaignQueueByContact({
+    contactId,
+    campaignId,
+    userId: args.userId,
+    reason: args.reason,
     workspaceId: args.workspaceId,
   });
 }

--- a/app/lib/campaign-queue-db.server.ts
+++ b/app/lib/campaign-queue-db.server.ts
@@ -520,25 +520,36 @@ async function dequeueCampaignQueueByContact(args: {
  * Behavior-preserving refactor: this function does not change what any
  * existing call site does, only where the mechanism selection lives.
  */
-export async function dequeueQueueEntry(
-  args:
-    | {
-        by: { id: number };
-        userId: string;
-        reason: string;
-        workspaceId?: string;
-        household?: undefined;
-      }
-    | {
-        by: { contactId: number; campaignId?: number | null };
-        userId: string | null;
-        reason: string;
-        workspaceId?: string;
-        household?: boolean;
-        exec?: RpcExecutor;
-      },
-): Promise<void> {
-  if ("id" in args.by) {
+type DequeueQueueEntryByIdArgs = {
+  by: { id: number };
+  userId: string;
+  reason: string;
+  workspaceId?: string;
+  household?: undefined;
+};
+
+type DequeueQueueEntryByContactArgs = {
+  by: { contactId: number; campaignId?: number | null };
+  userId: string | null;
+  reason: string;
+  workspaceId?: string;
+  household?: boolean;
+  exec?: RpcExecutor;
+};
+
+export type DequeueQueueEntryArgs =
+  | DequeueQueueEntryByIdArgs
+  | DequeueQueueEntryByContactArgs;
+
+// A plain `"id" in args.by` inline check narrows `args.by`'s type but not
+// sibling properties of `args` (e.g. `userId`) back at the call site — a
+// named type predicate narrows the whole `args` union instead.
+function isByIdArgs(args: DequeueQueueEntryArgs): args is DequeueQueueEntryByIdArgs {
+  return "id" in args.by;
+}
+
+export async function dequeueQueueEntry(args: DequeueQueueEntryArgs): Promise<void> {
+  if (isByIdArgs(args)) {
     await dequeueCampaignQueueById({
       queueId: args.by.id,
       userId: args.userId,

--- a/app/lib/campaign-sms-dispatch.server.ts
+++ b/app/lib/campaign-sms-dispatch.server.ts
@@ -14,7 +14,7 @@
 import {
   messageCampaignRequiresCallerId,
 } from "@/lib/sms-send-resolve";
-import { dequeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { loadCampaignSmsDispatchData } from "@/lib/sms-campaign-db.server";
 import { getCampaignQueueById } from "@/lib/database/campaign.server";
 import { getWorkspaceTwilioPortalConfig } from "@/lib/database/workspace.server";
@@ -188,8 +188,8 @@ export async function dispatchCampaignSmsBatch(args: {
         }
 
         if (member.contact?.opt_out) {
-          await dequeueCampaignQueueById({
-            queueId: member.id,
+          await dequeueQueueEntry({
+            by: { id: member.id },
             userId,
             reason: OPTED_OUT_SMS_DEQUEUED_REASON,
           });
@@ -212,8 +212,8 @@ export async function dispatchCampaignSmsBatch(args: {
           : null;
 
         if (isSmsIncapableLineType(lineType)) {
-          await dequeueCampaignQueueById({
-            queueId: member.id,
+          await dequeueQueueEntry({
+            by: { id: member.id },
             userId,
             reason: LANDLINE_SMS_DEQUEUED_REASON,
           });
@@ -234,8 +234,8 @@ export async function dispatchCampaignSmsBatch(args: {
         });
 
         if (duplicateExists) {
-          await dequeueCampaignQueueById({
-            queueId: member.id,
+          await dequeueQueueEntry({
+            by: { id: member.id },
             userId,
             reason: DUPLICATE_SMS_DEQUEUED_REASON,
           });

--- a/app/lib/campaign-sms-send.server.ts
+++ b/app/lib/campaign-sms-send.server.ts
@@ -5,7 +5,7 @@
  * Extracted from /api/sms route so both HTTP and worker dispatch use the same path.
  */
 import { buildTwilioOutboundSmsCreateParams } from "@/lib/twilio-outbound-sms.server";
-import { dequeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { createWorkspaceTwilioInstance } from "@/lib/database/workspace.server";
 import { countCampaignMessagesToPhone } from "@/lib/message-db.server";
 import { updateOutreachAttemptForWorkspace } from "@/lib/telephony-db.server";
@@ -124,8 +124,8 @@ export async function sendSingleCampaignSms(params: SendSingleSmsParams) {
 
   await Promise.all([
     persistMessageRecord(workspace, messageFields),
-    dequeueCampaignQueueById({
-      queueId: Number(queue_id),
+    dequeueQueueEntry({
+      by: { id: Number(queue_id) },
       userId: user_id,
       reason: "SMS message sent",
     }),

--- a/app/lib/database/campaign.server.ts
+++ b/app/lib/database/campaign.server.ts
@@ -13,7 +13,7 @@ import { fetchCampaignQueueWithContacts } from "../campaign-queue-search.server"
 import { campaign as campaignTable } from "@/db/schema";
 import { createTenantDb, type TenantDb } from "@/server/tenant-db";
 import { db, type Database } from "@/server/db";
-import { dequeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { enqueueContactsForCampaign } from "@/lib/queue.server";
 import {
   persistCampaignScript,
@@ -484,8 +484,8 @@ export async function splitMessageCampaign({
   // Remove the redistributed rows from the source so volume isn't double-sent.
   let movedContactCount = 0;
   for (const member of members) {
-    await dequeueCampaignQueueById({
-      queueId: Number(member.id),
+    await dequeueQueueEntry({
+      by: { id: Number(member.id) },
       userId,
       reason: "Moved to parallel split segment",
     });

--- a/app/lib/db-rpc.server.ts
+++ b/app/lib/db-rpc.server.ts
@@ -229,6 +229,13 @@ export async function rpcClaimQueueEntryForDial(
   return (result ?? "unavailable") as DialClaimResult;
 }
 
+/**
+ * Household-aware dequeue mechanism (issue #1240 B3). Exported only so
+ * app/lib/campaign-queue-db.server.ts's `dequeueQueueEntry` — the single
+ * caller-facing dequeue entry point — can import it across the module
+ * boundary; no other file should call this directly. Call
+ * `dequeueQueueEntry` instead.
+ */
 export async function rpcDequeueContact(
   executor: RpcExecutor,
   args: {

--- a/app/lib/ivr-initiate.server.ts
+++ b/app/lib/ivr-initiate.server.ts
@@ -3,7 +3,7 @@ import {
   requireWorkspaceAccess,
 } from "@/lib/database/workspace.server";
 import { rpcCreateOutreachAttempt } from "@/lib/db-rpc.server";
-import { dequeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { env } from "@/lib/env.server";
 import { logger } from "@/lib/logger.server";
 import { resolveIvrCallUrls } from "@/lib/twilio-ivr-runtime.server";
@@ -90,8 +90,8 @@ export async function initiateIvrCall(
       return { success: false, error: "Failed to insert call row" };
     }
 
-    await dequeueCampaignQueueById({
-      queueId: input.contact.id,
+    await dequeueQueueEntry({
+      by: { id: input.contact.id },
       userId: input.user_id,
       reason: "IVR call completed",
     });

--- a/app/routes/api+/auto-dial/$roomId.action.server.ts
+++ b/app/routes/api+/auto-dial/$roomId.action.server.ts
@@ -4,10 +4,8 @@ import { createWorkspaceTwilioInstance } from "@/lib/database/workspace.server";
 import { Database, Tables } from "@/lib/db-types";
 import { env } from "@/lib/env.server";
 import { runAutoDialerTurn } from "@/lib/auto-dial.server";
-import { rpcDequeueContact } from "@/lib/db-rpc.server";
-import { createTenantDb } from "@/server/tenant-db";
 import { logger } from "@/lib/logger.server";
-import { dequeueCampaignQueueByContact } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { fetchCampaignByIdForWorkspace } from "@/lib/campaign-ivr.server";
 import { getUserVerifiedAudioNumbers } from "@/lib/user-audio.server";
 import {
@@ -66,20 +64,18 @@ const dequeueContact = async (
   campaignId?: number | null,
 ) => {
     if (groupOnHousehold) {
-        const tdb = createTenantDb(workspace);
-        return await rpcDequeueContact(tdb, {
-            contactId: Number(contactId),
+        return await dequeueQueueEntry({
+            by: { contactId: Number(contactId) },
             workspaceId: workspace,
-            groupOnHousehold,
-            dequeuedById: userId,
-            dequeuedReasonText: "Auto-dial completed",
+            household: true,
+            userId,
+            reason: "Auto-dial completed",
         });
     }
 
     try {
-        return await dequeueCampaignQueueByContact({
-          contactId: Number(contactId),
-          campaignId,
+        return await dequeueQueueEntry({
+          by: { contactId: Number(contactId), campaignId },
           userId,
           reason: "Auto-dial completed",
         });

--- a/app/routes/api+/auto-dial/status.action.server.ts
+++ b/app/routes/api+/auto-dial/status.action.server.ts
@@ -4,12 +4,13 @@ import {
   twilioParamsToUnderCase,
 } from "@/lib/twilio-call-status.server";
 import { buildProviderStatusQueueUpdate } from "@/lib/queue-status";
-import { updateCampaignQueueByContactAndCampaign } from "@/lib/campaign-queue-db.server";
+import {
+  dequeueQueueEntry,
+  updateCampaignQueueByContactAndCampaign,
+} from "@/lib/campaign-queue-db.server";
 import { createWorkspaceTwilioInstance } from "@/lib/database/workspace.server";
 import { data as routeData } from "react-router";
 import { runAutoDialerTurn } from "@/lib/auto-dial.server";
-import { rpcDequeueContact } from "@/lib/db-rpc.server";
-import { createTenantDb } from "@/server/tenant-db";
 import { logger } from "@/lib/logger.server";
 import { OutreachAttempt } from "@/lib/types";
 import { Tables } from "@/lib/db-types";
@@ -156,16 +157,15 @@ const handleCallStatus = async (
       return;
     }
 
-    const tdb = createTenantDb(workspace);
-    await rpcDequeueContact(tdb, {
-      contactId: outreachStatus.contact_id,
+    await dequeueQueueEntry({
+      by: { contactId: outreachStatus.contact_id },
       workspaceId: workspace,
-      groupOnHousehold: true,
+      household: true,
       // A conference name is `${userId}~${uuid}`, and this argument is bound
       // as ::uuid — passing the raw name raised 22P02 on every terminal call,
       // so the contact was never dequeued and the dialer stopped after one.
-      dequeuedById: resolveUserIdFromConferenceName(callUpdate.conference_id) || null,
-      dequeuedReasonText: `Call ${status?.toLowerCase()}`,
+      userId: resolveUserIdFromConferenceName(callUpdate.conference_id) || null,
+      reason: `Call ${status?.toLowerCase()}`,
     });
     const conferences = await twilio.conferences.list({
       friendlyName: callUpdate.conference_id ?? "",

--- a/app/routes/api+/hangup.action.server.ts
+++ b/app/routes/api+/hangup.action.server.ts
@@ -9,7 +9,7 @@ import { eq } from "drizzle-orm";
 import { data as routeData } from "react-router";
 import { logger } from "@/lib/logger.server";
 import { requireJsonAuth } from "@/lib/api-auth.server";
-import { rpcDequeueContact } from "@/lib/db-rpc.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { createTenantDb } from "@/server/tenant-db";
 import { hangupTwiml } from "@/lib/twilio-twiml.server";
 import { defineAction } from "@/lib/handler.server";
@@ -56,12 +56,13 @@ export const action = defineAction({
                       columns: { group_household_queue: true },
                   })
                 : null;
-            await rpcDequeueContact(tdb, {
-                contactId: call.contact_id,
+            await dequeueQueueEntry({
+                by: { contactId: call.contact_id },
                 workspaceId,
-                groupOnHousehold: campaign?.group_household_queue ?? false,
-                dequeuedById: user.id,
-                dequeuedReasonText: "Call completed",
+                household: campaign?.group_household_queue ?? false,
+                userId: user.id,
+                reason: "Call completed",
+                exec: tdb,
             });
             // Scope the disposition to THIS call's attempt. The old
             // updateOutreachDispositionByContactId rewrote every attempt for

--- a/app/routes/api+/inbound-sms.action.server.ts
+++ b/app/routes/api+/inbound-sms.action.server.ts
@@ -14,7 +14,7 @@ import { createTenantDb } from "@/server/tenant-db";
 import { uploadObject } from "@/lib/object-storage.server";
 import { getWorkspaceMessagingOnboardingState } from "@/lib/messaging-onboarding.server";
 import { isOptOutMessage, parseOptOutKeywords } from "@/lib/chat-opt-out";
-import { dequeueCampaignQueueByContact } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { defineAction } from "@/lib/handler.server";
 import { emitChatMessageEvent } from "@/lib/workspace-events.server";
 
@@ -184,8 +184,8 @@ export const action = defineAction({
         // workspace; log-don't-throw so the inbound message is still recorded.
         try {
           for (const contactId of matchingContactIds) {
-            await dequeueCampaignQueueByContact({
-              contactId,
+            await dequeueQueueEntry({
+              by: { contactId },
               userId: null,
               reason: "Contact opted out via SMS",
               workspaceId: workspaceNumber.workspace,

--- a/app/routes/api+/ivr.action.server.ts
+++ b/app/routes/api+/ivr.action.server.ts
@@ -1,5 +1,5 @@
 import { data as routeData } from "react-router";
-import { dequeueCampaignQueueById } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { recipientCallingWindowStatus } from "@/lib/recipient-calling-window";
 import { createErrorResponse } from "@/lib/errors.server";
 import {
@@ -101,8 +101,8 @@ export const action = defineAction({
       if (!callRow) throw new Error("Failed to insert call record");
 
       // Dequeue
-      await dequeueCampaignQueueById({
-        queueId: Number(queue_id),
+      await dequeueQueueEntry({
+        by: { id: Number(queue_id) },
         userId: user_id,
         reason: "IVR call completed",
       });

--- a/app/routes/api+/questions.action.server.ts
+++ b/app/routes/api+/questions.action.server.ts
@@ -7,7 +7,7 @@ import { requireJsonAuth } from "@/lib/api-auth.server";
 import { defineAction } from "@/lib/handler.server";
 import { rpcCreateOutreachAttempt } from "@/lib/db-rpc.server";
 import { createTenantDb } from "@/server/tenant-db";
-import { dequeueCampaignQueueByContact } from "@/lib/campaign-queue-db.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 import { isDncDisposition } from "@/lib/outreach-disposition";
 import {
   contact as contactTable,
@@ -142,8 +142,8 @@ export const action = defineAction({
           set: { opt_out: true },
           where: eq(contactTable.id, Number(contact_id)),
         });
-        await dequeueCampaignQueueByContact({
-          contactId: Number(contact_id),
+        await dequeueQueueEntry({
+          by: { contactId: Number(contact_id) },
           userId: user.id,
           reason: "Do not call requested",
           workspaceId: workspace,

--- a/app/routes/api+/queues.action.server.ts
+++ b/app/routes/api+/queues.action.server.ts
@@ -7,9 +7,10 @@ import {
   resolveCampaignWorkspaceId,
   resolveContactWorkspaceId,
 } from "@/lib/platform-telephony.server";
-import { requeueAllCampaignQueueForCampaign } from "@/lib/campaign-queue-db.server";
-import { rpcDequeueContact } from "@/lib/db-rpc.server";
-import { createTenantDb } from "@/server/tenant-db";
+import {
+  dequeueQueueEntry,
+  requeueAllCampaignQueueForCampaign,
+} from "@/lib/campaign-queue-db.server";
 import { jsonError } from "@/lib/platform-api.server";
 import { logger } from "@/lib/logger.server";
 import { data as routeData } from "react-router";
@@ -36,14 +37,12 @@ export const action = defineAction({
         workspaceId,
       });
 
-      const tdb = createTenantDb(workspaceId);
-
-      await rpcDequeueContact(tdb, {
-        contactId: Number(contact_id),
+      await dequeueQueueEntry({
+        by: { contactId: Number(contact_id) },
         workspaceId,
-        groupOnHousehold: household,
-        dequeuedById: auth.user.id,
-        dequeuedReasonText: "Manually dequeued by user",
+        household,
+        userId: auth.user.id,
+        reason: "Manually dequeued by user",
       });
 
       return routeData({ success: true });

--- a/test/auto-dial-room.route.test.ts
+++ b/test/auto-dial-room.route.test.ts
@@ -80,14 +80,6 @@ vi.mock("@/lib/auto-dial.server", () => ({
 const roomRpcState = vi.hoisted(() => ({ client: null as any }));
 const roomStorageState = vi.hoisted(() => ({ error: null as Error | null }));
 
-vi.mock("@/lib/db-rpc.server", () => ({
-  rpcDequeueContact: async (_db: any) => {
-    const client = roomRpcState.client;
-    const result = await client.rpc("dequeue_contact");
-    if (result?.error) throw result.error;
-  },
-}));
-
 vi.mock("@/lib/object-storage.server", () => ({
   createSignedObjectUrl: async () => {
     if (roomStorageState.error) throw roomStorageState.error;
@@ -129,9 +121,22 @@ const roomDbMocks = vi.hoisted(() => ({
   getUserVerifiedAudioNumbers: vi.fn(async () => ["+1666"] as string[] | null),
 }));
 
+// dequeueQueueEntry (app/lib/campaign-queue-db.server.ts) is the single
+// entry point $roomId.action.server.ts's local dequeueContact helper now
+// calls for both branches (issue #1240 B3) — route it here the same way the
+// real function does: household => the simulated dequeue_contact RPC via
+// the fake postgrest client already wired up per-test through
+// roomRpcState.client; no household => the plain-Drizzle mock below.
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueByContact: (...args: unknown[]) =>
-    roomDbMocks.dequeueCampaignQueueByContact(...args),
+  dequeueQueueEntry: async (args: { household?: boolean }) => {
+    if (args.household) {
+      const client = roomRpcState.client;
+      const result = await client.rpc("dequeue_contact");
+      if (result?.error) throw result.error;
+      return;
+    }
+    return roomDbMocks.dequeueCampaignQueueByContact(args);
+  },
 }));
 
 vi.mock("@/lib/user-audio.server", () => ({

--- a/test/auto-dial-status.test.ts
+++ b/test/auto-dial-status.test.ts
@@ -30,6 +30,7 @@ const campaignQueueDbMocks = vi.hoisted(() => ({
 vi.mock("@/lib/logger.server", () => ({
   logger: loggerMocks,
 }));
+const dequeueQueueEntryMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/campaign-queue-db.server", () => ({
   updateCampaignQueueByContactAndCampaign: async (...args: unknown[]) => {
     if (campaignQueueDbMocks.updateError) {
@@ -37,13 +38,13 @@ vi.mock("@/lib/campaign-queue-db.server", () => ({
     }
     return campaignQueueDbMocks.updateCampaignQueueByContactAndCampaign(...args);
   },
+  dequeueQueueEntry: (...args: unknown[]) => dequeueQueueEntryMock(...args),
 }));
 
 const twilioValidation = vi.hoisted(() => ({
   validateTwilioWebhookParams: vi.fn(() => true),
   requireTwilioSignature: vi.fn(),
 }));
-const rpcDequeueContactMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/twilio-webhook.server", () => ({
   requireTwilioSignature: (...args: unknown[]) =>
     twilioValidation.requireTwilioSignature(...args),
@@ -67,10 +68,6 @@ vi.mock("@/lib/telephony-db.server", async () => {
     claimTerminalCallStatus: stub.telephonyDbMocks.claimTerminalCallStatus,
   };
 });
-
-vi.mock("@/lib/db-rpc.server", () => ({
-  rpcDequeueContact: rpcDequeueContactMock,
-}));
 
 const runAutoDialerTurnMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/auto-dial.server", () => ({
@@ -343,8 +340,8 @@ describe("api.auto-dial.status", () => {
     campaignQueueDbMocks.updateError = null;
     campaignQueueDbMocks.updateCampaignQueueByContactAndCampaign.mockReset();
     loggerMocks.info.mockReset();
-    rpcDequeueContactMock.mockReset();
-    rpcDequeueContactMock.mockImplementation(async () => {});
+    dequeueQueueEntryMock.mockReset();
+    dequeueQueueEntryMock.mockImplementation(async () => {});
     runAutoDialerTurnMock.mockReset();
     runAutoDialerTurnMock.mockResolvedValue({ success: true });
     emitPredictiveBroadcastMock.mockReset();
@@ -447,9 +444,8 @@ describe("api.auto-dial.status", () => {
 
     expect(res.status).toBe(200);
     expect(telephonyStubState.outreachUpdateCalls.length).toBe(0);
-    expect(rpcDequeueContactMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ contactId: 1 }),
+    expect(dequeueQueueEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ by: { contactId: 1 }, household: true }),
     );
   });
 
@@ -488,9 +484,8 @@ describe("api.auto-dial.status", () => {
     } as any));
 
     expect(res.status).toBe(200);
-    expect(rpcDequeueContactMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ dequeuedById: userId }),
+    expect(dequeueQueueEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId }),
     );
   });
 
@@ -717,7 +712,7 @@ describe("api.auto-dial.status", () => {
   });
 
   test("rpc dequeue_contact error returns 500", async () => {
-    rpcDequeueContactMock.mockRejectedValue(new Error("dq"));
+    dequeueQueueEntryMock.mockRejectedValue(new Error("dq"));
     const mod = await import("../app/routes/api+/auto-dial/status.route");
     const fd = new FormData();
     fd.set("CallSid", "CA1");
@@ -734,9 +729,8 @@ describe("api.auto-dial.status", () => {
       }),
     } as any));
     expect(res.status).toBe(500);
-    expect(rpcDequeueContactMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ contactId: 1 }),
+    expect(dequeueQueueEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ by: { contactId: 1 }, household: true }),
     );
     expect(loggerMocks.error).toHaveBeenCalledWith("Error in handleCallStatus:", expect.any(Error));
   });
@@ -853,7 +847,7 @@ describe("api.auto-dial.status", () => {
     await expect(res.json()).resolves.toMatchObject({ success: true, replay: true });
     // The dangerous side effects must not run again: no re-dequeue, no new
     // outbound call, no billing.
-    expect(rpcDequeueContactMock).not.toHaveBeenCalled();
+    expect(dequeueQueueEntryMock).not.toHaveBeenCalled();
     expect(runAutoDialerTurnMock).not.toHaveBeenCalled();
     expect(postgresStub._transactionRows.length).toBe(0);
   });
@@ -886,7 +880,7 @@ describe("api.auto-dial.status", () => {
       }),
     } as any));
     expect(res.status).toBe(200);
-    expect(rpcDequeueContactMock).toHaveBeenCalled();
+    expect(dequeueQueueEntryMock).toHaveBeenCalled();
   });
 
   test("replayed participant-join does not restamp answered_at", async () => {

--- a/test/auto-dial.server.test.ts
+++ b/test/auto-dial.server.test.ts
@@ -15,22 +15,22 @@ vi.mock("@/lib/logger.server", () => ({
 
 const rpcMocks = vi.hoisted(() => ({
   rpcCreateOutreachAttempt: vi.fn(),
-  rpcDequeueContact: vi.fn(),
   rpcTryCompleteCampaignIfDrained: vi.fn(),
 }));
 vi.mock("@/lib/db-rpc.server", () => ({
   rpcCreateOutreachAttempt: (...args: unknown[]) => rpcMocks.rpcCreateOutreachAttempt(...args),
-  rpcDequeueContact: (...args: unknown[]) => rpcMocks.rpcDequeueContact(...args),
   rpcTryCompleteCampaignIfDrained: (...args: unknown[]) =>
     rpcMocks.rpcTryCompleteCampaignIfDrained(...args),
 }));
 
 const claimNextQueueContactMock = vi.hoisted(() => vi.fn());
 const requeueCampaignQueueByIdMock = vi.hoisted(() => vi.fn());
+const dequeueQueueEntryMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/campaign-queue-db.server", () => ({
   claimNextQueueContact: (...args: unknown[]) => claimNextQueueContactMock(...args),
   requeueCampaignQueueById: (...args: unknown[]) =>
     requeueCampaignQueueByIdMock(...args),
+  dequeueQueueEntry: (...args: unknown[]) => dequeueQueueEntryMock(...args),
 }));
 
 const twilioMocks = vi.hoisted(() => ({
@@ -295,9 +295,11 @@ describe("auto-dial.server", () => {
       expect(twilioMocks.callsCreate).toHaveBeenCalledWith(
         expect.objectContaining({ to: "+16045550100" }),
       );
-      expect(rpcMocks.rpcDequeueContact).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ contactId: 102 }),
+      expect(dequeueQueueEntryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          by: { contactId: 102 },
+          household: true,
+        }),
       );
       expect(result).toEqual({ success: true });
     });
@@ -338,7 +340,7 @@ describe("auto-dial.server", () => {
       const result = await runAutoDialerTurn(turnInput);
 
       expect(requeueCampaignQueueByIdMock).toHaveBeenCalledWith(21, "ws-1");
-      expect(rpcMocks.rpcDequeueContact).not.toHaveBeenCalled();
+      expect(dequeueQueueEntryMock).not.toHaveBeenCalled();
       expect(result).toEqual({ success: false, error: "Invalid phone number" });
     });
 
@@ -350,11 +352,11 @@ describe("auto-dial.server", () => {
       const result = await runAutoDialerTurn(turnInput);
 
       expect(requeueCampaignQueueByIdMock).not.toHaveBeenCalled();
-      expect(rpcMocks.rpcDequeueContact).toHaveBeenCalledWith(
-        expect.anything(),
+      expect(dequeueQueueEntryMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          contactId: 201,
-          dequeuedReasonText: expect.stringContaining("Ambiguous dial failure"),
+          by: { contactId: 201 },
+          household: false,
+          reason: expect.stringContaining("Ambiguous dial failure"),
         }),
       );
       expect(result).toEqual({ success: false, error: "socket hang up" });

--- a/test/dequeue-queue-entry.test.ts
+++ b/test/dequeue-queue-entry.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * Unit tests for dequeueQueueEntry's routing logic (app/lib/campaign-queue-db.server.ts,
+ * issue #1240 B3) — the single QueueEntry dequeue entry point that replaced
+ * direct calls to dequeueCampaignQueueById, dequeueCampaignQueueByContact,
+ * and rpcDequeueContact across the app.
+ *
+ * `@/lib/db-rpc.server` is mocked wholesale so these tests exercise only the
+ * routing decision (which mechanism gets called, with what args), not the
+ * RPC's own household-lookup/emit behavior — that's covered by
+ * scope-dequeue-and-outreach-attempt.integration.test.ts and manual
+ * verification against a live Postgres instance (see that file's header).
+ */
+
+const rpcDequeueContactMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+const dbMocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  update: vi.fn(),
+  execute: vi.fn(async () => []),
+  // createTenantDb() (app/server/tenant-db.ts) eagerly reads db.query.<table>
+  // for every workspace-scoped table at construction time, even though the
+  // household RPC path (rpcDequeueContact, mocked wholesale below) never
+  // calls into it — a Proxy avoids having to enumerate every table.
+  query: new Proxy(
+    {},
+    { get: () => ({ findMany: () => Promise.resolve([]), findFirst: () => Promise.resolve(undefined) }) },
+  ),
+}));
+
+const emitQueueEventMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@/server/db", () => ({ db: dbMocks }));
+vi.mock("@/lib/workspace-events.server", () => ({
+  emitQueueEvent: (...args: unknown[]) => emitQueueEventMock(...args),
+}));
+vi.mock("@/lib/db-rpc.server", () => ({
+  rpcDequeueContact: (...args: unknown[]) => rpcDequeueContactMock(...args),
+}));
+
+// Captured `set` payloads and `where` filters from db.update().set(...).where(...) calls.
+let updateSetCalls: unknown[] = [];
+let updateCount = 0;
+
+function installDbMockImplementations() {
+  dbMocks.select.mockImplementation(() => {
+    const chain: any = {
+      from: () => chain,
+      where: () => chain,
+      then: (onFulfilled: any) => Promise.resolve([]).then(onFulfilled),
+    };
+    return chain;
+  });
+  dbMocks.update.mockImplementation(() => ({
+    set: (setPayload: unknown) => {
+      updateSetCalls.push(setPayload);
+      updateCount++;
+      return {
+        where: () => ({
+          returning: () => Promise.resolve([{ id: 1, workspace: "workspace-1" }]),
+        }),
+      };
+    },
+  }));
+}
+
+beforeEach(() => {
+  dbMocks.select.mockReset();
+  dbMocks.update.mockReset();
+  dbMocks.execute.mockReset();
+  emitQueueEventMock.mockClear();
+  rpcDequeueContactMock.mockReset();
+  rpcDequeueContactMock.mockResolvedValue(undefined);
+  updateSetCalls = [];
+  updateCount = 0;
+  installDbMockImplementations();
+});
+
+describe("dequeueQueueEntry routing", () => {
+  test("by: { id } always uses the plain-Drizzle mechanism, never the RPC", async () => {
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await dequeueQueueEntry({
+      by: { id: 42 },
+      userId: "user-1",
+      reason: "SMS message sent",
+      workspaceId: "workspace-1",
+    });
+
+    expect(updateCount).toBe(1);
+    expect(updateSetCalls[0]).toMatchObject({
+      queue_state: "dequeued",
+      dequeued_by: "user-1",
+      dequeued_reason: "SMS message sent",
+    });
+    expect(rpcDequeueContactMock).not.toHaveBeenCalled();
+  });
+
+  test("by: { contactId } with household omitted uses the plain-Drizzle mechanism", async () => {
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await dequeueQueueEntry({
+      by: { contactId: 7, campaignId: 99 },
+      userId: null,
+      reason: "Contact opted out via SMS",
+      workspaceId: "workspace-1",
+    });
+
+    expect(updateCount).toBe(1);
+    expect(updateSetCalls[0]).toMatchObject({
+      queue_state: "dequeued",
+      dequeued_by: null,
+      dequeued_reason: "Contact opted out via SMS",
+    });
+    expect(rpcDequeueContactMock).not.toHaveBeenCalled();
+  });
+
+  test("by: { contactId }, household: true uses the household-aware RPC with fan-out", async () => {
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await dequeueQueueEntry({
+      by: { contactId: 7 },
+      userId: "user-1",
+      reason: "Predictive Dialer called contact",
+      workspaceId: "workspace-1",
+      household: true,
+    });
+
+    expect(rpcDequeueContactMock).toHaveBeenCalledTimes(1);
+    expect(rpcDequeueContactMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        contactId: 7,
+        workspaceId: "workspace-1",
+        groupOnHousehold: true,
+        dequeuedById: "user-1",
+        dequeuedReasonText: "Predictive Dialer called contact",
+      }),
+    );
+    expect(updateCount).toBe(0);
+  });
+
+  test("by: { contactId }, household: false STILL uses the guarded RPC, not plain Drizzle", async () => {
+    // Preserves app/lib/auto-dial.server.ts's ambiguous-dial-park behavior:
+    // `false` is a deliberate, distinct third mode (guarded single-contact
+    // RPC dequeue), not an alias for the Drizzle default.
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await dequeueQueueEntry({
+      by: { contactId: 7 },
+      userId: "user-1",
+      reason: "Ambiguous dial failure — call may exist at Twilio; parked for review, not redialed",
+      workspaceId: "workspace-1",
+      household: false,
+    });
+
+    expect(rpcDequeueContactMock).toHaveBeenCalledTimes(1);
+    expect(rpcDequeueContactMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ groupOnHousehold: false }),
+    );
+    expect(updateCount).toBe(0);
+  });
+
+  test("household routing passes through an explicit exec instead of building a new one", async () => {
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+    const explicitExec = { execute: vi.fn(async () => []) };
+
+    await dequeueQueueEntry({
+      by: { contactId: 7 },
+      userId: "user-1",
+      reason: "Call completed",
+      workspaceId: "workspace-1",
+      household: true,
+      exec: explicitExec,
+    });
+
+    expect(rpcDequeueContactMock).toHaveBeenCalledWith(
+      explicitExec,
+      expect.objectContaining({ groupOnHousehold: true }),
+    );
+  });
+
+  test("household routing without an explicit exec builds a tenant-scoped one from workspaceId", async () => {
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await dequeueQueueEntry({
+      by: { contactId: 7 },
+      userId: "user-1",
+      reason: "Call completed",
+      workspaceId: "workspace-1",
+      household: true,
+    });
+
+    const [execArg] = rpcDequeueContactMock.mock.calls[0] as [unknown, unknown];
+    expect(execArg).not.toBe(undefined);
+    expect(typeof (execArg as { execute?: unknown }).execute).toBe("function");
+  });
+
+  test("household routing throws without a workspaceId (the RPC requires one)", async () => {
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await expect(
+      dequeueQueueEntry({
+        by: { contactId: 7 },
+        userId: "user-1",
+        reason: "Call completed",
+        household: true,
+      }),
+    ).rejects.toThrow(/workspaceId/);
+    expect(rpcDequeueContactMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/hangup.route.test.ts
+++ b/test/hangup.route.test.ts
@@ -32,8 +32,8 @@ vi.mock("@/lib/telephony-db.server", () => ({
   updateOutreachAttemptForWorkspace: vi.fn(),
 }));
 
-vi.mock("@/lib/db-rpc.server", () => ({
-  rpcDequeueContact: vi.fn(),
+vi.mock("@/lib/campaign-queue-db.server", () => ({
+  dequeueQueueEntry: vi.fn(),
 }));
 
 const tenantDbMocks = vi.hoisted(() => ({
@@ -48,7 +48,7 @@ vi.mock("@/server/tenant-db", () => ({
 }));
 
 import { findCallBySid, updateOutreachAttemptForWorkspace } from "@/lib/telephony-db.server";
-import { rpcDequeueContact } from "@/lib/db-rpc.server";
+import { dequeueQueueEntry } from "@/lib/campaign-queue-db.server";
 
 function mockCall(overrides?: Partial<{
   workspace: string;
@@ -76,7 +76,7 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     mocks.logger.error.mockReset();
     vi.mocked(findCallBySid).mockReset();
     vi.mocked(updateOutreachAttemptForWorkspace).mockReset();
-    vi.mocked(rpcDequeueContact).mockReset();
+    vi.mocked(dequeueQueueEntry).mockReset();
     tenantDbMocks.campaignFindFirst.mockReset();
     tenantDbMocks.campaignFindFirst.mockResolvedValue({ group_household_queue: false });
   });
@@ -94,7 +94,7 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     const mod = await import("../app/routes/api+/hangup");
     const res = await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
     await expect(res.json()).resolves.toEqual({ success: true });
-    expect(rpcDequeueContact).toHaveBeenCalled();
+    expect(dequeueQueueEntry).toHaveBeenCalled();
     // Scoped to the specific attempt (9), not every attempt for contact 2.
     expect(updateOutreachAttemptForWorkspace).toHaveBeenCalledWith(
       "w1",
@@ -116,9 +116,8 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     const mod = await import("../app/routes/api+/hangup");
     await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
 
-    expect(rpcDequeueContact).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ groupOnHousehold: true }),
+    expect(dequeueQueueEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ household: true }),
     );
   });
 
@@ -133,7 +132,7 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     const mod = await import("../app/routes/api+/hangup");
     const res = await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
     expect(res.status).toBe(200);
-    expect(rpcDequeueContact).toHaveBeenCalled();
+    expect(dequeueQueueEntry).toHaveBeenCalled();
     expect(updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
   });
 
@@ -154,7 +153,7 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     const res = await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ success: true });
-    expect(rpcDequeueContact).toHaveBeenCalled();
+    expect(dequeueQueueEntry).toHaveBeenCalled();
   });
 
   test("returns 500 when Twilio throws non-21220", async () => {
@@ -199,7 +198,7 @@ describe("app/routes/api+/hangup/route.tsx", () => {
     const res = await asRouteResponse(mod.action({ request: new Request("http://x", { method: "POST" }) } as any));
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ success: true });
-    expect(rpcDequeueContact).not.toHaveBeenCalled();
+    expect(dequeueQueueEntry).not.toHaveBeenCalled();
     expect(updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
   });
 

--- a/test/inbound-sms.route.test.ts
+++ b/test/inbound-sms.route.test.ts
@@ -48,12 +48,11 @@ vi.mock("@/lib/workspace-events.server", () => ({
 }));
 
 const queueDbMocks = vi.hoisted(() => ({
-  dequeueCampaignQueueByContact: vi.fn(),
+  dequeueQueueEntry: vi.fn(),
 }));
 
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueByContact: (...args: unknown[]) =>
-    queueDbMocks.dequeueCampaignQueueByContact(...args),
+  dequeueQueueEntry: (...args: unknown[]) => queueDbMocks.dequeueQueueEntry(...args),
 }));
 
 const onboardingMocks = vi.hoisted(() => ({
@@ -283,8 +282,8 @@ describe("app/routes/api+/inbound-sms", () => {
     mocks.logger.info.mockReset();
     mocks.logger.warn.mockReset();
     mocks.fetch.mockReset();
-    queueDbMocks.dequeueCampaignQueueByContact.mockReset();
-    queueDbMocks.dequeueCampaignQueueByContact.mockResolvedValue([]);
+    queueDbMocks.dequeueQueueEntry.mockReset();
+    queueDbMocks.dequeueQueueEntry.mockResolvedValue(undefined);
     vi.stubGlobal("fetch", mocks.fetch);
     onboardingMocks.getWorkspaceMessagingOnboardingState.mockReset();
     onboardingMocks.getWorkspaceMessagingOnboardingState.mockResolvedValue({
@@ -366,8 +365,8 @@ describe("app/routes/api+/inbound-sms", () => {
       expect(tenantDbStubState.contactUpdateCalls).toContainEqual(
         expect.objectContaining({ set: { opt_out: true } }),
       );
-      expect(queueDbMocks.dequeueCampaignQueueByContact).toHaveBeenCalledWith({
-        contactId: 9,
+      expect(queueDbMocks.dequeueQueueEntry).toHaveBeenCalledWith({
+        by: { contactId: 9 },
         userId: null,
         reason: "Contact opted out via SMS",
         workspaceId: "w1",
@@ -375,7 +374,7 @@ describe("app/routes/api+/inbound-sms", () => {
     });
 
     test("STOP dequeue failure is logged but the message is still recorded", async () => {
-      queueDbMocks.dequeueCampaignQueueByContact.mockRejectedValueOnce(
+      queueDbMocks.dequeueQueueEntry.mockRejectedValueOnce(
         new Error("queue down"),
       );
       const number = { workspace: "w1", twilio_data: { sid: "sid", authToken: "tok" }, webhook: [] };
@@ -412,7 +411,7 @@ describe("app/routes/api+/inbound-sms", () => {
         expect.objectContaining({ set: { opt_out: false } }),
       );
       // Re-subscribe must NOT touch campaign queues (no re-queueing).
-      expect(queueDbMocks.dequeueCampaignQueueByContact).not.toHaveBeenCalled();
+      expect(queueDbMocks.dequeueQueueEntry).not.toHaveBeenCalled();
     });
   });
 

--- a/test/ivr-initiate.server.test.ts
+++ b/test/ivr-initiate.server.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/lib/telephony-db.server", () => ({
 }));
 
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueById: vi.fn().mockResolvedValue(undefined),
+  dequeueQueueEntry: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("initiateIvrCall", () => {

--- a/test/ivr.route.test.ts
+++ b/test/ivr.route.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => {
     requireJsonAuth: vi.fn(),
     rpcCreateOutreachAttempt: vi.fn(),
     insertCallForWorkspace: vi.fn(),
-    dequeueCampaignQueueById: vi.fn(),
+    dequeueQueueEntry: vi.fn(),
     env: {
       BETTER_AUTH_URL: () => "https://sb.example",
       BETTER_AUTH_SERVICE_KEY: () => "svc",
@@ -50,7 +50,7 @@ vi.mock("@/lib/telephony-db.server", () => ({
   insertCallForWorkspace: (...a: any[]) => mocks.insertCallForWorkspace(...a),
 }));
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueById: (...a: any[]) => mocks.dequeueCampaignQueueById(...a),
+  dequeueQueueEntry: (...a: any[]) => mocks.dequeueQueueEntry(...a),
 }));
 vi.mock("@/lib/workspace-credits.server", () => ({
   getWorkspaceCreditsBalance: vi.fn(async () => creditsState.credits),
@@ -72,7 +72,7 @@ describe("app/routes/api+/ivr/tsx.route", () => {
     mocks.requireJsonAuth.mockReset();
     mocks.rpcCreateOutreachAttempt.mockReset();
     mocks.insertCallForWorkspace.mockReset();
-    mocks.dequeueCampaignQueueById.mockReset();
+    mocks.dequeueQueueEntry.mockReset();
     mocks.logger.error.mockReset();
     mocks.requireJsonAuth.mockResolvedValue({ user: { id: "u1" } });
     mocks.requireWorkspaceAccess.mockResolvedValue(undefined);
@@ -81,7 +81,7 @@ describe("app/routes/api+/ivr/tsx.route", () => {
       calls: { create: async () => ({ sid: "CA1" }) },
     });
     mocks.insertCallForWorkspace.mockResolvedValue({ sid: "CA1" });
-    mocks.dequeueCampaignQueueById.mockResolvedValue(undefined);
+    mocks.dequeueQueueEntry.mockResolvedValue(undefined);
     creditsState.credits = 10;
   });
 
@@ -169,8 +169,8 @@ describe("app/routes/api+/ivr/tsx.route", () => {
         outreach_attempt_id: 99,
       },
     );
-    expect(mocks.dequeueCampaignQueueById).toHaveBeenCalledWith({
-      queueId: 3,
+    expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith({
+      by: { id: 3 },
       userId: "u1",
       reason: "IVR call completed",
     });
@@ -206,7 +206,7 @@ describe("app/routes/api+/ivr/tsx.route", () => {
       statusCode: 500,
     });
 
-    mocks.dequeueCampaignQueueById.mockRejectedValueOnce(new Error("dequeue"));
+    mocks.dequeueQueueEntry.mockRejectedValueOnce(new Error("dequeue"));
     res = await asRouteResponse(mod.action({ request: makeReq() } as any));
     expect(res.status).toBe(500);
     await expect(res.json()).resolves.toMatchObject({

--- a/test/questions.route.test.ts
+++ b/test/questions.route.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => {
     requireWorkspaceAccess: vi.fn(),
     safeParseJson: vi.fn(),
     rpcCreateOutreachAttempt: vi.fn(),
-    dequeueCampaignQueueByContact: vi.fn(),
+    dequeueQueueEntry: vi.fn(),
     logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
   };
 });
@@ -41,8 +41,7 @@ vi.mock("@/lib/db-rpc.server", () => ({
 }));
 vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueByContact: (...args: any[]) =>
-    mocks.dequeueCampaignQueueByContact(...args),
+  dequeueQueueEntry: (...args: any[]) => mocks.dequeueQueueEntry(...args),
 }));
 vi.mock("@/server/tenant-db", () => ({
   createTenantDb: () => ({
@@ -83,13 +82,13 @@ describe("app/routes/api+/questions/route.tsx", () => {
     mocks.requireWorkspaceAccess.mockReset();
     mocks.safeParseJson.mockReset();
     mocks.rpcCreateOutreachAttempt.mockReset();
-    mocks.dequeueCampaignQueueByContact.mockReset();
+    mocks.dequeueQueueEntry.mockReset();
     mocks.logger.error.mockReset();
     tenantDbMocks.findFirst.mockReset();
     tenantDbMocks.update.mockReset();
     tenantDbMocks.contactUpdate.mockReset();
     tenantDbMocks.contactUpdate.mockResolvedValue([{ id: 1, opt_out: true }]);
-    mocks.dequeueCampaignQueueByContact.mockResolvedValue([]);
+    mocks.dequeueQueueEntry.mockResolvedValue(undefined);
 
     mocks.getSession.mockResolvedValue({ headers, user: { id: "u1" } });
     mocks.requireJsonAuth.mockResolvedValue({ user: { id: "u1" } });
@@ -292,8 +291,8 @@ describe("app/routes/api+/questions/route.tsx", () => {
         expect.objectContaining({ set: { opt_out: true } }),
       );
       // All-campaigns dequeue: campaignId must be omitted.
-      expect(mocks.dequeueCampaignQueueByContact).toHaveBeenCalledWith({
-        contactId: 1,
+      expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith({
+        by: { contactId: 1 },
         userId: "u1",
         reason: "Do not call requested",
         workspaceId: "w1",
@@ -303,7 +302,7 @@ describe("app/routes/api+/questions/route.tsx", () => {
     test("matches display-label and cased variants of do_not_call", async () => {
       for (const variant of ["Do not call", "DO-NOT-CALL"]) {
         tenantDbMocks.contactUpdate.mockClear();
-        mocks.dequeueCampaignQueueByContact.mockClear();
+        mocks.dequeueQueueEntry.mockClear();
         mocks.safeParseJson.mockResolvedValueOnce({
           ...defaultBody,
           disposition: variant,
@@ -312,7 +311,7 @@ describe("app/routes/api+/questions/route.tsx", () => {
         const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
         expect(res.status).toBe(200);
         expect(tenantDbMocks.contactUpdate).toHaveBeenCalledTimes(1);
-        expect(mocks.dequeueCampaignQueueByContact).toHaveBeenCalledTimes(1);
+        expect(mocks.dequeueQueueEntry).toHaveBeenCalledTimes(1);
       }
     });
 
@@ -325,7 +324,7 @@ describe("app/routes/api+/questions/route.tsx", () => {
       const res = await asRouteResponse(mod.action({ request: makeRequest(defaultBody) } as any));
       expect(res.status).toBe(200);
       expect(tenantDbMocks.contactUpdate).not.toHaveBeenCalled();
-      expect(mocks.dequeueCampaignQueueByContact).not.toHaveBeenCalled();
+      expect(mocks.dequeueQueueEntry).not.toHaveBeenCalled();
     });
 
     test("side-effect failures are logged but do not fail the disposition save", async () => {

--- a/test/queues.route.test.ts
+++ b/test/queues.route.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => {
     resolveCampaignWorkspaceId: vi.fn(async () => "w1"),
     resolveContactWorkspaceId: vi.fn(async () => "w1"),
     rpcSelectAndUpdateCampaignContacts: vi.fn(async () => []),
-    rpcDequeueContact: vi.fn(async () => ({})),
+    dequeueQueueEntry: vi.fn(async () => undefined),
   };
 });
 
@@ -30,6 +30,7 @@ vi.mock("@/lib/campaign-queue-db.server", () => ({
   fetchCampaignQueueRowsByIds: (...args: unknown[]) => mocks.fetchCampaignQueueRowsByIds(...args),
   requeueAllCampaignQueueForCampaign: (...args: unknown[]) =>
     mocks.requeueAllCampaignQueueForCampaign(...args),
+  dequeueQueueEntry: (...args: unknown[]) => mocks.dequeueQueueEntry(...args),
 }));
 vi.mock("@/lib/platform-telephony.server", () => ({
   resolveCampaignWorkspaceId: (...args: unknown[]) => mocks.resolveCampaignWorkspaceId(...args),
@@ -37,7 +38,6 @@ vi.mock("@/lib/platform-telephony.server", () => ({
 }));
 vi.mock("@/lib/db-rpc.server", () => ({
   rpcSelectAndUpdateCampaignContacts: (...args: unknown[]) => mocks.rpcSelectAndUpdateCampaignContacts(...args),
-  rpcDequeueContact: (...args: unknown[]) => mocks.rpcDequeueContact(...args),
 }));
 
 describe("app/routes/api+/queues/route.tsx", () => {
@@ -50,7 +50,7 @@ describe("app/routes/api+/queues/route.tsx", () => {
     mocks.resolveCampaignWorkspaceId.mockReset();
     mocks.resolveContactWorkspaceId.mockReset();
     mocks.rpcSelectAndUpdateCampaignContacts.mockReset();
-    mocks.rpcDequeueContact.mockReset();
+    mocks.dequeueQueueEntry.mockReset();
     mocks.resolveCampaignWorkspaceId.mockResolvedValue("w1");
     mocks.resolveContactWorkspaceId.mockResolvedValue("w1");
     mocks.fetchCampaignQueueRowsByIds.mockResolvedValue([]);
@@ -108,8 +108,8 @@ describe("app/routes/api+/queues/route.tsx", () => {
     expect(mocks.fetchCampaignQueueRowsByIds).toHaveBeenCalledWith([1, 2]);
   });
 
-  test("action POST returns 500 and logs when rpc errors", async () => {
-    mocks.rpcDequeueContact.mockRejectedValueOnce(new Error("rpc fail"));
+  test("action POST returns 500 and logs when dequeue errors", async () => {
+    mocks.dequeueQueueEntry.mockRejectedValueOnce(new Error("rpc fail"));
     queueJsonAuthSession({ user: { id: "u1" } });
     mocks.safeParseJson.mockResolvedValueOnce({ contact_id: 1, household: true });
 
@@ -124,7 +124,7 @@ describe("app/routes/api+/queues/route.tsx", () => {
   });
 
   test("action POST returns data on success", async () => {
-    mocks.rpcDequeueContact.mockResolvedValueOnce({ ok: true });
+    mocks.dequeueQueueEntry.mockResolvedValueOnce(undefined);
     queueJsonAuthSession({ user: { id: "u1" } });
     mocks.safeParseJson.mockResolvedValueOnce({ contact_id: 2, household: false });
 
@@ -135,6 +135,13 @@ describe("app/routes/api+/queues/route.tsx", () => {
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ success: true });
+    expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith({
+      by: { contactId: 2 },
+      workspaceId: "w1",
+      household: false,
+      userId: "u1",
+      reason: "Manually dequeued by user",
+    });
   });
 
   test("action DELETE returns 500 and logs when update errors", async () => {

--- a/test/route-live-media-stream.test.ts
+++ b/test/route-live-media-stream.test.ts
@@ -43,10 +43,8 @@ const mocks = vi.hoisted(() => ({
   runAutoDialerTurn: vi.fn(async () => undefined),
   getUserVerifiedAudioNumbers: vi.fn(),
   fetchCampaignByIdForWorkspace: vi.fn(),
-  dequeueCampaignQueueByContact: vi.fn(),
-  rpcDequeueContact: vi.fn(),
+  dequeueQueueEntry: vi.fn(),
   createSignedObjectUrl: vi.fn(async () => null),
-  createTenantDb: vi.fn(() => ({})),
 }));
 
 // `twilio`'s package entrypoint pulls in a jsonwebtoken → jwa chain that fails
@@ -118,17 +116,10 @@ vi.mock("@/lib/campaign-ivr.server", () => ({
     mocks.fetchCampaignByIdForWorkspace(...a),
 }));
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueByContact: (...a: unknown[]) =>
-    mocks.dequeueCampaignQueueByContact(...a),
-}));
-vi.mock("@/lib/db-rpc.server", () => ({
-  rpcDequeueContact: (...a: unknown[]) => mocks.rpcDequeueContact(...a),
+  dequeueQueueEntry: (...a: unknown[]) => mocks.dequeueQueueEntry(...a),
 }));
 vi.mock("@/lib/object-storage.server", () => ({
   createSignedObjectUrl: (...a: unknown[]) => mocks.createSignedObjectUrl(...a),
-}));
-vi.mock("@/server/tenant-db", () => ({
-  createTenantDb: (...a: unknown[]) => mocks.createTenantDb(...a),
 }));
 
 /** The three capability states each route is exercised against. */

--- a/test/sms-action.route.test.ts
+++ b/test/sms-action.route.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   getCampaignQueueById: vi.fn(),
   getWorkspaceTwilioPortalConfig: vi.fn(),
   createWorkspaceTwilioInstance: vi.fn(),
-  dequeueCampaignQueueById: vi.fn(async () => undefined),
+  dequeueQueueEntry: vi.fn(async () => undefined),
   countCampaignMessagesToPhone: vi.fn(async () => 0),
   updateOutreachAttemptForWorkspace: vi.fn(async () => ({ campaign_id: 1 })),
   rpcCreateOutreachAttempt: vi.fn(async () => 1),
@@ -59,7 +59,7 @@ vi.mock("@/lib/database/workspace.server", () => ({
     mocks.createWorkspaceTwilioInstance(...args),
 }));
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueById: (...args: unknown[]) => mocks.dequeueCampaignQueueById(...args),
+  dequeueQueueEntry: (...args: unknown[]) => mocks.dequeueQueueEntry(...args),
 }));
 vi.mock("@/lib/message-db.server", () => ({
   countCampaignMessagesToPhone: (...args: unknown[]) =>
@@ -134,7 +134,7 @@ describe("app/routes/api+/sms.action.server.ts (campaign SMS dispatch)", () => {
     mocks.createWorkspaceTwilioInstance.mockResolvedValue({
       messages: { create: vi.fn(async (args: any) => ({ sid: "SM1", ...args })) },
     });
-    mocks.dequeueCampaignQueueById.mockResolvedValue(undefined);
+    mocks.dequeueQueueEntry.mockResolvedValue(undefined);
     mocks.countCampaignMessagesToPhone.mockResolvedValue(0);
     mocks.updateOutreachAttemptForWorkspace.mockResolvedValue({ campaign_id: 1 });
     mocks.rpcCreateOutreachAttempt.mockResolvedValue(1);
@@ -167,8 +167,8 @@ describe("app/routes/api+/sms.action.server.ts (campaign SMS dispatch)", () => {
     expect(body.responses[0]).toEqual({
       9: { success: true, skipped: true, reason: "Contact opted out" },
     });
-    expect(mocks.dequeueCampaignQueueById).toHaveBeenCalledWith({
-      queueId: 501,
+    expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith({
+      by: { id: 501 },
       userId: "u1",
       reason: "Contact opted out",
     });
@@ -198,7 +198,7 @@ describe("app/routes/api+/sms.action.server.ts (campaign SMS dispatch)", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { responses: Array<Record<string, any>> };
     expect(body.responses[0][10]).toMatchObject({ success: true });
-    expect(mocks.dequeueCampaignQueueById).toHaveBeenCalledWith(
+    expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "SMS message sent" }),
     );
   });
@@ -228,8 +228,8 @@ describe("app/routes/api+/sms.action.server.ts (campaign SMS dispatch)", () => {
     expect(body.responses[0]).toEqual({
       11: { success: true, skipped: true, reason: "Landline — cannot receive SMS" },
     });
-    expect(mocks.dequeueCampaignQueueById).toHaveBeenCalledWith({
-      queueId: 503,
+    expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith({
+      by: { id: 503 },
       userId: "u1",
       reason: "Landline — cannot receive SMS",
     });
@@ -269,7 +269,7 @@ describe("app/routes/api+/sms.action.server.ts (campaign SMS dispatch)", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as { responses: Array<Record<string, any>> };
       expect(body.responses[0][12]).toMatchObject({ success: true });
-      expect(mocks.dequeueCampaignQueueById).toHaveBeenCalledWith(
+      expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith(
         expect.objectContaining({ reason: "SMS message sent" }),
       );
     },

--- a/test/sms.route.test.ts
+++ b/test/sms.route.test.ts
@@ -41,7 +41,7 @@ const mocks = vi.hoisted(() => {
     createWorkspaceTwilioInstance: vi.fn(),
     requireWorkspaceAccess: vi.fn(),
     processTemplateTags: vi.fn((text: string) => text),
-    dequeueCampaignQueueById: vi.fn(async () => []),
+    dequeueQueueEntry: vi.fn(async () => undefined),
     loadCampaignSmsDispatchData: vi.fn(),
     countCampaignMessagesToPhone: vi.fn(),
     updateOutreachAttemptForWorkspace: vi.fn(),
@@ -135,7 +135,7 @@ vi.mock("@/server/tenant-db", () => ({
 }));
 
 vi.mock("@/lib/campaign-queue-db.server", () => ({
-  dequeueCampaignQueueById: (...args: unknown[]) => mocks.dequeueCampaignQueueById(...args),
+  dequeueQueueEntry: (...args: unknown[]) => mocks.dequeueQueueEntry(...args),
 }));
 
 vi.mock("@/lib/sms-campaign-db.server", () => ({
@@ -277,7 +277,7 @@ describe("app/routes/api+/sms/route.tsx", () => {
     mocks.createWorkspaceTwilioInstance.mockReset();
     mocks.requireWorkspaceAccess.mockReset();
     mocks.processTemplateTags.mockReset();
-    mocks.dequeueCampaignQueueById.mockReset();
+    mocks.dequeueQueueEntry.mockReset();
     mocks.loadCampaignSmsDispatchData.mockReset();
     mocks.countCampaignMessagesToPhone.mockReset();
     mocks.updateOutreachAttemptForWorkspace.mockReset();


### PR DESCRIPTION
Part 3 of #1240 (B3), stacked on #1245

**Stacked PR** — base branch is `refactor/1240-queue-entry-transitions` (B1, unmerged #1245), not `dev`. B2 (a separate check-script PR off the same B1 branch) is not needed here and is not included in this diff.

## What this does

Collapses the three dequeue mechanisms scattered across 13+ call sites into one caller-facing entry point, `dequeueQueueEntry` (`app/lib/campaign-queue-db.server.ts`). The three mechanisms — plain-Drizzle by queue id, plain-Drizzle by contact, and the household-aware `dequeue_contact` Postgres RPC (`rpcDequeueContact` in `db-rpc.server.ts`, kept per ADR-0003 for its concurrency properties) — are now internal implementation details `dequeueQueueEntry` routes to. `dequeueCampaignQueueById` and `dequeueCampaignQueueByContact` are no longer exported; `rpcDequeueContact` stays exported only because `dequeueQueueEntry` needs to import it across the file boundary, with a doc comment marking it call-`dequeueQueueEntry`-instead. Verified by grep: nothing outside `campaign-queue-db.server.ts` / `db-rpc.server.ts` references any of the three mechanisms directly anymore.

## The interface

```ts
dequeueQueueEntry(
  | { by: { id: number }; userId: string; reason: string; workspaceId?: string }
  | {
      by: { contactId: number; campaignId?: number | null };
      userId: string | null;
      reason: string;
      workspaceId?: string;
      household?: boolean;   // see below
      exec?: RpcExecutor;    // tenant-scoped executor for the RPC path; built from workspaceId if omitted
    }
): Promise<void>
```

Routing:
- `by: { id }` → always plain-Drizzle by queue-row id (no contact to key a household lookup off of).
- `by: { contactId }`, `household` **omitted** → plain-Drizzle by contact, unconditional on the row's current `queue_state`, optionally scoped to `campaignId`.
- `by: { contactId }`, `household: true` → the RPC, fanned out to every contact sharing the source contact's `household_id` ("household is the unit of contact" — CONTEXT.md).
- `by: { contactId }`, `household: false` → **also the RPC**, but without fan-out. This is a real third mode, not an alias for the Drizzle default: `dequeue_contact`'s SQL only touches rows currently `queued`/null (see `client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql`), so it's a *guarded* dequeue that silently no-ops on a row in any other `queue_state`. Exactly one call site relies on this — see the census.

`household: false` vs omitted is distinguished by `=== undefined`, not truthiness, so it's not a footgun in practice, but it's the one subtle part of this interface — flagged here for review attention.

## Call-site census

| Site | Old mechanism | Migrated form |
|---|---|---|
| `auto-dial.server.ts:318` (ambiguous dial failure — park for review) | `rpcDequeueContact`, `groupOnHousehold: false` | `dequeueQueueEntry({ by: { contactId }, household: false, exec: tdb })` |
| `auto-dial.server.ts:336` (successful dial) | `rpcDequeueContact`, `groupOnHousehold: true` | `dequeueQueueEntry({ by: { contactId }, household: true, exec: tdb })` |
| `hangup.action.server.ts` | `rpcDequeueContact`, `groupOnHousehold: campaign?.group_household_queue ?? false` | same, via `household:` |
| `queues.action.server.ts` (manual dequeue button) | `rpcDequeueContact`, `groupOnHousehold: <client-supplied>` | same, via `household:` (client-supplied boolean, always defined) |
| `auto-dial/status.action.server.ts` | `rpcDequeueContact`, `groupOnHousehold: true` | `household: true` |
| `auto-dial/$roomId.action.server.ts` (local `dequeueContact` helper — already branched between mechanisms) | `rpcDequeueContact` (household branch) / `dequeueCampaignQueueByContact` (non-household branch, try/catch-wrapped) | both branches now call `dequeueQueueEntry`; try/catch preserved around the non-household call |
| `campaign-sms-dispatch.server.ts` ×3 (opt-out, landline, duplicate skips) | `dequeueCampaignQueueById` | `dequeueQueueEntry({ by: { id } })` |
| `campaign-sms-send.server.ts` (SMS sent) | `dequeueCampaignQueueById` | `dequeueQueueEntry({ by: { id } })` |
| `database/campaign.server.ts` (`splitMessageCampaign`, moved-to-segment) | `dequeueCampaignQueueById` | `dequeueQueueEntry({ by: { id } })` |
| `ivr-initiate.server.ts` | `dequeueCampaignQueueById` | `dequeueQueueEntry({ by: { id } })` |
| `routes/api+/ivr.action.server.ts` | `dequeueCampaignQueueById` | `dequeueQueueEntry({ by: { id } })` |
| `routes/api+/inbound-sms.action.server.ts` (STOP keyword) | `dequeueCampaignQueueByContact`, no campaignId (all campaigns) | `dequeueQueueEntry({ by: { contactId } })` |
| `routes/api+/questions.action.server.ts` (do-not-call disposition) | `dequeueCampaignQueueByContact`, no campaignId | `dequeueQueueEntry({ by: { contactId } })` |
| `campaign-queue-db.server.ts` internal (`claimNextQueueContact` opt-out-claim skip) | `dequeueCampaignQueueById` (same-file call) | left calling the (now-private) mechanism directly — already inside the module, no behavior change |

Every migrated call preserves its exact reason string, mechanism, `campaignId`/`workspaceId` scoping, and error handling (e.g. `$roomId.action.server.ts`'s custom "Error updating queue status: …" wrapper around the non-household branch is unchanged).

## Flagged, not fixed (behavior-preserving — did not touch)

1. **`auto-dial.server.ts:318`'s `household: false` (guarded RPC, no fan-out) instead of the Drizzle default.** This looked like it could just be an accident of "the RPC was already imported here" — but the two mechanisms are *not* interchangeable at this call site: by the time this line runs, the row was already claimed by `claim_next_queue_contact` (`queue_state = 'assigned'`), and `dequeue_contact`'s SQL only updates rows where `queue_state is null or queue_state = 'queued'`. Switching this call to the Drizzle path would be a real behavior change (Drizzle dequeues unconditionally regardless of current state), so it's preserved exactly as-is. Documented in `dequeueQueueEntry`'s doc comment.

2. **Possible pre-existing bug, out of scope for B3**: because of the same precondition, every `household: true`/`false` RPC-based dequeue call in this codebase (`auto-dial.server.ts`, `hangup.action.server.ts`, `queues.action.server.ts`, `auto-dial/status.action.server.ts`) fires *after* the target row has already transitioned to `queue_state = 'assigned'` (via `claim_next_queue_contact`, or by simply being an in-progress call). `dequeue_contact`'s WHERE clause (`client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql`) only touches rows in `queued`/null state, so — if I'm reading the SQL right — the primary contact's own row may never actually get dequeued by these calls; only `queued`/null household members would be swept by the fan-out branch. This predates B1/B2/B3 (confirmed present in `client/migrations/20260716140000_fix_dequeue_contact_bigint.sql`, the earliest version of this function). I have **not** verified this against a live Postgres instance and did not touch it — flagging for someone with a live-DB harness to confirm/refute, separate from this PR.

## Tests

- New `test/dequeue-queue-entry.test.ts`: unit tests for `dequeueQueueEntry`'s routing logic (by-id vs by-contact, `household` true/false/omitted, explicit `exec` vs auto-built tenant db, the `workspaceId`-required guard for the RPC path). `@/lib/db-rpc.server` is mocked wholesale so these only exercise routing, not the RPC's own household-lookup/emit behavior.
- Updated mocks/assertions in every touched test suite: `questions.route`, `sms-action.route`, `route-live-media-stream`, `inbound-sms.route`, `auto-dial.server`, `ivr.route`, `ivr-initiate.server`, `hangup.route`, `sms.route`, `queues.route`, `auto-dial-room.route`, `auto-dial-status`.
- Ran the three named integration tests (`atomic-manual-dial-claims`, `campaign-queue-throughput`, `scope-dequeue-and-outreach-attempt`) — unaffected (they assert against migration SQL text, not app code) and green.
- Full `vitest run -c vitest.node.config.ts`: 350 files / 2562 tests passed, 3 skipped (pre-existing, unrelated).
- `npm run typecheck`: clean.
- `node scripts/check-handlers.mjs` and `node scripts/check-db-rpcs.mjs`: both pass.

## Merge-conflict awareness

Edits are scoped tightly to the dequeue call expressions and their imports. `hangup.action.server.ts` and `dial.action` files are also touched by unmerged PR #1249 (TwiML construction) — this PR does not touch TwiML code in either file, so the two diffs should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>



Closes #1240 (final B-lane item; lands with #1245 and #1250).
