### PR TITLE
refactor(worker): typed enqueue call sites + requeue hatch (#1239 A3)

### DIFF
--- a/app/lib/admin-jobs.server.ts
+++ b/app/lib/admin-jobs.server.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, sql } from "drizzle-orm";
 import { job as jobTable } from "@/db/schema";
 import { adminDb } from "@/server/admin-db";
 import { logger } from "@/lib/logger.server";
+import { validateStoredJobParams } from "@/lib/worker/job-params.server";
 
 export const DEAD_LETTER_JOB_STATUS = "dead_letter";
 
@@ -27,7 +28,8 @@ export async function listRecentDeadLetteredJobs(limit = 25) {
 
 export type RequeueResult =
   | { ok: true; jobId: number; type: string }
-  | { ok: false; reason: "not_found" };
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "invalid_params"; error: string };
 
 /**
  * Return a dead-lettered job to the queue.
@@ -50,11 +52,39 @@ export type RequeueResult =
  * The status predicate is part of the UPDATE, not a preceding SELECT, so two
  * admins clicking at once cannot both requeue: the second matches no row and
  * gets `not_found`.
+ *
+ * Before flipping the status, the row's stored `type`/`params` are validated
+ * against the job registry (#1239 A3, `validateStoredJobParams`): a
+ * dead-lettered row can be any registered type with arbitrary stored params,
+ * so this can't be pinned to one literal type at compile time the way a
+ * normal enqueue call site can. Reinstating a row whose params no longer
+ * pass validation would just dead-letter it again on the next attempt, so
+ * that's rejected up front with a typed reason instead.
  */
 export async function requeueDeadLetteredJob(
   jobId: number,
   actorUserId: string,
 ): Promise<RequeueResult> {
+  const [existing] = await adminDb
+    .select({ type: jobTable.type, params: jobTable.params })
+    .from(jobTable)
+    .where(and(eq(jobTable.id, jobId), eq(jobTable.status, DEAD_LETTER_JOB_STATUS)));
+
+  if (!existing) {
+    return { ok: false, reason: "not_found" };
+  }
+
+  const validated = validateStoredJobParams(existing.type, existing.params);
+  if (!validated.ok) {
+    logger.error("admin.job.requeue_rejected", {
+      jobId,
+      jobType: existing.type,
+      actorUserId,
+      error: validated.error,
+    });
+    return { ok: false, reason: "invalid_params", error: validated.error };
+  }
+
   const [row] = await adminDb
     .update(jobTable)
     .set({

--- a/app/lib/campaign-execution.server.ts
+++ b/app/lib/campaign-execution.server.ts
@@ -1,4 +1,5 @@
-import { enqueueJob, type EnqueueJobResult } from "@/lib/worker/enqueue-job.server";
+import type { EnqueueJobResult } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { getCampaignReadiness, type CampaignReadinessIssue } from "@/lib/campaign-readiness";
 import { updateCampaignStatusInWorkspace } from "@/lib/campaign-ivr.server";
 import { CAMPAIGN_DISPATCH_JOB_TYPE } from "@/lib/worker/job-types.server";
@@ -80,7 +81,11 @@ export async function launchCampaign(args: {
   // For message campaigns, enqueue dispatch work.
   // Voice campaigns will be dispatched by the dialer.
   if (campaign.type === "message") {
-    const job = await enqueueJob({
+    // `campaignDispatchHandler` reads the campaign's own `status` column, not
+    // a `mode` param — this call never passed one through the schema either
+    // way (`campaign_dispatch`'s params are `campaignId`/`workspaceId`/`userId`
+    // only), so it's dropped here rather than smuggled in as an extra field.
+    const job = await enqueueRegisteredJob({
       type: CAMPAIGN_DISPATCH_JOB_TYPE,
       workspaceId,
       userId,
@@ -88,7 +93,6 @@ export async function launchCampaign(args: {
         workspaceId,
         campaignId: Number(campaignId),
         userId,
-        mode: status,
       },
       dedupe: { kind: "live", workspaceId, campaignId: Number(campaignId) },
       runAt: mode === "scheduled" ? campaign.start_date : undefined,

--- a/app/lib/twilio-open-sync.server.ts
+++ b/app/lib/twilio-open-sync.server.ts
@@ -5,7 +5,7 @@ import { createTenantDb } from "@/server/tenant-db";
 import { logger } from "@/lib/logger.server";
 import { processCallStatusWebhook } from "@/lib/twilio-call-status.server";
 import { updateMessageBySid } from "@/lib/message-db.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { SMS_STATUS_SIDE_EFFECTS_JOB_TYPE } from "@/lib/worker/job-types.server";
 import { isTerminalSmsStatus, normalizeSmsStatus } from "@/lib/sms-status";
 
@@ -164,12 +164,12 @@ export async function triggerTwilioOpenSync({
         // lost webhook would have run. The job + ledger are both idempotent,
         // so racing a late-arriving webhook cannot double-debit.
         if (isTerminalSmsStatus(normalizeSmsStatus(twilioStatus))) {
-          await enqueueJob({
+          await enqueueRegisteredJob({
             type: SMS_STATUS_SIDE_EFFECTS_JOB_TYPE,
             workspaceId,
             idempotencyKey: `sms_status_side_effects:${local.sid}:${twilioStatus}`,
             params: {
-              messageSid: local.sid,
+              sid: local.sid,
               twilioParams: {
                 MessageStatus: twilioStatus,
                 ...(errorCode != null ? { ErrorCode: String(errorCode) } : {}),

--- a/app/lib/worker/cron-job-enqueue-route.server.ts
+++ b/app/lib/worker/cron-job-enqueue-route.server.ts
@@ -1,9 +1,7 @@
 import { secureCompare } from "@/lib/secure-compare";
 import { data as routeData } from "react-router";
-import {
-  enqueueJob,
-  type EnqueueJobResult,
-} from "@/lib/worker/enqueue-job.server";
+import type { EnqueueJobResult } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob, type JobParamsMap } from "@/lib/worker/job-params.server";
 import type { SideEffect } from "@/lib/handler.server";
 
 function toEnqueueResponse(result: EnqueueJobResult) {
@@ -34,13 +32,20 @@ export function parseCronWorkspaceId(
 /**
  * Legacy HTTP cron entry points enqueue coordinator/workspace jobs only.
  * WS-A: Bun worker owns execution after enqueue.
+ *
+ * `type` is narrowed to a registered job type and `buildParams` must return
+ * that type's zod-inferred params shape (#1239 A3) — `body` is still an
+ * untrusted `Record<string, unknown>` parsed straight off the request, so
+ * `buildParams` is where callers narrow individual fields out of it (see
+ * `twilio-open-sync.action.server.ts`'s `typeof body.callLimit === "number"`
+ * checks) rather than spreading it wholesale into `params`.
  */
-export function createCronEnqueueAction(args: {
-  type: string;
+export function createCronEnqueueAction<Type extends keyof JobParamsMap & string>(args: {
+  type: Type;
   buildParams: (
     body: Record<string, unknown>,
     workspaceId?: string,
-  ) => Record<string, unknown>;
+  ) => JobParamsMap[Type];
   /** Downstream effects of the enqueued job (e.g. "credit" for billing jobs). */
   extraSideEffects?: SideEffect[];
 }): {
@@ -58,7 +63,7 @@ export function createCronEnqueueAction(args: {
         () => ({} as Record<string, unknown>),
       );
       const workspaceId = parseCronWorkspaceId(body);
-      const result = await enqueueJob({
+      const result = await enqueueRegisteredJob({
         type: args.type,
         workspaceId,
         params: args.buildParams(body, workspaceId),

--- a/app/lib/worker/enqueue-job.server.ts
+++ b/app/lib/worker/enqueue-job.server.ts
@@ -249,8 +249,17 @@ async function enqueueWithLiveDedupe(args: {
  * - `idempotency`: unique key; revives dead-letter rows on conflict
  * - `live`: skip if queued/running row of same type (+ optional workspace) exists
  * - `none`: always insert
+ *
+ * UNSAFE: `type`/`params` are untyped strings/records here — a typo'd type or
+ * a mismatched params shape compiles fine and only surfaces later as a
+ * dead-lettered job. This is the raw primitive the job registry
+ * (`job-registry.server.ts`'s `createTypedEnqueue`/`createRequeueStoredJob`)
+ * wraps; it's the only intended caller (#1239 A3). New call sites should go
+ * through `enqueueRegisteredJob` (typed to a registered job type) or, for
+ * genuinely dynamic types, `requeueStoredJob`/`validateStoredJobParams` — not
+ * this function directly.
  */
-export async function enqueueJob(
+export async function unsafeEnqueueJob(
   args: EnqueueJobArgs,
 ): Promise<EnqueueJobResult> {
   const params = addRequestIdToJobParams(args.params ?? {});

--- a/app/lib/worker/ensure-scheduled-jobs.server.ts
+++ b/app/lib/worker/ensure-scheduled-jobs.server.ts
@@ -12,7 +12,7 @@
  */
 
 import { logger } from "@/lib/logger.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { requeueStoredJob } from "@/lib/worker/job-params.server";
 import {
   SELF_SCHEDULING_JOB_TYPES,
   SELF_SCHEDULING_SEED_PARAMS,
@@ -32,16 +32,21 @@ export async function ensureSelfSchedulingJobsSeeded(): Promise<{
   for (const type of SELF_SCHEDULING_JOB_TYPES) {
     try {
       const params = SELF_SCHEDULING_SEED_PARAMS[type] ?? {};
-      const result = await enqueueJob({
-        type,
-        params,
-        dedupe: { kind: "live" },
-      });
-      if (result.enqueued) {
+      // `type` here is a runtime-derived `string` (iterating every
+      // self-scheduling type, not one compile-time-known literal), so this
+      // goes through the `requeueStoredJob` escape hatch rather than the
+      // per-literal-typed `enqueueRegisteredJob` — see that function's doc
+      // comment in job-registry.server.ts.
+      const outcome = await requeueStoredJob(type, params, { dedupe: { kind: "live" } });
+      if (!outcome.ok) {
+        logger.error("worker.schedule_seed.failed", { type, error: outcome.error });
+        continue;
+      }
+      if (outcome.result.enqueued) {
         seeded.push(type);
         logger.info("worker.schedule_seed.inserted", {
           type,
-          jobId: result.jobId,
+          jobId: outcome.result.jobId,
         });
       }
     } catch (error) {

--- a/app/lib/worker/handlers.server.ts
+++ b/app/lib/worker/handlers.server.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import {
   CALL_STATUS_SIDE_EFFECTS_JOB_TYPE,
   CAMPAIGN_DISPATCH_JOB_TYPE,
@@ -7,20 +6,27 @@ import {
   SMS_STATUS_SIDE_EFFECTS_JOB_TYPE,
   WEBHOOK_DELIVERY_JOB_TYPE,
   ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE,
+  TWILIO_WEBHOOK_AUDIT_JOB_TYPE,
+  WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
 } from "@/lib/worker/job-types.server";
 import type { JobHandlers } from "@/lib/worker/poll-jobs.server";
+import { defineJob, type RegisteredJob } from "@/lib/worker/job-registry.server";
 import {
-  createTypedEnqueue,
-  defineJob,
-  legacyNullableStringParam,
-  legacyNumericParam,
-  legacyObjectParam,
-  legacyRequiredNumberParam,
-  legacyRequiredObjectParam,
-  legacyRequiredStringParam,
-  legacyStringParam,
-  type RegisteredJob,
-} from "@/lib/worker/job-registry.server";
+  audienceUploadParams,
+  billingReconcileParams,
+  callStatusSideEffectsParams,
+  campaignDispatchParams,
+  campaignExportParams,
+  elevenlabsBatchTranscribeParams,
+  noParams,
+  numberRentalBillingParams,
+  recordingSideEffectsParams,
+  smsStatusSideEffectsParams,
+  twilioOpenSyncParams,
+  twilioWebhookAuditParams,
+  webhookDeliveryParams,
+  workspaceTwilioComplianceParams,
+} from "@/lib/worker/job-params.server";
 import {
   billingReconcileHandler,
   campaignScheduleSyncHandler,
@@ -28,12 +34,10 @@ import {
   numberRentalBillingHandler,
   twilioOpenSyncHandler,
   twilioWebhookAuditHandler,
-  TWILIO_WEBHOOK_AUDIT_JOB_TYPE,
 } from "./handlers/cron.server";
 import {
   callStatusSideEffectsHandler,
   recordingSideEffectsHandler,
-  sidAndTwilioParamsSchema,
   smsStatusSideEffectsHandler,
 } from "./handlers/webhook-adapters.server";
 import {
@@ -42,12 +46,23 @@ import {
   campaignExportHandler,
   enqueueWorkspaceComplianceJob,
   webhookDeliveryHandler,
-  WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
   workspaceTwilioComplianceHandler,
 } from "./handlers/campaign.server";
 import { elevenlabsBatchTranscribeHandler } from "./handlers/elevenlabs-batch-transcribe.server";
 
 export { enqueueWorkspaceComplianceJob };
+
+// The typed enqueue/requeue surface (`enqueueRegisteredJob`,
+// `requeueStoredJob`, `validateStoredJobParams`) is built in
+// `job-params.server.ts` from the SAME schema objects imported above, and
+// re-exported here as the canonical registry surface for callers outside the
+// worker/handlers tree (routes, campaign-execution.server.ts, etc). Handler
+// implementation files that need to enqueue/self-reschedule (cron.server.ts,
+// campaign.server.ts, webhook-side-effects.server.ts, twilio-open-sync.server.ts)
+// import directly from job-params.server.ts instead of from here, to avoid a
+// module cycle — see that module's doc comment for why.
+export { enqueueRegisteredJob, requeueStoredJob, validateStoredJobParams } from "@/lib/worker/job-params.server";
+export type { JobParamsMap } from "@/lib/worker/job-params.server";
 
 /**
  * The worker job registry (ADR-0007, #1239).
@@ -60,169 +75,17 @@ export { enqueueWorkspaceComplianceJob };
  * Every job type is registered via `defineJob`: params are validated with a
  * zod schema before the handler runs (#1239 A1 landed the mechanism plus
  * three proof-of-concept types; A2 migrated the remaining twelve off the
- * `legacyJob` escape hatch, which no longer exists). Each schema below is a
+ * `legacyJob` escape hatch, which no longer exists; A3 migrated every
+ * production enqueue call site onto the typed `enqueueRegisteredJob` built
+ * from these same schemas — see `job-params.server.ts`). Each schema is a
  * direct translation of the hand-rolled `typeof`-narrowing its handler used
  * to do — see the PR body for a per-type equivalence note (exactly-equivalent
  * vs. deliberately-looser-than-the-old-narrowing, and why).
  */
 
-const twilioOpenSyncParams = z.object({
-  callLimit: legacyNumericParam(50),
-  messageLimit: legacyNumericParam(50),
-  maxAgeMinutes: legacyNumericParam(120),
-});
-
-const billingReconcileParams = z.object({
-  workspaceId: z.string().optional(),
-});
-
-const elevenlabsBatchTranscribeParams = z.object({
-  callSid: z.preprocess(
-    (value) => (typeof value === "string" ? value : ""),
-    z.string().min(1, "elevenlabs_batch_transcribe: missing callSid"),
-  ),
-});
-
-/**
- * `workspace_twilio_compliance` — `reason` defaulted to `"worker"` in the
- * handler (`requireStringParam(params, "reason") ?? "worker"`); `workspaceId`
- * and `actorUserId` are resolved against `job.workspace_id`/`job.user_id`
- * first, so both stay optional here. Exactly equivalent.
- */
-const workspaceTwilioComplianceParams = z.object({
-  workspaceId: legacyStringParam(),
-  reason: legacyStringParam().default("worker"),
-  actorUserId: legacyStringParam(),
-});
-
-/**
- * `audience_upload` — the widest hand-rolled narrowing in the worker.
- * `uploadId`/`audienceId` were `requireNumberParam(...)` then combined into a
- * bundled `if (!uploadId || !audienceId || !workspaceId || !userId) throw`;
- * split into per-field zod failures here (still rejects the same falsy
- * values, including a coerced `0` — see `legacyRequiredNumberParam`).
- * `workspaceId`/`userId` are still resolved against the job row in the
- * handler, so they stay optional in the schema. `headerMapping` and
- * `voterListSource` are DELIBERATELY LOOSER than a "real" schema would be:
- * the old code only checked `typeof`, never validated `headerMapping`'s
- * values are strings or that `voterListSource` is one of the six enum
- * members it's typed as (see `normalizeVoterListSource`, which already runs
- * at the one enqueue site) — this schema preserves that permissiveness so an
- * already-queued row with a shape the old code would have blindly accepted
- * doesn't dead-letter.
- */
-const audienceUploadParams = z.object({
-  uploadId: legacyRequiredNumberParam("audience_upload: missing or invalid uploadId"),
-  audienceId: legacyRequiredNumberParam("audience_upload: missing or invalid audienceId"),
-  workspaceId: legacyStringParam(),
-  userId: legacyStringParam(),
-  fileContent: legacyStringParam().default(""),
-  headerMapping: legacyObjectParam<Record<string, string>>({}),
-  splitNameColumn: legacyNullableStringParam(),
-  voterListSource: legacyNullableStringParam(),
-});
-
-/**
- * `campaign_schedule_sync` / `low_credit_notify` — neither handler ever reads
- * `job.params`. `z.unknown()` accepts anything, matching that.
- */
-const noParams = z.unknown();
-
-/**
- * `twilio_webhook_audit` — `autoRepair` defaulted to `true` unless explicitly
- * `false` (`params.autoRepair !== false`); the workspace fanout always runs
- * across every workspace and never reads a `workspaceId` param. Exactly
- * equivalent.
- */
-const twilioWebhookAuditParams = z.object({
-  autoRepair: z.preprocess((value) => value !== false, z.boolean()),
-});
-
-/**
- * `number_rental_billing` — only `workspaceId` is read, resolved against
- * `job.workspace_id` first and never required (absence means "fan out across
- * every workspace"). Exactly equivalent.
- */
-const numberRentalBillingParams = z.object({
-  workspaceId: legacyStringParam(),
-});
-
-/**
- * `campaign_export` — `campaignId`/`exportId`/`campaignType` were bundled
- * into one `if (!x || !y...) throw "missing campaignId, exportId,
- * workspaceId, or campaignType"` alongside `workspaceId`; split into
- * per-field zod failures for the three pure-params fields (still rejects the
- * same falsy values), `workspaceId` stays optional here since it's resolved
- * against `job.workspace_id` in the handler. `campaignType`'s
- * message/live_call/robocall restriction is business logic, not narrowing —
- * it stays in the handler exactly as before (same "unsupported campaign
- * type" error). Exactly equivalent.
- */
-const campaignExportParams = z.object({
-  campaignId: legacyRequiredNumberParam("campaign_export: missing or invalid campaignId"),
-  exportId: legacyRequiredStringParam("campaign_export: missing exportId"),
-  campaignName: legacyStringParam().default(""),
-  campaignType: legacyRequiredStringParam("campaign_export: missing campaignType"),
-  workspaceId: legacyStringParam(),
-});
-
-/**
- * `campaign_dispatch` — `campaignId` is a pure params field (required, same
- * falsy-including-`0` rejection as the old bundled check); `workspaceId` and
- * `userId` are resolved against the job row in the handler, exactly as
- * before, including the separate "missing userId (launching actor)" error.
- * Exactly equivalent.
- */
-const campaignDispatchParams = z.object({
-  campaignId: legacyRequiredNumberParam("campaign_dispatch: missing or invalid campaignId"),
-  workspaceId: legacyStringParam(),
-  userId: legacyStringParam(),
-});
-
-/**
- * `webhook_delivery` — `eventCategory`/`eventType`/`payload` were bundled
- * into the same "missing workspaceId, eventCategory, eventType, or payload"
- * check as `workspaceId`; split into per-field zod failures for the three
- * pure-params fields, `workspaceId` stays optional (resolved against
- * `job.workspace_id`). `eventType` is validated against the same two-value
- * enum the old ternary checked (`"INSERT" | "UPDATE"`, anything else was
- * already treated as missing). `optional` mirrors the old `=== true` check.
- * Exactly equivalent.
- */
-const webhookDeliveryParams = z.object({
-  workspaceId: legacyStringParam(),
-  eventCategory: legacyRequiredStringParam("webhook_delivery: missing eventCategory"),
-  eventType: z.enum(["INSERT", "UPDATE"]),
-  payload: legacyRequiredObjectParam("webhook_delivery: missing payload"),
-  optional: z.preprocess((value) => value === true, z.boolean()),
-});
-
-/**
- * `call_status_side_effects` / `sms_status_side_effects` /
- * `recording_side_effects` — all three used to call the same
- * `requireSidAndTwilioParams(job, sidKey, label)` helper in
- * webhook-adapters.server.ts; that's now `sidAndTwilioParamsSchema(sidKey,
- * label)`, one shared factory instead of three copies. `twilioParams` is
- * DELIBERATELY LOOSER than a "real" schema: the old code never validated its
- * values are strings (just `typeof value === "object" && value !== null`),
- * and neither does `legacyObjectParam`. Exactly equivalent otherwise.
- */
-const callStatusSideEffectsParams = sidAndTwilioParamsSchema(
-  "callSid",
-  "call_status_side_effects",
-);
-const smsStatusSideEffectsParams = sidAndTwilioParamsSchema(
-  "messageSid",
-  "sms_status_side_effects",
-);
-const recordingSideEffectsParams = sidAndTwilioParamsSchema(
-  "callSid",
-  "recording_side_effects",
-);
-
-// Kept as its own (non-widened) tuple so `createTypedEnqueue` below can infer
-// each registration's literal `type` and its zod-inferred `Params` — spread
-// into `jobRegistry` as plain `RegisteredJob`s further down.
+// Kept as its own (non-widened) tuple so a future consumer needing the
+// literal `type`/`Params` union can still infer it — spread into
+// `jobRegistry` as plain `RegisteredJob`s further down.
 const registrations = [
   defineJob({
     type: "twilio_open_sync",
@@ -319,16 +182,6 @@ export const jobRegistry: RegisteredJob[] = [...registrations];
 export const jobHandlers: JobHandlers = Object.fromEntries(
   jobRegistry.map((registration) => [registration.type, registration.jobHandler]),
 );
-
-/**
- * Typed `enqueueJob`, narrowed to every registered job type: `type` is a
- * literal union instead of `string`, and `params` must match that type's zod
- * schema — an enqueue-time typo or shape mismatch is now a compile error (or
- * a `ZodError` at call time) instead of a dead-lettered job discovered later.
- * Wraps `enqueueJob`; existing untyped callers are unaffected. No call site
- * has been migrated onto this yet — that's #1239 A3.
- */
-export const enqueueRegisteredJob = createTypedEnqueue(registrations);
 
 /**
  * Job types whose permanent failure warrants waking someone: the two billing

--- a/app/lib/worker/handlers/campaign.server.ts
+++ b/app/lib/worker/handlers/campaign.server.ts
@@ -5,9 +5,12 @@ import {
 } from "@/lib/campaign-export.server";
 import { sendWorkspaceWebhookNotification } from "@/lib/workspace-webhooks.server";
 import { runWorkspaceTwilioComplianceJob } from "@/lib/twilio-compliance-job.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { dispatchCampaignSmsBatch } from "@/lib/campaign-sms-dispatch.server";
-import { CAMPAIGN_DISPATCH_JOB_TYPE } from "@/lib/worker/job-types.server";
+import {
+  CAMPAIGN_DISPATCH_JOB_TYPE,
+  WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
+} from "@/lib/worker/job-types.server";
 import {
   findCampaignInWorkspace,
   updateCampaignStatusInWorkspace,
@@ -19,7 +22,10 @@ import { logger } from "@/lib/logger.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
 import type { VoterListSource } from "@/lib/audience-upload-process.server";
 
-export const WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE = "workspace_twilio_compliance";
+// Re-exported for backwards compatibility: moved to job-types.server.ts in
+// #1239 A3 so job-params.server.ts can reference it without importing this
+// file (see job-params.server.ts's doc comment for why that'd cycle).
+export { WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE };
 
 export type AudienceUploadParams = {
   uploadId: number;
@@ -89,10 +95,10 @@ export async function enqueueWorkspaceComplianceJob(
   workspaceId: string,
   reason: string,
 ): Promise<void> {
-  const result = await enqueueJob({
+  const result = await enqueueRegisteredJob({
     type: WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
     workspaceId,
-    params: { workspaceId, reason },
+    params: { workspaceId, reason, actorUserId: undefined },
     dedupe: { kind: "live", workspaceId },
   });
   if (result.deduped) {
@@ -161,7 +167,7 @@ async function enqueueDispatchSuccessor(args: {
   completedJobId: number;
   delayMs: number;
 }): Promise<void> {
-  await enqueueJob({
+  await enqueueRegisteredJob({
     type: CAMPAIGN_DISPATCH_JOB_TYPE,
     workspaceId: args.workspaceId,
     userId: args.userId,

--- a/app/lib/worker/handlers/cron.server.ts
+++ b/app/lib/worker/handlers/cron.server.ts
@@ -15,6 +15,7 @@ import {
 import { listAllWorkspacesOrdered } from "@/lib/workspace-members-db.server";
 import { logger } from "@/lib/logger.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
+import { TWILIO_WEBHOOK_AUDIT_JOB_TYPE } from "@/lib/worker/job-types.server";
 import { withReschedule } from "./shared.server";
 
 const LOW_CREDIT_NOTIFY_RESCHEDULE_MS = 24 * 60 * 60 * 1000;
@@ -27,7 +28,10 @@ const TWILIO_WEBHOOK_AUDIT_RESCHEDULE_MS = 6 * 60 * 60 * 1000;
 // campaign needs a transition.
 const CAMPAIGN_SCHEDULE_SYNC_RESCHEDULE_MS = 60 * 1000;
 
-export const TWILIO_WEBHOOK_AUDIT_JOB_TYPE = "twilio_webhook_audit";
+// Re-exported for backwards compatibility: moved to job-types.server.ts in
+// #1239 A3 so job-params.server.ts can reference it without importing this
+// file (see job-params.server.ts's doc comment for why that'd cycle).
+export { TWILIO_WEBHOOK_AUDIT_JOB_TYPE };
 
 type TwilioWebhookAuditWorkspaceResult = {
   workspaceId: string;
@@ -109,6 +113,7 @@ export async function billingReconcileHandler(job: ClaimedJobRow): Promise<unkno
     {
       type: "billing_reconcile",
       delayMs: BILLING_RECONCILE_RESCHEDULE_MS,
+      params: {},
       completedJobId: job.id,
       enabled: !workspaceId,
     },
@@ -154,6 +159,7 @@ export async function numberRentalBillingHandler(
     {
       type: "number_rental_billing",
       delayMs: NUMBER_RENTAL_BILLING_RESCHEDULE_MS,
+      params: { workspaceId: undefined },
       completedJobId: job.id,
       enabled: !workspaceId,
     },
@@ -172,6 +178,7 @@ export async function lowCreditNotifyHandler(job: ClaimedJobRow): Promise<unknow
     {
       type: "low_credit_notify",
       delayMs: LOW_CREDIT_NOTIFY_RESCHEDULE_MS,
+      params: {},
       completedJobId: job.id,
     },
     async () => {
@@ -231,6 +238,7 @@ export async function campaignScheduleSyncHandler(job: ClaimedJobRow): Promise<u
     {
       type: "campaign_schedule_sync",
       delayMs: CAMPAIGN_SCHEDULE_SYNC_RESCHEDULE_MS,
+      params: {},
       completedJobId: job.id,
     },
     () => runCampaignScheduleSync(),
@@ -248,6 +256,11 @@ export async function twilioWebhookAuditHandler(
     {
       type: TWILIO_WEBHOOK_AUDIT_JOB_TYPE,
       delayMs: TWILIO_WEBHOOK_AUDIT_RESCHEDULE_MS,
+      // Matches the pre-#1239-A3 behaviour exactly: the reschedule never
+      // carried the current job's `autoRepair` forward, and the schema
+      // defaults a missing value to `true` (`v !== false`) — spelled out
+      // explicitly here since the typed schema requires the key.
+      params: { autoRepair: true },
       completedJobId: job.id,
     },
     () => runTwilioWebhookAudit(params.autoRepair),

--- a/app/lib/worker/handlers/shared.server.ts
+++ b/app/lib/worker/handlers/shared.server.ts
@@ -1,5 +1,5 @@
 import { logger } from "@/lib/logger.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob, type JobParamsMap } from "@/lib/worker/job-params.server";
 
 /**
  * Run a self-scheduling job's work, guaranteeing the next occurrence is
@@ -15,11 +15,11 @@ import { enqueueJob } from "@/lib/worker/enqueue-job.server";
  * on a live row excluding this job, so a retry of the same job finds the
  * successor already queued and no-ops.
  */
-export async function withReschedule<T>(
+export async function withReschedule<T, Type extends keyof JobParamsMap & string>(
   args: {
-    type: string;
+    type: Type;
     delayMs: number;
-    params?: Record<string, unknown>;
+    params: JobParamsMap[Type];
     completedJobId: number;
     /** Skip for per-workspace child jobs; only the root job carries the chain. */
     enabled?: boolean;
@@ -33,7 +33,7 @@ export async function withReschedule<T>(
       await rescheduleJob(
         args.type,
         args.delayMs,
-        args.params ?? {},
+        args.params,
         args.completedJobId,
       );
     }
@@ -41,17 +41,20 @@ export async function withReschedule<T>(
 }
 
 /**
- * Enqueue the next run of a self-scheduling cron/coordinator job.
+ * Enqueue the next run of a self-scheduling cron/coordinator job. Typed
+ * (#1239 A3) against the same registered-job param schemas every other
+ * enqueue call site validates against — `type` must be a registered job
+ * type, and `params` must match its zod-inferred shape at compile time.
  */
-export async function rescheduleJob(
-  type: string,
+export async function rescheduleJob<Type extends keyof JobParamsMap & string>(
+  type: Type,
   delayMs: number,
-  params: Record<string, unknown>,
+  params: JobParamsMap[Type],
   completedJobId: number,
 ): Promise<void> {
   const nextRunAt = new Date(Date.now() + delayMs).toISOString();
   try {
-    await enqueueJob({
+    await enqueueRegisteredJob({
       type,
       params,
       runAt: nextRunAt,

--- a/app/lib/worker/handlers/webhook-adapters.server.ts
+++ b/app/lib/worker/handlers/webhook-adapters.server.ts
@@ -1,51 +1,13 @@
-import { z } from "zod";
 import {
   runCallStatusSideEffects,
   runRecordingSideEffects,
   runSmsStatusSideEffects,
 } from "@/lib/worker/webhook-side-effects.server";
 import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
-import { legacyObjectParam, legacyStringParam } from "@/lib/worker/job-registry.server";
-
-export type SidAndTwilioParams = {
-  sid: string;
-  twilioParams: Record<string, string>;
-};
-
-/**
- * Shared params schema for the three Twilio webhook fast-ack side-effect job
- * types (#1239 A2): each one used to re-implement the same
- * `requireSidAndTwilioParams` narrowing (sid key differs, everything else is
- * identical). One factory, parameterized on the sid field name and the label
- * used in the error message, replaces all three copies.
- *
- * Both `callSid` and `messageSid` are read from `job.params` regardless of
- * which one this job type actually uses — matching the old code, which read
- * `job.params[sidKey]` and simply never looked at the other key.
- */
-export function sidAndTwilioParamsSchema(
-  sidKey: "callSid" | "messageSid",
-  label: string,
-): z.ZodType<SidAndTwilioParams> {
-  return z
-    .object({
-      callSid: legacyStringParam(),
-      messageSid: legacyStringParam(),
-      twilioParams: legacyObjectParam<Record<string, string> | undefined>(undefined),
-    })
-    .transform((value, ctx) => {
-      const sid = sidKey === "callSid" ? value.callSid : value.messageSid;
-      const twilioParams = value.twilioParams;
-      if (!sid || !twilioParams) {
-        ctx.addIssue({
-          code: "custom",
-          message: `${label}: missing ${sidKey} or twilioParams`,
-        });
-        return z.NEVER;
-      }
-      return { sid, twilioParams };
-    });
-}
+// `sidAndTwilioParamsSchema` moved to job-registry.server.ts in #1239 A3 so
+// job-params.server.ts (schema-only) can build these registrations without
+// depending on this file — see that module's doc comment for why.
+import type { SidAndTwilioParams } from "@/lib/worker/job-registry.server";
 
 export async function callStatusSideEffectsHandler(
   job: ClaimedJobRow,

--- a/app/lib/worker/job-params.server.ts
+++ b/app/lib/worker/job-params.server.ts
@@ -1,0 +1,239 @@
+import { z } from "zod";
+import {
+  createRequeueStoredJob,
+  createTypedEnqueue,
+  createValidateStoredJobParams,
+  legacyNullableStringParam,
+  legacyNumericParam,
+  legacyObjectParam,
+  legacyRequiredNumberParam,
+  legacyRequiredObjectParam,
+  legacyRequiredStringParam,
+  legacyStringParam,
+  sidAndTwilioParamsSchema,
+  type JobParamsEntry,
+} from "@/lib/worker/job-registry.server";
+import {
+  CALL_STATUS_SIDE_EFFECTS_JOB_TYPE,
+  CAMPAIGN_DISPATCH_JOB_TYPE,
+  CAMPAIGN_EXPORT_JOB_TYPE,
+  ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE,
+  RECORDING_SIDE_EFFECTS_JOB_TYPE,
+  SMS_STATUS_SIDE_EFFECTS_JOB_TYPE,
+  TWILIO_WEBHOOK_AUDIT_JOB_TYPE,
+  WEBHOOK_DELIVERY_JOB_TYPE,
+  WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE,
+} from "@/lib/worker/job-types.server";
+
+/**
+ * Every registered job type's params schema, plus the typed enqueue/requeue
+ * surface built from them (#1239 A3).
+ *
+ * This is a separate module from `handlers.server.ts` on purpose:
+ * `handlers.server.ts` imports handler IMPLEMENTATIONS from files like
+ * `handlers/cron.server.ts` and `handlers/campaign.server.ts` to build
+ * `defineJob` registrations (schema + handler + paging/schedule metadata).
+ * Several of those same implementation files need to enqueue/self-reschedule
+ * jobs — if they imported `enqueueRegisteredJob` from `handlers.server.ts`,
+ * that would cycle straight back through the file that imports them
+ * (`handlers.server.ts` -> `handlers/cron.server.ts` -> `handlers.server.ts`).
+ *
+ * This module has zero dependency on any handler implementation (only
+ * `job-registry.server.ts`'s mechanism + `job-types.server.ts`'s literal job
+ * type constants), so handler-implementation files can import
+ * `enqueueRegisteredJob`/`requeueStoredJob` from HERE instead, with no cycle.
+ * `handlers.server.ts` imports these same schema objects to build its
+ * `defineJob` registrations, so both the enqueue side and the dequeue side
+ * validate against the exact same schema instance — see
+ * `test/job-registry.test.ts` for the guard that keeps the two lists in sync.
+ */
+
+export const twilioOpenSyncParams = z.object({
+  callLimit: legacyNumericParam(50),
+  messageLimit: legacyNumericParam(50),
+  maxAgeMinutes: legacyNumericParam(120),
+});
+
+export const billingReconcileParams = z.object({
+  workspaceId: z.string().optional(),
+});
+
+export const elevenlabsBatchTranscribeParams = z.object({
+  callSid: z.preprocess(
+    (value) => (typeof value === "string" ? value : ""),
+    z.string().min(1, "elevenlabs_batch_transcribe: missing callSid"),
+  ),
+});
+
+/**
+ * `workspace_twilio_compliance` — `reason` defaulted to `"worker"` in the
+ * handler (`requireStringParam(params, "reason") ?? "worker"`); `workspaceId`
+ * and `actorUserId` are resolved against `job.workspace_id`/`job.user_id`
+ * first, so both stay optional here. Exactly equivalent.
+ */
+export const workspaceTwilioComplianceParams = z.object({
+  workspaceId: legacyStringParam(),
+  reason: legacyStringParam().default("worker"),
+  actorUserId: legacyStringParam(),
+});
+
+/**
+ * `audience_upload` — the widest hand-rolled narrowing in the worker.
+ * `uploadId`/`audienceId` were `requireNumberParam(...)` then combined into a
+ * bundled `if (!uploadId || !audienceId || !workspaceId || !userId) throw`;
+ * split into per-field zod failures here (still rejects the same falsy
+ * values, including a coerced `0` — see `legacyRequiredNumberParam`).
+ * `workspaceId`/`userId` are still resolved against the job row in the
+ * handler, so they stay optional in the schema. `headerMapping` and
+ * `voterListSource` are DELIBERATELY LOOSER than a "real" schema would be:
+ * the old code only checked `typeof`, never validated `headerMapping`'s
+ * values are strings or that `voterListSource` is one of the six enum
+ * members it's typed as (see `normalizeVoterListSource`, which already runs
+ * at the one enqueue site) — this schema preserves that permissiveness so an
+ * already-queued row with a shape the old code would have blindly accepted
+ * doesn't dead-letter.
+ */
+export const audienceUploadParams = z.object({
+  uploadId: legacyRequiredNumberParam("audience_upload: missing or invalid uploadId"),
+  audienceId: legacyRequiredNumberParam("audience_upload: missing or invalid audienceId"),
+  workspaceId: legacyStringParam(),
+  userId: legacyStringParam(),
+  fileContent: legacyStringParam().default(""),
+  headerMapping: legacyObjectParam<Record<string, string>>({}),
+  splitNameColumn: legacyNullableStringParam(),
+  voterListSource: legacyNullableStringParam(),
+});
+
+/**
+ * `campaign_schedule_sync` / `low_credit_notify` — neither handler ever reads
+ * `job.params`. `z.unknown()` accepts anything, matching that.
+ */
+export const noParams = z.unknown();
+
+/**
+ * `twilio_webhook_audit` — `autoRepair` defaulted to `true` unless explicitly
+ * `false` (`params.autoRepair !== false`); the workspace fanout always runs
+ * across every workspace and never reads a `workspaceId` param. Exactly
+ * equivalent.
+ */
+export const twilioWebhookAuditParams = z.object({
+  autoRepair: z.preprocess((value) => value !== false, z.boolean()),
+});
+
+/**
+ * `number_rental_billing` — only `workspaceId` is read, resolved against
+ * `job.workspace_id` first and never required (absence means "fan out across
+ * every workspace"). Exactly equivalent.
+ */
+export const numberRentalBillingParams = z.object({
+  workspaceId: legacyStringParam(),
+});
+
+/**
+ * `campaign_export` — `campaignId`/`exportId`/`campaignType` were bundled
+ * into one `if (!x || !y...) throw "missing campaignId, exportId,
+ * workspaceId, or campaignType"` alongside `workspaceId`; split into
+ * per-field zod failures for the three pure-params fields (still rejects the
+ * same falsy values), `workspaceId` stays optional here since it's resolved
+ * against `job.workspace_id` in the handler. `campaignType`'s
+ * message/live_call/robocall restriction is business logic, not narrowing —
+ * it stays in the handler exactly as before (same "unsupported campaign
+ * type" error). Exactly equivalent.
+ */
+export const campaignExportParams = z.object({
+  campaignId: legacyRequiredNumberParam("campaign_export: missing or invalid campaignId"),
+  exportId: legacyRequiredStringParam("campaign_export: missing exportId"),
+  campaignName: legacyStringParam().default(""),
+  campaignType: legacyRequiredStringParam("campaign_export: missing campaignType"),
+  workspaceId: legacyStringParam(),
+});
+
+/**
+ * `campaign_dispatch` — `campaignId` is a pure params field (required, same
+ * falsy-including-`0` rejection as the old bundled check); `workspaceId` and
+ * `userId` are resolved against the job row in the handler, exactly as
+ * before, including the separate "missing userId (launching actor)" error.
+ * Exactly equivalent.
+ */
+export const campaignDispatchParams = z.object({
+  campaignId: legacyRequiredNumberParam("campaign_dispatch: missing or invalid campaignId"),
+  workspaceId: legacyStringParam(),
+  userId: legacyStringParam(),
+});
+
+/**
+ * `webhook_delivery` — `eventCategory`/`eventType`/`payload` were bundled
+ * into the same "missing workspaceId, eventCategory, eventType, or payload"
+ * check as `workspaceId`; split into per-field zod failures for the three
+ * pure-params fields, `workspaceId` stays optional (resolved against
+ * `job.workspace_id`). `eventType` is validated against the same two-value
+ * enum the old ternary checked (`"INSERT" | "UPDATE"`, anything else was
+ * already treated as missing). `optional` mirrors the old `=== true` check.
+ * Exactly equivalent.
+ */
+export const webhookDeliveryParams = z.object({
+  workspaceId: legacyStringParam(),
+  eventCategory: legacyRequiredStringParam("webhook_delivery: missing eventCategory"),
+  eventType: z.enum(["INSERT", "UPDATE"]),
+  payload: legacyRequiredObjectParam("webhook_delivery: missing payload"),
+  optional: z.preprocess((value) => value === true, z.boolean()),
+});
+
+export const callStatusSideEffectsParams = sidAndTwilioParamsSchema(
+  "callSid",
+  "call_status_side_effects",
+);
+export const smsStatusSideEffectsParams = sidAndTwilioParamsSchema(
+  "messageSid",
+  "sms_status_side_effects",
+);
+export const recordingSideEffectsParams = sidAndTwilioParamsSchema(
+  "callSid",
+  "recording_side_effects",
+);
+
+/**
+ * Every registered job type's `{type, params}` pair. `handlers.server.ts`
+ * builds its `defineJob` registrations from these SAME schema objects
+ * (imported, not redeclared) — see `test/job-registry.test.ts` for the drift
+ * guard that keeps this list and `jobRegistry` in sync.
+ */
+export const jobParamsRegistry = [
+  { type: "twilio_open_sync", params: twilioOpenSyncParams },
+  { type: "billing_reconcile", params: billingReconcileParams },
+  { type: ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE, params: elevenlabsBatchTranscribeParams },
+  { type: WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE, params: workspaceTwilioComplianceParams },
+  { type: "campaign_schedule_sync", params: noParams },
+  { type: "number_rental_billing", params: numberRentalBillingParams },
+  { type: "audience_upload", params: audienceUploadParams },
+  { type: "low_credit_notify", params: noParams },
+  { type: TWILIO_WEBHOOK_AUDIT_JOB_TYPE, params: twilioWebhookAuditParams },
+  { type: CALL_STATUS_SIDE_EFFECTS_JOB_TYPE, params: callStatusSideEffectsParams },
+  { type: SMS_STATUS_SIDE_EFFECTS_JOB_TYPE, params: smsStatusSideEffectsParams },
+  { type: RECORDING_SIDE_EFFECTS_JOB_TYPE, params: recordingSideEffectsParams },
+  { type: CAMPAIGN_EXPORT_JOB_TYPE, params: campaignExportParams },
+  { type: CAMPAIGN_DISPATCH_JOB_TYPE, params: campaignDispatchParams },
+  { type: WEBHOOK_DELIVERY_JOB_TYPE, params: webhookDeliveryParams },
+] as const satisfies readonly JobParamsEntry<string, unknown>[];
+
+/** `{ [registered type]: its zod-inferred params type }`, for callers that need the map directly. */
+export type JobParamsMap = {
+  [E in (typeof jobParamsRegistry)[number] as E["type"]]: z.infer<E["params"]>;
+};
+
+/**
+ * Typed `enqueueJob`, narrowed to every registered job type: `type` is a
+ * literal union instead of `string`, and `params` must match that type's zod
+ * schema — an enqueue-time typo or shape mismatch is now a compile error (or
+ * a `ZodError` at call time) instead of a dead-lettered job discovered later.
+ */
+export const enqueueRegisteredJob = createTypedEnqueue(jobParamsRegistry);
+
+/** Pure runtime validation gate — see `createValidateStoredJobParams`'s doc comment. */
+export const validateStoredJobParams = createValidateStoredJobParams(jobParamsRegistry);
+
+/**
+ * The escape hatch for genuinely dynamic enqueue sites (dead-letter requeue,
+ * self-scheduling boot seed) — see `createRequeueStoredJob`'s doc comment.
+ */
+export const requeueStoredJob = createRequeueStoredJob(jobParamsRegistry, validateStoredJobParams);

--- a/app/lib/worker/job-registry.server.ts
+++ b/app/lib/worker/job-registry.server.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ClaimedJobRow, JobHandler } from "@/lib/worker/poll-jobs.server";
 import {
-  enqueueJob,
+  unsafeEnqueueJob,
   type EnqueueJobArgs,
   type EnqueueJobResult,
 } from "@/lib/worker/enqueue-job.server";
@@ -64,12 +64,27 @@ export type JobDefinition<Type extends string, Params> = {
   handler: (job: ClaimedJobRow, params: Params) => Promise<unknown>;
 };
 
-export type RegisteredJob<Type extends string = string, Params = unknown> = {
+/**
+ * The minimal shape `createTypedEnqueue`/`createRequeueStoredJob` need: a
+ * `job.type` literal paired with the zod schema its params validate against.
+ * `RegisteredJob` (below) extends this with handler wiring, but the
+ * enqueue-side helpers only ever touch `type`/`params` — keeping their
+ * constraint this loose lets a schema-only list (no handler implementations,
+ * see `job-params.server.ts`) satisfy it too, which is what lets
+ * handler-implementation files import the typed enqueue back without a
+ * module cycle through `handlers.server.ts` (#1239 A3).
+ */
+export type JobParamsEntry<Type extends string = string, Params = unknown> = {
   type: Type;
+  params: z.ZodType<Params>;
+};
+
+export type RegisteredJob<Type extends string = string, Params = unknown> = JobParamsEntry<
+  Type,
+  Params
+> & {
   pages: boolean;
   schedule: JobSchedule;
-  /** The zod schema this registration validates `job.params` against. */
-  params: z.ZodType<Params>;
   /** The `(job) => Promise<unknown>` shape `jobHandlers`/the poll loop expects. */
   jobHandler: JobHandler;
 };
@@ -205,8 +220,64 @@ export function legacyRequiredObjectParam(
   );
 }
 
-type ParamsOf<R> = R extends RegisteredJob<string, infer Params> ? Params : never;
-type TypeOf<R> = R extends RegisteredJob<infer Type, unknown> ? Type : never;
+export type SidAndTwilioParams = {
+  sid: string;
+  twilioParams: Record<string, string>;
+};
+
+/**
+ * Shared params schema for the three Twilio webhook fast-ack side-effect job
+ * types (#1239 A2): each one used to re-implement the same
+ * `requireSidAndTwilioParams` narrowing (sid key differs, everything else is
+ * identical). One factory, parameterized on the sid field name and the label
+ * used in the error message, replaces all three copies.
+ *
+ * Moved here from `handlers/webhook-adapters.server.ts` in #1239 A3 so
+ * `job-params.server.ts` (schema-only, no handler-implementation
+ * dependencies — see its module doc) can build these three job types'
+ * registrations without importing `webhook-adapters.server.ts`, which would
+ * otherwise cycle back through `handlers.server.ts`.
+ *
+ * `twilioParams` is DELIBERATELY LOOSER than a "real" schema: the old code
+ * never validated its values are strings (just `typeof value === "object" &&
+ * value !== null`), and neither does `legacyObjectParam`. Exactly equivalent
+ * otherwise.
+ *
+ * `sid` (#1239 A3): `enqueueRegisteredJob`'s `params` argument must match this
+ * schema's OUTPUT shape (`{sid, twilioParams}`), not its pre-transform input
+ * — so new enqueue call sites pass a `sid` field directly instead of the
+ * `callSid`/`messageSid` the old ad-hoc job.params shape used. `callSid` and
+ * `messageSid` stay accepted as a fallback so an already-queued job written
+ * before this migration still parses correctly at dequeue time.
+ */
+export function sidAndTwilioParamsSchema(
+  sidKey: "callSid" | "messageSid",
+  label: string,
+): z.ZodType<SidAndTwilioParams> {
+  return z
+    .object({
+      sid: legacyStringParam(),
+      callSid: legacyStringParam(),
+      messageSid: legacyStringParam(),
+      twilioParams: legacyObjectParam<Record<string, string> | undefined>(undefined),
+    })
+    .transform((value, ctx) => {
+      const legacySid = sidKey === "callSid" ? value.callSid : value.messageSid;
+      const sid = value.sid ?? legacySid;
+      const twilioParams = value.twilioParams;
+      if (!sid || !twilioParams) {
+        ctx.addIssue({
+          code: "custom",
+          message: `${label}: missing ${sidKey} or twilioParams`,
+        });
+        return z.NEVER;
+      }
+      return { sid, twilioParams };
+    });
+}
+
+type ParamsOf<E> = E extends JobParamsEntry<string, infer Params> ? Params : never;
+type TypeOf<E> = E extends JobParamsEntry<infer Type, unknown> ? Type : never;
 
 export type TypedEnqueueArgs<Type extends string, Params> = Omit<
   EnqueueJobArgs,
@@ -217,35 +288,106 @@ export type TypedEnqueueArgs<Type extends string, Params> = Omit<
 };
 
 /**
- * Build a typed `enqueueJob` scoped to a fixed list of `defineJob`
- * registrations: `type` is narrowed to one of the registered literal types,
- * and `params` must match that type's zod-inferred shape (parsed again here,
- * so a bad caller-supplied value fails at enqueue time instead of dequeue
- * time). Wraps the existing untyped `enqueueJob` — every current caller of
- * that function is untouched.
+ * Build a typed `enqueueJob` scoped to a fixed list of job-param entries
+ * (either full `defineJob` registrations or a schema-only `JobParamsEntry`
+ * list — see `job-params.server.ts`): `type` is narrowed to one of the
+ * registered literal types, and `params` must match that type's zod-inferred
+ * shape (parsed again here, so a bad caller-supplied value fails at enqueue
+ * time instead of dequeue time). Wraps `unsafeEnqueueJob`.
  *
- * Every registered job type gets a real `Params` type as of #1239 A2. No
- * enqueue call site has been migrated onto this yet — that's #1239 A3;
- * `enqueueJob` remains the only path every current caller uses.
+ * Every registered job type got a real `Params` type as of #1239 A2. As of
+ * #1239 A3, every production enqueue call site is migrated onto this (or, for
+ * genuinely dynamic types, `requeueStoredJob`) — `unsafeEnqueueJob` is no
+ * longer meant to be called directly outside this file.
  */
-export function createTypedEnqueue<const Regs extends readonly RegisteredJob<string, unknown>[]>(
-  registrations: Regs,
+export function createTypedEnqueue<const Entries extends readonly JobParamsEntry<string, unknown>[]>(
+  entries: Entries,
 ) {
-  type Reg = Regs[number];
-  type ParamsMap = { [R in Reg as TypeOf<R>]: ParamsOf<R> };
+  type Entry = Entries[number];
+  type ParamsMap = { [E in Entry as TypeOf<E>]: ParamsOf<E> };
 
   return async function enqueueRegisteredJob<Type extends keyof ParamsMap & string>(
     args: TypedEnqueueArgs<Type, ParamsMap[Type]>,
   ): Promise<EnqueueJobResult> {
-    const registration = registrations.find(
-      (candidate): candidate is Reg => candidate.type === args.type,
+    const entry = entries.find(
+      (candidate): candidate is Entry => candidate.type === args.type,
     );
-    if (!registration) {
+    if (!entry) {
       throw new Error(
         `enqueueRegisteredJob: no defineJob registration for type "${args.type}"`,
       );
     }
-    const parsed = registration.params.parse(args.params) as Record<string, unknown>;
-    return enqueueJob({ ...args, params: parsed });
+    const parsed = entry.params.parse(args.params) as Record<string, unknown>;
+    return unsafeEnqueueJob({ ...args, params: parsed });
+  };
+}
+
+export type StoredJobValidation =
+  | { ok: true; type: string; params: Record<string, unknown> }
+  | { ok: false; error: string };
+
+/**
+ * Validate arbitrary stored `(type, params)` — e.g. a dead-lettered job's
+ * DB row — against whichever registration matches `type` at runtime. Unlike
+ * `createTypedEnqueue`, `type` here is a plain `string`: this is for
+ * genuinely dynamic call sites that can't pin one literal job type at compile
+ * time (a dead-letter requeue can be any type; a boot-time self-scheduling
+ * seed loop iterates every self-scheduling type). Returns a typed error
+ * instead of throwing so callers can report "unknown job type" or "invalid
+ * params" without a try/catch.
+ */
+export function createValidateStoredJobParams<
+  const Entries extends readonly JobParamsEntry<string, unknown>[],
+>(entries: Entries) {
+  return function validateStoredJobParams(
+    type: string,
+    storedParams: unknown,
+  ): StoredJobValidation {
+    const entry = entries.find((candidate) => candidate.type === type);
+    if (!entry) {
+      return { ok: false, error: `No defineJob registration for job type "${type}"` };
+    }
+    const parsed = entry.params.safeParse(storedParams ?? {});
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: `Stored params failed validation for job type "${type}": ${parsed.error.message}`,
+      };
+    }
+    return { ok: true, type, params: parsed.data as Record<string, unknown> };
+  };
+}
+
+export type StoredJobRequeueResult =
+  | { ok: true; result: EnqueueJobResult }
+  | { ok: false; error: string };
+
+/**
+ * The single sanctioned escape hatch for enqueueing a job whose type isn't
+ * known until runtime (dead-letter requeue, self-scheduling boot seed): runs
+ * the same runtime validation `createValidateStoredJobParams` does, then
+ * enqueues via `unsafeEnqueueJob` with the validated params — never the raw
+ * stored value. Returns a typed error for an unknown type or invalid params
+ * instead of enqueueing garbage that would just dead-letter again.
+ */
+export function createRequeueStoredJob<
+  const Entries extends readonly JobParamsEntry<string, unknown>[],
+>(
+  entries: Entries,
+  validate: ReturnType<typeof createValidateStoredJobParams<Entries>> = createValidateStoredJobParams(
+    entries,
+  ),
+) {
+  return async function requeueStoredJob(
+    type: string,
+    storedParams: unknown,
+    extra: Omit<EnqueueJobArgs, "type" | "params"> = {},
+  ): Promise<StoredJobRequeueResult> {
+    const validated = validate(type, storedParams);
+    if (!validated.ok) {
+      return validated;
+    }
+    const result = await unsafeEnqueueJob({ ...extra, type: validated.type, params: validated.params });
+    return { ok: true, result };
   };
 }

--- a/app/lib/worker/job-types.server.ts
+++ b/app/lib/worker/job-types.server.ts
@@ -16,3 +16,14 @@ export const CAMPAIGN_EXPORT_JOB_TYPE = "campaign_export";
 export const CAMPAIGN_DISPATCH_JOB_TYPE = "campaign_dispatch";
 export const WEBHOOK_DELIVERY_JOB_TYPE = "webhook_delivery";
 export const ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE = "elevenlabs_batch_transcribe";
+
+/**
+ * Moved here from `handlers/campaign.server.ts` / `handlers/cron.server.ts`
+ * in #1239 A3: `job-params.server.ts` needs these literals to build its
+ * schema-only registry, and importing them from the handler-implementation
+ * files that used to declare them would create a module cycle (those files
+ * import `enqueueRegisteredJob` back from `job-params.server.ts`). Both
+ * files still export the same name, importing it from here.
+ */
+export const WORKSPACE_TWILIO_COMPLIANCE_JOB_TYPE = "workspace_twilio_compliance";
+export const TWILIO_WEBHOOK_AUDIT_JOB_TYPE = "twilio_webhook_audit";

--- a/app/lib/worker/webhook-side-effects.server.ts
+++ b/app/lib/worker/webhook-side-effects.server.ts
@@ -34,7 +34,7 @@ import {
   twilioParamsToUnderCase,
 } from "@/lib/twilio-call-status.server";
 import { persistCallRecordingToStorage } from "@/lib/call-recording-storage.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE } from "@/lib/worker/job-types.server";
 import { isBatchTranscriptionEnabled } from "@/lib/worker/handlers/elevenlabs-batch-transcribe.server";
 
@@ -278,7 +278,7 @@ export async function runRecordingSideEffects(args: {
       // enqueue entirely rather than queueing work nothing will bill for.
       if (await isBatchTranscriptionEnabled(callRow.workspace)) {
         try {
-          await enqueueJob({
+          await enqueueRegisteredJob({
             type: ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE,
             workspaceId: callRow.workspace,
             params: { callSid: args.callSid },

--- a/app/routes/admin+/dead-letters.action.server.ts
+++ b/app/routes/admin+/dead-letters.action.server.ts
@@ -17,6 +17,12 @@ export const action = defineAction({
     const result = await requeueDeadLetteredJob(jobId, auth.user.id);
 
     if (!result.ok) {
+      if (result.reason === "invalid_params") {
+        return routeData(
+          { error: `Job #${jobId} can't be requeued — its stored params no longer pass validation: ${result.error}` },
+          { status: 422 },
+        );
+      }
       // Either the id is wrong or another admin already requeued it. Both mean
       // "no dead-lettered job with that id right now", which is what to say.
       return routeData(

--- a/app/routes/api+/audience-upload.action.server.ts
+++ b/app/routes/api+/audience-upload.action.server.ts
@@ -17,7 +17,7 @@ import {
 import { requireWorkspaceAccess } from "@/lib/database/workspace.server";
 import { AppError } from "@/lib/errors.server";
 import { defineAction } from "@/lib/handler.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { toUserMessage } from "@/lib/user-message";
 import type { ActionFunctionArgs } from "react-router";
 import type { Database } from "@/lib/db-types";
@@ -58,7 +58,7 @@ type AudienceUploadDeps = Partial<{
     headers: Headers;
     user: { id: string } | null;
   }>;
-  enqueueJob: typeof enqueueJob;
+  enqueueJob: typeof enqueueRegisteredJob;
   requireWorkspaceAccess: (args: {
     user: { id: string };
     workspaceId: string;
@@ -74,7 +74,7 @@ export const action = defineAction({
 
   const d = {
     verifyAuth: deps?.verifyAuth ?? resolveDualAuthSession,
-    enqueueJob: deps?.enqueueJob ?? enqueueJob,
+    enqueueJob: deps?.enqueueJob ?? enqueueRegisteredJob,
     requireWorkspaceAccess: deps?.requireWorkspaceAccess ?? requireWorkspaceAccess,
   };
   const { headers, user } = await d.verifyAuth(request);

--- a/app/routes/api+/call-status.action.server.ts
+++ b/app/routes/api+/call-status.action.server.ts
@@ -5,7 +5,7 @@ import {
 import { data as routeData } from "react-router";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { defineAction } from "@/lib/handler.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { CALL_STATUS_SIDE_EFFECTS_JOB_TYPE } from "@/lib/worker/job-types.server";
 import type { ActionFunctionArgs } from "react-router";
 
@@ -54,12 +54,12 @@ export const action = defineAction({
       .trim()
       .toLowerCase();
 
-    await enqueueJob({
+    await enqueueRegisteredJob({
       type: CALL_STATUS_SIDE_EFFECTS_JOB_TYPE,
       workspaceId: call.workspace ?? null,
       idempotencyKey: callStatusSideEffectsIdempotencyKey(callSidRaw, status || "unknown"),
       params: {
-        callSid: callSidRaw,
+        sid: callSidRaw,
         twilioParams: params,
       },
     });

--- a/app/routes/api+/jobs+/twilio-open-sync.action.server.ts
+++ b/app/routes/api+/jobs+/twilio-open-sync.action.server.ts
@@ -8,8 +8,10 @@ import { createCronEnqueueAction } from "@/lib/worker/cron-job-enqueue-route.ser
 export const action = defineAction(
   createCronEnqueueAction({
     type: "twilio_open_sync",
-    buildParams: (body, workspaceId) => ({
-      workspaceId,
+    // `workspaceId` isn't in `twilio_open_sync`'s params schema — the job's
+    // top-level `workspaceId` (passed by `createCronEnqueueAction` alongside
+    // these params) is what `resolveWorkspaceId` reads.
+    buildParams: (body) => ({
       callLimit: typeof body.callLimit === "number" ? body.callLimit : 50,
       messageLimit:
         typeof body.messageLimit === "number" ? body.messageLimit : 50,

--- a/app/routes/api+/recording.action.server.ts
+++ b/app/routes/api+/recording.action.server.ts
@@ -3,7 +3,7 @@ import { logger } from "@/lib/logger.server";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { updateCallRecordingUrlBySid } from "@/lib/telephony-db.server";
 import { defineAction } from "@/lib/handler.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { RECORDING_SIDE_EFFECTS_JOB_TYPE } from "@/lib/worker/job-types.server";
 import type { ActionFunctionArgs } from "react-router";
 
@@ -50,12 +50,12 @@ export const action = defineAction({
         if (!updated) {
           logger.error("Recording webhook: call not found for CallSid", { callSid });
         } else {
-          await enqueueJob({
+          await enqueueRegisteredJob({
             type: RECORDING_SIDE_EFFECTS_JOB_TYPE,
             workspaceId: updated.workspace ?? null,
             idempotencyKey: recordingSideEffectsIdempotencyKey(callSid, recordingUrl),
             params: {
-              callSid,
+              sid: callSid,
               twilioParams: params,
             },
           });

--- a/app/routes/api+/sms/status.action.server.ts
+++ b/app/routes/api+/sms/status.action.server.ts
@@ -9,7 +9,7 @@ import {
 import type { TwilioSmsStatusWebhook } from "@/lib/twilio.types";
 import { findMessageBySid, updateMessageBySid } from "@/lib/message-db.server";
 import { defineAction } from "@/lib/handler.server";
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { SMS_STATUS_SIDE_EFFECTS_JOB_TYPE } from "@/lib/worker/job-types.server";
 import type { ActionFunctionArgs } from "react-router";
 
@@ -120,13 +120,23 @@ export const action = defineAction({
         return routeData({ error: "Failed to update message" }, { status: 500 });
       }
 
-      await enqueueJob({
+      // Narrow the webhook body to a plain string map at the boundary: the
+      // typed `payload: Partial<TwilioSmsStatusWebhook>` shape (used above
+      // for field access) has no index signature, so it isn't assignable to
+      // the job's `twilioParams: Record<string, string>` schema as-is.
+      const twilioParams: Record<string, string> = Object.fromEntries(
+        Object.entries(payload).filter(
+          (entry): entry is [string, string] => typeof entry[1] === "string",
+        ),
+      );
+
+      await enqueueRegisteredJob({
         type: SMS_STATUS_SIDE_EFFECTS_JOB_TYPE,
         workspaceId: messageData.workspace,
         idempotencyKey: smsStatusSideEffectsIdempotencyKey(sid, messageStatus),
         params: {
-          messageSid: sid,
-          twilioParams: payload,
+          sid,
+          twilioParams,
         },
       });
 

--- a/test/admin-jobs.server.test.ts
+++ b/test/admin-jobs.server.test.ts
@@ -1,21 +1,49 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+// `requeueDeadLetteredJob` (#1239 A3) does a plain `select().from().where()`
+// (awaited directly, no orderBy/limit) BEFORE the status-flip `update`;
+// `listRecentDeadLetteredJobs` does `select().from().where().orderBy().limit()`.
+// One `select` mock supports both shapes: `where()` returns an object that's
+// both directly awaitable (resolves `selectRows()`) and chainable via
+// `.orderBy().limit()`, matching how a real drizzle query builder behaves.
 const mocks = vi.hoisted(() => {
-  const limit = vi.fn(async () => [{ id: 7 }]);
+  const selectRows = vi.fn(async () => [{ id: 7 }]);
+  const limit = vi.fn(async (n: number) => selectRows(n));
   const orderBy = vi.fn(() => ({ limit }));
-  const where = vi.fn(() => ({ orderBy }));
+  const where = vi.fn(() => {
+    const result = selectRows();
+    return Object.assign(Promise.resolve(result), { orderBy });
+  });
   const from = vi.fn(() => ({ where }));
   const select = vi.fn(() => ({ from }));
-  return { select, from, where, orderBy, limit };
+
+  const updateReturning = vi.fn(async () => [{ id: 7, type: "billing_reconcile" }]);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  return {
+    selectRows,
+    select,
+    from,
+    where,
+    orderBy,
+    limit,
+    update,
+    updateSet,
+    updateWhere,
+    updateReturning,
+  };
 });
 
 vi.mock("@/server/admin-db", () => ({
-  adminDb: { select: mocks.select },
+  adminDb: { select: mocks.select, update: mocks.update },
 }));
 
 import {
   DEAD_LETTER_JOB_STATUS,
   listRecentDeadLetteredJobs,
+  requeueDeadLetteredJob,
 } from "@/lib/admin-jobs.server";
 
 describe("admin dead-letter jobs", () => {
@@ -23,6 +51,8 @@ describe("admin dead-letter jobs", () => {
     for (const mock of Object.values(mocks)) {
       mock.mockClear();
     }
+    mocks.selectRows.mockResolvedValue([{ id: 7 }]);
+    mocks.updateReturning.mockResolvedValue([{ id: 7, type: "billing_reconcile" }]);
   });
 
   test("queries dead-letter jobs with the requested limit", async () => {
@@ -33,5 +63,70 @@ describe("admin dead-letter jobs", () => {
     expect(mocks.orderBy).toHaveBeenCalledOnce();
     expect(mocks.limit).toHaveBeenCalledWith(100);
     expect(rows).toEqual([{ id: 7 }]);
+  });
+});
+
+/**
+ * requeueDeadLetteredJob's #1239 A3 validation gate: the row's stored
+ * type/params are checked against the job registry (`validateStoredJobParams`)
+ * before the status flip, so a corrupted or since-removed job type is
+ * rejected with a typed reason instead of being reinstated only to
+ * dead-letter again on the next attempt.
+ */
+describe("requeueDeadLetteredJob — registry validation gate (#1239 A3)", () => {
+  beforeEach(() => {
+    for (const mock of Object.values(mocks)) {
+      mock.mockClear();
+    }
+  });
+
+  test("rejects a job whose stored type is no longer registered, without touching the update", async () => {
+    mocks.selectRows.mockResolvedValue([{ type: "no_longer_a_job_type", params: {} }]);
+
+    const result = await requeueDeadLetteredJob(7, "admin-1");
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "invalid_params",
+      error: 'No defineJob registration for job type "no_longer_a_job_type"',
+    });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("rejects a job whose stored params no longer pass its schema", async () => {
+    mocks.selectRows.mockResolvedValue([
+      { type: "audience_upload", params: { uploadId: 0, audienceId: 5 } },
+    ]);
+
+    const result = await requeueDeadLetteredJob(7, "admin-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === "invalid_params") {
+      expect(result.error).toMatch(/audience_upload: missing or invalid uploadId/);
+    } else {
+      throw new Error("expected an invalid_params rejection");
+    }
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  test("requeues a job whose stored params still pass its schema", async () => {
+    mocks.selectRows.mockResolvedValue([
+      { type: "billing_reconcile", params: { workspaceId: "ws_1" } },
+    ]);
+    mocks.updateReturning.mockResolvedValue([{ id: 7, type: "billing_reconcile" }]);
+
+    const result = await requeueDeadLetteredJob(7, "admin-1");
+
+    expect(result).toEqual({ ok: true, jobId: 7, type: "billing_reconcile" });
+    expect(mocks.update).toHaveBeenCalledOnce();
+  });
+
+  test("reports not_found when no dead-lettered row matches", async () => {
+    mocks.selectRows.mockResolvedValue([]);
+
+    const result = await requeueDeadLetteredJob(999, "admin-1");
+
+    expect(result).toEqual({ ok: false, reason: "not_found" });
+    expect(mocks.update).not.toHaveBeenCalled();
   });
 });

--- a/test/audience-upload.route.test.ts
+++ b/test/audience-upload.route.test.ts
@@ -65,7 +65,7 @@ vi.mock("@/lib/database/workspace.server", () => ({
     requireWorkspaceAccessMock.requireWorkspaceAccess(...args),
 }));
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 vi.mock("@/lib/logger.server", () => ({ logger }));

--- a/test/call-status-billing.test.ts
+++ b/test/call-status-billing.test.ts
@@ -52,7 +52,7 @@ vi.mock("@/lib/workspace-events.server", () => ({
 const enqueueJobMock = vi.hoisted(() => vi.fn(async () => ({ enqueued: true, jobId: 1 })));
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 const transactionRowsState = vi.hoisted(() => ({ rows: [] as TransactionRow[] }));

--- a/test/call-status.route.test.ts
+++ b/test/call-status.route.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/lib/workspace-events.server", () => ({
 const enqueueJobMock = vi.hoisted(() => vi.fn(async () => ({ enqueued: true, jobId: 1 })));
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 const mocks = vi.hoisted(() => {

--- a/test/campaign-dispatch-worker.test.ts
+++ b/test/campaign-dispatch-worker.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/campaign-sms-dispatch.server", () => ({
   dispatchCampaignSmsBatch: mocks.dispatchCampaignSmsBatch,
 }));
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: mocks.enqueueJob,
+  unsafeEnqueueJob: mocks.enqueueJob,
 }));
 vi.mock("@/lib/campaign-ivr.server", () => ({
   findCampaignInWorkspace: mocks.findCampaignInWorkspace,

--- a/test/enqueue-job.test.ts
+++ b/test/enqueue-job.test.ts
@@ -4,7 +4,7 @@ vi.hoisted(() => {
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
 });
 
-import { enqueueJob } from "@/lib/worker/enqueue-job.server";
+import { unsafeEnqueueJob as enqueueJob } from "@/lib/worker/enqueue-job.server";
 import { runWithRequestContext } from "@/lib/request-context.server";
 import { db } from "@/server/db";
 

--- a/test/ensure-scheduled-jobs.test.ts
+++ b/test/ensure-scheduled-jobs.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const enqueueJobMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 vi.mock("@/lib/logger.server", () => ({

--- a/test/job-registry.test.ts
+++ b/test/job-registry.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "vitest";
 import {
+  enqueueRegisteredJob,
   jobHandlers,
   jobRegistry,
   PAGING_JOB_TYPES,
+  requeueStoredJob,
   SELF_SCHEDULING_JOB_TYPES,
   SELF_SCHEDULING_SEED_PARAMS,
+  validateStoredJobParams,
 } from "@/lib/worker/handlers.server";
+import { jobParamsRegistry } from "@/lib/worker/job-params.server";
 
 /**
  * Drift guard for #1239 A1: `jobHandlers`, `PAGING_JOB_TYPES`, and
@@ -284,5 +288,77 @@ describe("job registry — defineJob params validation (#1239 A2 migrations)", (
     // Negative numbers are truthy in JS, so the old `!campaignId` check never
     // rejected them — only an exact falsy 0 (or a non-numeric value).
     expect(dispatchReg!.params.parse({ campaignId: -5 }).campaignId).toBe(-5);
+  });
+});
+
+/**
+ * Drift guard for #1239 A3: `job-params.server.ts`'s `jobParamsRegistry`
+ * (schema-only, importable by handler-implementation files without a module
+ * cycle back through `handlers.server.ts` — see that module's doc comment)
+ * must register exactly the same job types as `handlers.server.ts`'s
+ * `jobRegistry` (schema + handler + paging/schedule). If a job type is added
+ * to one list without the other, `enqueueRegisteredJob` and the dequeue-side
+ * `jobHandlers` would silently disagree about what's a valid job type.
+ */
+describe("job registry — enqueue-side/dequeue-side registry parity (#1239 A3)", () => {
+  test("jobParamsRegistry and jobRegistry register exactly the same set of job types", () => {
+    const enqueueSideTypes = jobParamsRegistry.map((entry) => entry.type).sort();
+    const dequeueSideTypes = jobRegistry.map((registration) => registration.type).sort();
+    expect(enqueueSideTypes).toEqual(dequeueSideTypes);
+  });
+
+  test("jobParamsRegistry and jobRegistry validate each type against the exact same schema instance", () => {
+    for (const entry of jobParamsRegistry) {
+      const registration = jobRegistry.find((r) => r.type === entry.type);
+      expect(registration).toBeDefined();
+      expect(registration!.params).toBe(entry.params);
+    }
+  });
+});
+
+/**
+ * `requeueStoredJob`/`validateStoredJobParams` are the sanctioned escape
+ * hatch for enqueue sites that can't pin one job type at compile time (a
+ * dead-letter requeue can be any type; `ensure-scheduled-jobs.server.ts`'s
+ * boot seed iterates every self-scheduling type) — see their doc comments in
+ * job-registry.server.ts. Both must reject an unknown type with a typed
+ * error instead of enqueueing garbage or throwing.
+ */
+describe("job registry — requeue/validate escape hatch (#1239 A3)", () => {
+  test("validateStoredJobParams rejects an unregistered job type", () => {
+    const result = validateStoredJobParams("not_a_real_job_type", {});
+    expect(result).toEqual({
+      ok: false,
+      error: 'No defineJob registration for job type "not_a_real_job_type"',
+    });
+  });
+
+  test("validateStoredJobParams rejects params that fail the matched type's schema", () => {
+    const result = validateStoredJobParams("audience_upload", { uploadId: 0, audienceId: 5 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/audience_upload: missing or invalid uploadId/);
+    }
+  });
+
+  test("validateStoredJobParams accepts valid stored params for a registered type", () => {
+    const result = validateStoredJobParams("billing_reconcile", { workspaceId: "ws_1" });
+    expect(result).toEqual({
+      ok: true,
+      type: "billing_reconcile",
+      params: { workspaceId: "ws_1" },
+    });
+  });
+
+  test("requeueStoredJob rejects an unregistered job type without calling enqueueJob", async () => {
+    const result = await requeueStoredJob("not_a_real_job_type", {});
+    expect(result).toEqual({
+      ok: false,
+      error: 'No defineJob registration for job type "not_a_real_job_type"',
+    });
+  });
+
+  test("enqueueRegisteredJob is exported and callable for a known type (compile-time narrowing smoke test)", () => {
+    expect(typeof enqueueRegisteredJob).toBe("function");
   });
 });

--- a/test/jobs-billing-reconcile.route.test.ts
+++ b/test/jobs-billing-reconcile.route.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
 }));
 
 const CRON_SECRET = "test-cron-secret";

--- a/test/jobs-number-rental-billing.route.test.ts
+++ b/test/jobs-number-rental-billing.route.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
 }));
 
 const CRON_SECRET = "test-cron-secret";

--- a/test/jobs-twilio-open-sync.route.test.ts
+++ b/test/jobs-twilio-open-sync.route.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
 }));
 
 const CRON_SECRET = "test-cron-secret";
@@ -65,7 +65,6 @@ describe("app/routes/api+/jobs+/twilio-open-sync.action.server.ts", () => {
       type: "twilio_open_sync",
       workspaceId: "ws-1",
       params: {
-        workspaceId: "ws-1",
         callLimit: 10,
         messageLimit: 50,
         maxAgeMinutes: 120,

--- a/test/outreach-disposition-transition.test.ts
+++ b/test/outreach-disposition-transition.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/lib/workspace-events.server", () => ({
 }));
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: vi.fn(async () => ({ enqueued: true, jobId: 1 })),
+  unsafeEnqueueJob: vi.fn(async () => ({ enqueued: true, jobId: 1 })),
 }));
 
 describe("outreach disposition transitions", () => {

--- a/test/recording.route.test.ts
+++ b/test/recording.route.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
 
 const enqueueJobMock = vi.hoisted(() => vi.fn(async () => ({ enqueued: true, jobId: 1 })));
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 describe("app/routes/api+/recording", () => {

--- a/test/sms-status-webhook.test.ts
+++ b/test/sms-status-webhook.test.ts
@@ -57,7 +57,7 @@ vi.mock("@/lib/database/workspace.server", () => ({
 }));
 vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: any[]) => mocks.enqueueJob(...args),
+  unsafeEnqueueJob: (...args: any[]) => mocks.enqueueJob(...args),
 }));
 vi.mock("@/lib/sms-status", async (importOriginal) => {
   const actual = (await importOriginal()) as any;

--- a/test/sms-status.route.test.ts
+++ b/test/sms-status.route.test.ts
@@ -69,7 +69,7 @@ vi.mock("@/lib/twilio-lookup.server", () => ({
 
 const enqueueJobMock = vi.hoisted(() => vi.fn(async () => ({ enqueued: true, jobId: 1 })));
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 function makeSmsStatusRequest(payload: { SmsSid?: string; SmsStatus?: string }) {

--- a/test/twilio-open-sync.server.test.ts
+++ b/test/twilio-open-sync.server.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/message-db.server", () => ({
   updateMessageBySid: (...args: unknown[]) => mocks.updateMessageBySid(...args),
 }));
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
 }));
 vi.mock("@/lib/logger.server", () => ({ logger: mocks.logger }));
 
@@ -124,7 +124,7 @@ describe("triggerTwilioOpenSync terminal recovery (TEL-04)", () => {
       expect.objectContaining({
         type: "sms_status_side_effects",
         idempotencyKey: "sms_status_side_effects:SM1:delivered",
-        params: expect.objectContaining({ messageSid: "SM1" }),
+        params: expect.objectContaining({ sid: "SM1" }),
       }),
     );
   });

--- a/test/webhook-side-effects.test.ts
+++ b/test/webhook-side-effects.test.ts
@@ -28,7 +28,7 @@ vi.mock("@/lib/worker/handlers/elevenlabs-batch-transcribe.server", () => ({
 }));
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
 }));
 
 vi.mock("@/lib/telephony-db.server", () => ({

--- a/test/worker-cron-handlers.server.test.ts
+++ b/test/worker-cron-handlers.server.test.ts
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
 // withReschedule -> rescheduleJob -> enqueueJob, and stubbing the middle of
 // that chain would not exercise the ordering guarantee these tests exist for.
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => mocks.enqueueJob(...args),
 }));
 
 vi.mock("@/lib/cron-workspace-fanout.server", () => ({

--- a/test/worker-reschedule.test.ts
+++ b/test/worker-reschedule.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const enqueueJobMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/worker/enqueue-job.server", () => ({
-  enqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
+  unsafeEnqueueJob: (...args: unknown[]) => enqueueJobMock(...args),
 }));
 
 vi.mock("@/lib/logger.server", () => ({
@@ -21,11 +21,15 @@ describe("rescheduleJob", () => {
   });
 
   test("uses unified enqueue with runAt and ignores the current running job", async () => {
-    await rescheduleJob("billing_reconcile", 60_000, { source: "cron" }, 41);
+    // `rescheduleJob` is typed (#1239 A3) against the same registered-job
+    // schemas every other enqueue call site validates against — params must
+    // match `billing_reconcile`'s schema (`{workspaceId?: string}`), not an
+    // arbitrary shape.
+    await rescheduleJob("billing_reconcile", 60_000, { workspaceId: "ws_1" }, 41);
 
     expect(enqueueJobMock).toHaveBeenCalledWith({
       type: "billing_reconcile",
-      params: { source: "cron" },
+      params: { workspaceId: "ws_1" },
       runAt: "2026-07-14T18:01:00.000Z",
       dedupe: {
         kind: "live",


### PR DESCRIPTION
Part 3 of #1239 (A3), stacked on #1256. Closes #1239

## Summary

Stacked on `refactor/1239-migrate-job-types` (A2, PR #1256), which is itself stacked on `refactor/1239-define-job-registry` (A1, PR #1247). This PR makes every production job-enqueue call site typo-proof by migrating it off the untyped `enqueueJob` onto the registry's typed `enqueueRegisteredJob` (or, for genuinely dynamic call sites, a new `requeueStoredJob`/`validateStoredJobParams` escape hatch).

- **New `app/lib/worker/job-params.server.ts`**: every registered job type's params schema, plus the typed `enqueueRegisteredJob`/`requeueStoredJob`/`validateStoredJobParams` built from them. Split out of `handlers.server.ts` so handler-implementation files (`handlers/cron.server.ts`, `handlers/campaign.server.ts`, `webhook-side-effects.server.ts`, `twilio-open-sync.server.ts`) — which `handlers.server.ts` itself imports to build its `defineJob` registrations — can import the typed enqueue back without a module cycle. `handlers.server.ts` re-exports the same instances as its canonical public surface.
- **`sidAndTwilioParamsSchema`** moved from `handlers/webhook-adapters.server.ts` into `job-registry.server.ts` (schema-only, no handler deps) and gained a `sid` input field: `enqueueRegisteredJob`'s `params` must match the schema's *output* shape (`{sid, twilioParams}`), not its pre-transform `callSid`/`messageSid` input, so new enqueue call sites pass `sid` directly. `callSid`/`messageSid` stay accepted as a fallback so an already-queued job written before this migration still parses at dequeue time.
- **`createValidateStoredJobParams`/`createRequeueStoredJob`** (`job-registry.server.ts`): the sanctioned escape hatch for the two call sites that can't pin one job type at compile time — `admin-jobs.server.ts`'s dead-letter requeue (any registered type) and `ensure-scheduled-jobs.server.ts`'s boot-time seed loop (iterates every self-scheduling type). Both runtime-validate against the matching registration and return a typed error for an unknown type instead of enqueueing/reinstating unvalidated params.
- **`enqueueJob` renamed to `unsafeEnqueueJob`** in `enqueue-job.server.ts`: only `job-registry.server.ts`'s typed wrappers call it now.

### Enqueue-site census

| Site | Before | After |
|---|---|---|
| `app/lib/worker/cron-job-enqueue-route.server.ts` (`createCronEnqueueAction`, backs the 4 `api+/jobs+/*` HTTP cron routes) | `enqueueJob({type: string, ...})` | `enqueueRegisteredJob`, generic over the registered type; `buildParams`'s return type is checked against that type's schema |
| `handlers/cron.server.ts` × 6 self-reschedule sites (`twilio_open_sync`, `billing_reconcile`, `number_rental_billing`, `low_credit_notify`, `campaign_schedule_sync`, `twilio_webhook_audit`) | `rescheduleJob(type: string, delayMs, params: Record<string,unknown>, completedJobId)` → raw `enqueueJob` | `rescheduleJob<Type extends keyof JobParamsMap & string>` → `enqueueRegisteredJob` |
| `handlers/campaign.server.ts` `enqueueWorkspaceComplianceJob` | `enqueueJob` | `enqueueRegisteredJob` |
| `handlers/campaign.server.ts` `enqueueDispatchSuccessor` | `enqueueJob` | `enqueueRegisteredJob` |
| `webhook-side-effects.server.ts` (elevenlabs batch transcribe) | `enqueueJob` | `enqueueRegisteredJob` |
| `twilio-open-sync.server.ts` (sms_status_side_effects) | `enqueueJob({params: {messageSid, ...}})` | `enqueueRegisteredJob({params: {sid, ...}})` |
| `routes/api+/call-status.action.server.ts` | `enqueueJob({params: {callSid, ...}})` | `enqueueRegisteredJob({params: {sid, ...}})` |
| `routes/api+/recording.action.server.ts` | `enqueueJob({params: {callSid, ...}})` | `enqueueRegisteredJob({params: {sid, ...}})` |
| `routes/api+/sms/status.action.server.ts` | `enqueueJob({params: {messageSid, twilioParams: payload}})` | `enqueueRegisteredJob({params: {sid, twilioParams}})`, `twilioParams` narrowed from `Partial<TwilioSmsStatusWebhook>` to `Record<string,string>` at the boundary |
| `routes/api+/audience-upload.action.server.ts` | `deps.enqueueJob: typeof enqueueJob` | `deps.enqueueJob: typeof enqueueRegisteredJob` |
| `app/lib/campaign-execution.server.ts` (`launchCampaign`) | `enqueueJob({params: {..., mode}})` | `enqueueRegisteredJob`; dropped `mode`, a field `campaignDispatchHandler` never read and the schema never validated |
| `app/lib/worker/ensure-scheduled-jobs.server.ts` (boot seed, iterates every self-scheduling type) | `enqueueJob` | `requeueStoredJob` (dynamic type — see hatch below) |
| `app/lib/admin-jobs.server.ts` (`requeueDeadLetteredJob`) | raw `UPDATE ... SET status='queued'`, no params check | `validateStoredJobParams` gate before the same `UPDATE`; new `invalid_params` result surfaced as HTTP 422 |
| `app/lib/adapters/jobqueue.adapter.server.ts` | — | checked; only re-exports the dequeue/claim side, no enqueue path |

### The requeue hatch

`createValidateStoredJobParams`/`createRequeueStoredJob` (`job-registry.server.ts`) take the same job-param entries `enqueueRegisteredJob` does. `validateStoredJobParams(type, storedParams)` looks up the matching registration by `type` (a plain runtime `string`) and `safeParse`s the stored params, returning `{ok:true, type, params}` or a typed `{ok:false, error}` — no throw. `requeueStoredJob` wraps that with the actual enqueue (`unsafeEnqueueJob`) on success. Two call sites use it:
- `admin-jobs.server.ts` now does `SELECT type, params` before the status-flip `UPDATE`, validates via `validateStoredJobParams`, and rejects (422, no DB write) instead of reinstating a row that would just dead-letter again.
- `ensure-scheduled-jobs.server.ts`'s boot loop iterates `SELF_SCHEDULING_JOB_TYPES` (a runtime `string[]`, not a compile-time literal) and calls `requeueStoredJob` per type.

### Sealed / deleted

- `enqueueJob` → `unsafeEnqueueJob` (renamed, not deleted — still the primitive `job-registry.server.ts` wraps).
- No `job-types.server.ts` constants became dead — all stay referenced by the registry itself, even where no enqueue call site produces that type yet (`campaign_export`, `webhook_delivery`).
- No `as any`/`as unknown as` escapes added (type-safety gate count unchanged, see below).

### Gate results

- `npm run typecheck` — clean
- `npx vitest run -c vitest.node.config.ts` — 350/350 files, 2571 passed, 3 skipped
- `bun test test/server-runtime.test.ts test/twilio-webhook-prehandler.test.ts vendor/scriptkit/scriptkit-call-script-core/src/` — 22/22 passed
- `node scripts/check-handlers.mjs` — passed
- `node scripts/check-type-safety.mjs` — **93/93** escape hatches (baseline unchanged, no new `as any`/`as unknown as`/`: any`)
- `check:effects`, `check:dry`, `check:db-rpcs`, `check:route-authz`, `check:route-membership`, `check:client-bundle`, `check:route-server-leaks`, `check:workspace-projection`, `check:twilio-webhooks` (pre-existing unrelated warning only), `check:request-body-consumption`, `check:middleware`, `check:credit-writes`, `check:dual-auth` — all passed

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run -c vitest.node.config.ts`
- [x] `bun test test/server-runtime.test.ts test/twilio-webhook-prehandler.test.ts vendor/scriptkit/scriptkit-call-script-core/src/`
- [x] `node scripts/check-handlers.mjs`
- [x] `node scripts/check-type-safety.mjs`
- [x] Remaining `check:*` gates (effects, dry, db-rpcs, route-authz, route-membership, client-bundle, route-server-leaks, workspace-projection, twilio-webhooks, request-body-consumption, middleware, credit-writes, dual-auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)