### PR TITLE
refactor(twilio): parse voice callbacks once into a typed union (#1243 E1)

### DIFF
--- a/app/lib/twilio-call-status.server.ts
+++ b/app/lib/twilio-call-status.server.ts
@@ -19,6 +19,7 @@ import { callKey } from "@/lib/billing-keys";
 import { debitAmountFromCredits } from "@/lib/pricing";
 import { logger } from "@/lib/logger.server";
 import { emitPostgresChangeEvent } from "@/lib/workspace-events.server";
+import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 
 export {
   voiceBillingKindFromCampaignType,
@@ -303,31 +304,23 @@ export async function persistCallStatusFromParams(args: {
   outreachAttemptId?: number | null;
   selectResult?: boolean;
 }): Promise<Tables<"call"> | null> {
-  const underCase = twilioParamsToUnderCase(args.params);
-  const callSid =
-    typeof underCase.call_sid === "string" ? underCase.call_sid : null;
+  const event = parseTwilioVoiceCallback(args.params);
+  const callSid = event.callSid;
   if (!callSid) {
     throw new Error("Missing CallSid in status params");
   }
-  const timestamp =
-    typeof underCase.timestamp === "string" ? underCase.timestamp : null;
   const status = args.disposition
     ? String(args.disposition).toLowerCase()
-    : typeof underCase.call_status === "string"
-      ? String(underCase.call_status).toLowerCase()
-      : null;
+    : event.callStatus.toLowerCase() || null;
 
   const update: Record<string, unknown> = {};
-  if (timestamp) {
-    update.end_time = new Date(timestamp).toISOString();
+  if (event.timestamp) {
+    update.end_time = new Date(event.timestamp).toISOString();
   }
   if (status) {
     update.status = status;
   }
-  const duration = Math.max(
-    Number(underCase.duration) || 0,
-    Number(underCase.call_duration) || 0,
-  );
+  const duration = event.durationSeconds ?? 0;
   if (duration > 0) {
     update.duration = String(duration);
   }

--- a/app/lib/twilio/voice-callback.ts
+++ b/app/lib/twilio/voice-callback.ts
@@ -1,0 +1,290 @@
+import { z } from "zod";
+
+/**
+ * Twilio VOICE webhook payloads, parsed ONCE at the route boundary into a
+ * discriminated union (#1243 E1).
+ *
+ * Before this, every voice callback route re-derived its own view of the same
+ * form body: `twilioParamsToUnderCase` produced a `Record<string, unknown>`
+ * and each read was re-narrowed inline with `typeof x === "string" ? x : ...`
+ * — 15 of them in `auto-dial/status` alone. Those narrowings were not
+ * validation: they said "this might be a string" over a value that is always a
+ * form field, and they hid the questions that actually matter (is this a call
+ * status? a conference participant event? a recording?).
+ *
+ * The rule is: parse at the edge, pass the parsed event inward. Handlers take
+ * a narrowed member (`ParticipantJoinEvent`, not `{[x: string]: string}`), and
+ * the worker jobs that continue a webhook's work carry the parsed event in
+ * their payload instead of re-reading the raw params.
+ *
+ * NEVER THROWS. A Twilio webhook that 500s is retried for hours, so an
+ * unexpected body must not be an error: anything that does not match a known
+ * shape comes back as `UnrecognizedCallback`, carrying `raw` so a caller can
+ * still log or fall back on the original params.
+ *
+ * Follows the typed-Twilio-message pattern in `services/media-stream/types.ts`
+ * (shape-per-event + a guard), with the schemas as the source of truth so the
+ * job-payload validation in `job-registry.server.ts` cannot drift from the
+ * types the routes consume.
+ */
+
+/** `StatusCallbackEvent` values Twilio sends for conference callbacks. */
+export const PARTICIPANT_EVENT_NAMES = [
+  "participant-join",
+  "participant-leave",
+  "participant-modify",
+  "participant-speech-start",
+  "participant-speech-stop",
+  "conference-start",
+  "conference-end",
+  "announcement-start",
+  "announcement-end",
+] as const;
+
+const participantEventName = z.enum(PARTICIPANT_EVENT_NAMES);
+
+/**
+ * Fields Twilio puts on voice callbacks regardless of shape.
+ *
+ * `callStatus` is `""` (not null) when absent because every existing caller
+ * compared it as a string (`switch (callStatus)`, `.toLowerCase()`), and
+ * `durationSeconds` is the `max(Duration, CallDuration)` those callers all
+ * computed by hand.
+ */
+const voiceCallbackCommon = {
+  /** The form body exactly as Twilio posted it. */
+  raw: z.record(z.string(), z.string()),
+  callSid: z.string().nullable(),
+  accountSid: z.string().nullable(),
+  callStatus: z.string(),
+  timestamp: z.string().nullable(),
+  durationSeconds: z.number().nullable(),
+};
+
+/** A plain call status callback: `CallSid` + `CallStatus`, no conference, no recording. */
+export const callStatusCallbackSchema = z.object({
+  ...voiceCallbackCommon,
+  kind: z.literal("call-status"),
+  callSid: z.string(),
+  callStatus: z.string().min(1),
+  answeredBy: z.string().nullable(),
+  direction: z.string().nullable(),
+  from: z.string().nullable(),
+  to: z.string().nullable(),
+  parentCallSid: z.string().nullable(),
+  sequenceNumber: z.string().nullable(),
+});
+
+/**
+ * A conference `StatusCallbackEvent`.
+ *
+ * `conferenceName` and `conferenceSid` are DELIBERATELY separate fields, and
+ * this is the whole point of the union for this route. CallCaster mints
+ * conference names as `${userId}~${uuid}` and stores that name in
+ * `call.conference_id`, while `ConferenceSid` is a `CF…` SID — two different
+ * identifiers that the old untyped code kept collapsing into one
+ * `friendly_name ?? conference_sid` expression. `dequeue_contact` binds the
+ * user argument as `::uuid`, so feeding it a conference NAME raised 22P02 on
+ * every terminal call: the contact was never dequeued and the dialer stopped
+ * after one call with the campaign stuck on "Running" (#1004).
+ *
+ * `conferenceUserId` is that name's user-id prefix, parsed here once, so the
+ * distinction is a field you have to pick rather than a cast you can forget.
+ * `conferenceRef` is the value used to ADDRESS the conference (name preferred,
+ * SID as fallback) — what `twilio.conferences.list({friendlyName})` wants and
+ * what gets written to `call.conference_id`.
+ */
+export const participantEventSchema = z.object({
+  ...voiceCallbackCommon,
+  kind: z.literal("participant"),
+  event: participantEventName,
+  /** `CF…` conference SID. */
+  conferenceSid: z.string().nullable(),
+  /** `FriendlyName` — the `${userId}~${uuid}` conference NAME, never a uuid on its own. */
+  conferenceName: z.string().nullable(),
+  /** `conferenceName ?? conferenceSid` — how the conference is addressed. */
+  conferenceRef: z.string().nullable(),
+  /** The `userId` prefix of `conferenceName`, or null when the name is not `${userId}~${uuid}`. */
+  conferenceUserId: z.string().nullable(),
+  participantCallSid: z.string().nullable(),
+  reasonParticipantLeft: z.string().nullable(),
+});
+
+/** A recording status callback (call or conference recording). */
+export const recordingEventSchema = z.object({
+  ...voiceCallbackCommon,
+  kind: z.literal("recording"),
+  recordingSid: z.string().nullable(),
+  recordingUrl: z.string().nullable(),
+  recordingStatus: z.string().nullable(),
+  /** Kept as a string: it is written straight to `call.recording_duration`, a text column. */
+  recordingDuration: z.string().nullable(),
+  conferenceSid: z.string().nullable(),
+});
+
+/**
+ * Anything else. Not an error — see the module doc: webhooks must never 500 on
+ * an unexpected body, so the raw params travel with the event and each route
+ * keeps whatever fallback it had.
+ */
+export const unrecognizedCallbackSchema = z.object({
+  ...voiceCallbackCommon,
+  kind: z.literal("unrecognized"),
+});
+
+export const twilioVoiceCallbackSchema = z.discriminatedUnion("kind", [
+  callStatusCallbackSchema,
+  participantEventSchema,
+  recordingEventSchema,
+  unrecognizedCallbackSchema,
+]);
+
+export type ParticipantEventName = (typeof PARTICIPANT_EVENT_NAMES)[number];
+export type CallStatusCallback = z.infer<typeof callStatusCallbackSchema>;
+export type ParticipantEvent = z.infer<typeof participantEventSchema>;
+export type RecordingEvent = z.infer<typeof recordingEventSchema>;
+export type UnrecognizedCallback = z.infer<typeof unrecognizedCallbackSchema>;
+export type TwilioVoiceCallback = z.infer<typeof twilioVoiceCallbackSchema>;
+
+export type ParticipantJoinEvent = ParticipantEvent & { event: "participant-join" };
+export type ParticipantLeaveEvent = ParticipantEvent & { event: "participant-leave" };
+
+function readString(
+  params: Record<string, string>,
+  key: string,
+): string | null {
+  const value = params[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function readNumber(params: Record<string, string>, key: string): number | null {
+  const raw = readString(params, key);
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * The `userId` half of a `${userId}~${uuid}` conference name.
+ *
+ * Returns null when the value has no `~` separator — a bare `CF…` SID or a
+ * legacy name is NOT a user id, and passing one to a `::uuid`-bound argument
+ * is the 22P02 crash described on `participantEventSchema`. Callers that only
+ * have `call.conference_id` (a stored conference name) use this too.
+ */
+export function userIdFromConferenceName(
+  conferenceName: string | null | undefined,
+): string | null {
+  if (!conferenceName) return null;
+  const separator = conferenceName.indexOf("~");
+  if (separator === -1) return null;
+  const userId = conferenceName.slice(0, separator);
+  return userId === "" ? null : userId;
+}
+
+const RECORDING_KEYS = ["RecordingSid", "RecordingUrl", "RecordingStatus"] as const;
+
+/**
+ * Parse a Twilio voice webhook form body into exactly one union member.
+ *
+ * Discrimination, in order:
+ *  1. any recording field present (`RecordingSid` / `RecordingUrl` /
+ *     `RecordingStatus`) → `recording`. Checked FIRST so a conference
+ *     recording callback (which also carries `ConferenceSid` and a
+ *     `StatusCallbackEvent`) cannot be mistaken for a participant event and
+ *     silently drop its recording fields. The consequence callers rely on:
+ *     if `kind !== "recording"`, there are no recording fields to read.
+ *  2. a recognized `StatusCallbackEvent` → `participant`.
+ *  3. `CallSid` and a non-empty `CallStatus` → `call-status`.
+ *  4. otherwise → `unrecognized`.
+ */
+export function parseTwilioVoiceCallback(
+  params: Record<string, string>,
+): TwilioVoiceCallback {
+  const raw = params ?? {};
+  const duration = readNumber(raw, "Duration");
+  const callDuration = readNumber(raw, "CallDuration");
+  const common = {
+    raw,
+    callSid: readString(raw, "CallSid"),
+    accountSid: readString(raw, "AccountSid"),
+    callStatus: readString(raw, "CallStatus") ?? "",
+    timestamp: readString(raw, "Timestamp"),
+    durationSeconds:
+      duration === null && callDuration === null
+        ? null
+        : Math.max(duration ?? 0, callDuration ?? 0),
+  };
+
+  if (RECORDING_KEYS.some((key) => readString(raw, key) !== null)) {
+    return {
+      ...common,
+      kind: "recording",
+      recordingSid: readString(raw, "RecordingSid"),
+      recordingUrl: readString(raw, "RecordingUrl"),
+      recordingStatus: readString(raw, "RecordingStatus"),
+      recordingDuration: readString(raw, "RecordingDuration"),
+      conferenceSid: readString(raw, "ConferenceSid"),
+    };
+  }
+
+  const statusCallbackEvent = readString(raw, "StatusCallbackEvent");
+  const participantEvent = participantEventName.safeParse(statusCallbackEvent);
+  if (participantEvent.success) {
+    const conferenceName = readString(raw, "FriendlyName");
+    const conferenceSid = readString(raw, "ConferenceSid");
+    return {
+      ...common,
+      kind: "participant",
+      event: participantEvent.data,
+      conferenceSid,
+      conferenceName,
+      conferenceRef: conferenceName ?? conferenceSid,
+      conferenceUserId: userIdFromConferenceName(conferenceName),
+      participantCallSid: readString(raw, "ParticipantCallSid") ?? common.callSid,
+      reasonParticipantLeft: readString(raw, "ReasonParticipantLeft"),
+    };
+  }
+
+  if (common.callSid && common.callStatus) {
+    return {
+      ...common,
+      kind: "call-status",
+      callSid: common.callSid,
+      callStatus: common.callStatus,
+      answeredBy: readString(raw, "AnsweredBy"),
+      direction: readString(raw, "Direction"),
+      from: readString(raw, "From"),
+      to: readString(raw, "To"),
+      parentCallSid: readString(raw, "ParentCallSid"),
+      sequenceNumber: readString(raw, "SequenceNumber"),
+    };
+  }
+
+  return { ...common, kind: "unrecognized" };
+}
+
+export function isParticipantJoin(
+  event: TwilioVoiceCallback,
+): event is ParticipantJoinEvent {
+  return event.kind === "participant" && event.event === "participant-join";
+}
+
+export function isParticipantLeave(
+  event: TwilioVoiceCallback,
+): event is ParticipantLeaveEvent {
+  return event.kind === "participant" && event.event === "participant-leave";
+}
+
+/**
+ * A participant leave the callee/agent caused by hanging up, as opposed to one
+ * the platform caused by ending the conference. Only the former should tear
+ * the conference down.
+ */
+export function isParticipantHangup(
+  event: TwilioVoiceCallback,
+): event is ParticipantLeaveEvent {
+  return isParticipantLeave(event) && event.reasonParticipantLeft === "participant_hung_up";
+}

--- a/app/lib/worker/handlers/webhook-adapters.server.ts
+++ b/app/lib/worker/handlers/webhook-adapters.server.ts
@@ -7,15 +7,18 @@ import type { ClaimedJobRow } from "@/lib/worker/poll-jobs.server";
 // `sidAndTwilioParamsSchema` moved to job-registry.server.ts in #1239 A3 so
 // job-params.server.ts (schema-only) can build these registrations without
 // depending on this file — see that module's doc comment for why.
-import type { SidAndTwilioParams } from "@/lib/worker/job-registry.server";
+import type {
+  SidAndTwilioParams,
+  VoiceSideEffectsParams,
+} from "@/lib/worker/job-registry.server";
 
 export async function callStatusSideEffectsHandler(
   job: ClaimedJobRow,
-  params: SidAndTwilioParams,
+  params: VoiceSideEffectsParams,
 ): Promise<unknown> {
   return runCallStatusSideEffects({
     callSid: params.sid,
-    twilioParams: params.twilioParams,
+    event: params.event,
   });
 }
 
@@ -31,10 +34,10 @@ export async function smsStatusSideEffectsHandler(
 
 export async function recordingSideEffectsHandler(
   job: ClaimedJobRow,
-  params: SidAndTwilioParams,
+  params: VoiceSideEffectsParams,
 ): Promise<unknown> {
   return runRecordingSideEffects({
     callSid: params.sid,
-    twilioParams: params.twilioParams,
+    event: params.event,
   });
 }

--- a/app/lib/worker/job-params.server.ts
+++ b/app/lib/worker/job-params.server.ts
@@ -11,6 +11,7 @@ import {
   legacyRequiredStringParam,
   legacyStringParam,
   sidAndTwilioParamsSchema,
+  voiceSideEffectsParamsSchema,
   type JobParamsEntry,
 } from "@/lib/worker/job-registry.server";
 import {
@@ -179,16 +180,20 @@ export const webhookDeliveryParams = z.object({
   optional: z.preprocess((value) => value === true, z.boolean()),
 });
 
-export const callStatusSideEffectsParams = sidAndTwilioParamsSchema(
-  "callSid",
+/**
+ * The two VOICE side-effect jobs additionally carry the route's parsed
+ * callback event (#1243 E1); SMS keeps the plain sid+params schema. Both voice
+ * schemas re-derive `event` from `twilioParams` when it is absent, so rows
+ * queued before E1 still parse — see `voiceSideEffectsParamsSchema`.
+ */
+export const callStatusSideEffectsParams = voiceSideEffectsParamsSchema(
   "call_status_side_effects",
 );
 export const smsStatusSideEffectsParams = sidAndTwilioParamsSchema(
   "messageSid",
   "sms_status_side_effects",
 );
-export const recordingSideEffectsParams = sidAndTwilioParamsSchema(
-  "callSid",
+export const recordingSideEffectsParams = voiceSideEffectsParamsSchema(
   "recording_side_effects",
 );
 

--- a/app/lib/worker/job-registry.server.ts
+++ b/app/lib/worker/job-registry.server.ts
@@ -5,6 +5,11 @@ import {
   type EnqueueJobArgs,
   type EnqueueJobResult,
 } from "@/lib/worker/enqueue-job.server";
+import {
+  parseTwilioVoiceCallback,
+  twilioVoiceCallbackSchema,
+  type TwilioVoiceCallback,
+} from "@/lib/twilio/voice-callback";
 
 /**
  * Job registry mechanism (ADR-0007 worker, #1239).
@@ -226,7 +231,7 @@ export type SidAndTwilioParams = {
 };
 
 /**
- * Shared params schema for the three Twilio webhook fast-ack side-effect job
+ * Shared params schema for the Twilio webhook fast-ack side-effect job
  * types (#1239 A2): each one used to re-implement the same
  * `requireSidAndTwilioParams` narrowing (sid key differs, everything else is
  * identical). One factory, parameterized on the sid field name and the label
@@ -273,6 +278,62 @@ export function sidAndTwilioParamsSchema(
         return z.NEVER;
       }
       return { sid, twilioParams };
+    });
+}
+
+export type VoiceSideEffectsParams = SidAndTwilioParams & {
+  /** The webhook body, parsed once by the route that enqueued this job. */
+  event: TwilioVoiceCallback;
+};
+
+/**
+ * Params schema for the VOICE fast-ack side-effect job types
+ * (`call_status_side_effects`, `recording_side_effects`) — #1243 E1.
+ *
+ * Same `{sid, twilioParams}` contract as `sidAndTwilioParamsSchema`, plus the
+ * parsed `event`: the route already discriminated the payload at its boundary,
+ * so the worker should not re-derive its own view of the same body with a
+ * second pass of loose `underCase` reads. `sms_status_side_effects` keeps the
+ * plain schema — it is not a voice callback.
+ *
+ * COMPATIBILITY, both directions:
+ * - Rows queued BEFORE this change carry only `{callSid|sid, twilioParams}`.
+ *   A missing (or malformed) `event` is re-derived from `twilioParams` with
+ *   `parseTwilioVoiceCallback`, so an already-queued job still runs, and runs
+ *   through exactly the same parser the route would have used.
+ * - Rows queued AFTER it are validated against `twilioVoiceCallbackSchema`, so
+ *   a payload written by some other shape falls back to re-deriving
+ *   rather than reaching a handler as a half-typed object.
+ *
+ * `twilioParams` stays on the payload deliberately: it is the raw evidence for
+ * dead-letter inspection and requeue, and E2's remaining routes still read it.
+ */
+export function voiceSideEffectsParamsSchema(
+  label: string,
+): z.ZodType<VoiceSideEffectsParams> {
+  return z
+    .object({
+      sid: legacyStringParam(),
+      callSid: legacyStringParam(),
+      twilioParams: legacyObjectParam<Record<string, string> | undefined>(undefined),
+      event: z.unknown().optional(),
+    })
+    .transform((value, ctx) => {
+      const sid = value.sid ?? value.callSid;
+      const twilioParams = value.twilioParams;
+      if (!sid || !twilioParams) {
+        ctx.addIssue({
+          code: "custom",
+          message: `${label}: missing callSid or twilioParams`,
+        });
+        return z.NEVER;
+      }
+      const parsed = twilioVoiceCallbackSchema.safeParse(value.event);
+      return {
+        sid,
+        twilioParams,
+        event: parsed.success ? parsed.data : parseTwilioVoiceCallback(twilioParams),
+      };
     });
 }
 

--- a/app/lib/worker/webhook-side-effects.server.ts
+++ b/app/lib/worker/webhook-side-effects.server.ts
@@ -32,8 +32,8 @@ import { emitPredictiveBroadcast } from "@/lib/workspace-events.server";
 import {
   billTerminalCallStatus,
   resolveCallOutreachContext,
-  twilioParamsToUnderCase,
 } from "@/lib/twilio-call-status.server";
+import type { TwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 import { persistCallRecordingToStorage } from "@/lib/call-recording-storage.server";
 import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
 import { ELEVENLABS_BATCH_TRANSCRIBE_JOB_TYPE } from "@/lib/worker/job-types.server";
@@ -48,9 +48,15 @@ const CALL_STATUS_TO_DISPOSITION: Record<string, string> = {
   canceled: "canceled",
 };
 
+/**
+ * `event` is the callback the ROUTE already parsed (#1243 E1) — the worker no
+ * longer re-derives its own `underCase` view of the same body. Jobs queued
+ * before E1 get it re-derived from their stored `twilioParams` by
+ * `voiceSideEffectsParamsSchema`, so this always receives a real union member.
+ */
 export async function runCallStatusSideEffects(args: {
   callSid: string;
-  twilioParams: Record<string, string>;
+  event: TwilioVoiceCallback;
 }): Promise<{ ok: true }> {
   const callRow = await findCallBySid(args.callSid);
   if (!callRow) {
@@ -59,7 +65,7 @@ export async function runCallStatusSideEffects(args: {
 
   await billTerminalCallStatus(callRow);
 
-  const underCaseData = twilioParamsToUnderCase(args.twilioParams);
+  const callStatus = args.event.callStatus;
   const { outreachAttemptId, workspaceId } = await resolveCallOutreachContext(callRow);
 
   const currentAttempt =
@@ -71,7 +77,7 @@ export async function runCallStatusSideEffects(args: {
   if (currentAttempt && billingWorkspace) {
     await emitPredictiveBroadcast(billingWorkspace, {
       contact_id: currentAttempt.contact_id,
-      status: String(underCaseData.call_status ?? ""),
+      status: callStatus,
     });
 
     // Provider-terminal statuses stamp a disposition so every call yields a
@@ -80,8 +86,7 @@ export async function runCallStatusSideEffects(args: {
     // transition guard keeps AMD "voicemail" and other terminal values from
     // being downgraded, and an explicit agent choice via /api/questions
     // bypasses this guard entirely, so it always wins.
-    const terminalDisposition =
-      CALL_STATUS_TO_DISPOSITION[String(underCaseData.call_status ?? "").toLowerCase()];
+    const terminalDisposition = CALL_STATUS_TO_DISPOSITION[callStatus.toLowerCase()];
     if (
       terminalDisposition &&
       shouldUpdateOutreachDisposition({
@@ -244,16 +249,20 @@ export async function runSmsStatusSideEffects(args: {
 
 export async function runRecordingSideEffects(args: {
   callSid: string;
-  twilioParams: Record<string, string>;
+  event: TwilioVoiceCallback;
 }): Promise<{ ok: true }> {
   const callRow = await findCallBySid(args.callSid);
   if (!callRow?.workspace) {
     throw new Error(`Call ${args.callSid} not found for recording side effects`);
   }
 
-  const recordingSid = args.twilioParams.RecordingSid?.trim();
-  const recordingDuration = args.twilioParams.RecordingDuration?.trim();
-  const accountSid = args.twilioParams.AccountSid?.trim();
+  // The parser classifies any payload carrying a recording field as
+  // `recording`, so a non-recording event provably has nothing to persist —
+  // no raw-params fallback needed here.
+  const recording = args.event.kind === "recording" ? args.event : null;
+  const recordingSid = recording?.recordingSid ?? null;
+  const recordingDuration = recording?.recordingDuration ?? null;
+  const accountSid = args.event.accountSid;
 
   const enrichment: Record<string, string> = {};
   if (recordingSid) {

--- a/app/routes/api+/auto-dial/status.action.server.ts
+++ b/app/routes/api+/auto-dial/status.action.server.ts
@@ -1,8 +1,16 @@
 import {
   buildCallUpsertFromTwilioParams,
   processCallStatusWebhook,
-  twilioParamsToUnderCase,
 } from "@/lib/twilio-call-status.server";
+import {
+  isParticipantHangup,
+  isParticipantJoin,
+  parseTwilioVoiceCallback,
+  userIdFromConferenceName,
+  type ParticipantJoinEvent,
+  type ParticipantLeaveEvent,
+  type TwilioVoiceCallback,
+} from "@/lib/twilio/voice-callback";
 import { buildProviderStatusQueueUpdate } from "@/lib/queue-status";
 import {
   dequeueQueueEntry,
@@ -91,11 +99,18 @@ const updateCampaignQueue = async (
   }
 };
 
+/**
+ * The user id stored inside a `call.conference_id`, which is a conference NAME
+ * (`${userId}~${uuid}`), not a SID. Webhook payloads get this parsed for them
+ * as `conferenceUserId`; this wrapper is for the DB-derived value.
+ *
+ * The `?? conferenceId` fallback is deliberate legacy tolerance: a stored
+ * conference id with no `~` predates the `${userId}~${uuid}` naming and was
+ * always passed through whole.
+ */
 function resolveUserIdFromConferenceName(conferenceId: string | null): string {
   if (!conferenceId) return "";
-  const sep = conferenceId.indexOf("~");
-  if (sep === -1) return conferenceId;
-  return conferenceId.slice(0, sep);
+  return userIdFromConferenceName(conferenceId) ?? conferenceId;
 }
 
 const triggerAutoDialer = async (callData: Tables<"call">) => {
@@ -121,14 +136,13 @@ const triggerAutoDialer = async (callData: Tables<"call">) => {
 };
 
 const handleCallStatus = async (
-  parsedBody: { [x: string]: string },
+  event: TwilioVoiceCallback,
   dbCall: Tables<"call">,
   twilio: TwilioClient,
   status: Tables<"call">["status"],
 ) => {
   try {
-    const callSid = requireValue(parsedBody.CallSid, "CallSid");
-    const updateData = buildCallUpsertFromTwilioParams(parsedBody);
+    const updateData = buildCallUpsertFromTwilioParams(event.raw);
     if (status) {
       updateData.status = status;
     }
@@ -181,22 +195,20 @@ const handleCallStatus = async (
 };
 
 const handleParticipantLeave = async (
-  parsedBody: { [x: string]: string },
+  event: ParticipantLeaveEvent,
   twilio: TwilioClient,
 ) => {
-  const underCase = twilioParamsToUnderCase(parsedBody);
-
   try {
-    const callSid = requireValue(typeof underCase.call_sid === "string" ? underCase.call_sid : null, "CallSid");
-    const timestamp = requireValue(typeof underCase.timestamp === "string" ? underCase.timestamp : null, "Timestamp");
+    const callSid = requireValue(event.callSid, "CallSid");
+    const timestamp = requireValue(event.timestamp, "Timestamp");
     const existingCall = await findCallBySid(callSid);
     if (!existingCall?.workspace) {
       throw new Error("Call not found for participant leave");
     }
     const dbCall = await updateCall(callSid, existingCall.workspace, {
       end_time: new Date(timestamp).toISOString(),
-      duration: Math.max(Number(underCase.duration), Number(underCase.call_duration)).toString(),
-      status: (typeof underCase.call_status === "string" ? underCase.call_status : "")?.toLowerCase() as Tables<"call">["status"]
+      duration: String(event.durationSeconds ?? 0),
+      status: event.callStatus.toLowerCase() as Tables<"call">["status"],
     });
     if (!dbCall.outreach_attempt_id) {
       throw new Error("Missing outreach_attempt_id for participant leave");
@@ -210,7 +222,7 @@ const handleParticipantLeave = async (
     }
 
     const conferences = await twilio.conferences.list({
-      friendlyName: typeof underCase.friendly_name === "string" ? underCase.friendly_name : (typeof underCase.conference_sid === "string" ? underCase.conference_sid : ""),
+      friendlyName: event.conferenceRef ?? "",
       status: "in-progress",
     });
     await Promise.all(
@@ -225,25 +237,21 @@ const handleParticipantLeave = async (
 };
 
 const handleParticipantJoin = async (
-  parsedBody: { [x: string]: string },
+  event: ParticipantJoinEvent,
   dbCall: Tables<"call">,
 ) => {
-  const underCase = twilioParamsToUnderCase(parsedBody);
   try {
     const workspaceId = requireValue(dbCall.workspace, "workspace");
     if (!dbCall.conference_id) {
-      await updateCall(
-        requireValue(typeof underCase.call_sid === "string" ? underCase.call_sid : null, "CallSid"),
-        workspaceId,
-        {
-          conference_id: requireValue(
-          (typeof underCase.friendly_name === "string" ? underCase.friendly_name : null) ??
-            (typeof underCase.conference_sid === "string" ? underCase.conference_sid : null),
-          "ConferenceSid",
-        ),
-          start_time: new Date(requireValue(typeof underCase.timestamp === "string" ? underCase.timestamp : null, "Timestamp")).toISOString(),
-        },
-      );
+      await updateCall(requireValue(event.callSid, "CallSid"), workspaceId, {
+        // `conferenceRef`, not `conferenceUserId`: `call.conference_id` holds
+        // the conference NAME. Reading the user id back out of it is
+        // `resolveUserIdFromConferenceName`'s job, at the point of use.
+        conference_id: requireValue(event.conferenceRef, "ConferenceSid"),
+        start_time: new Date(
+          requireValue(event.timestamp, "Timestamp"),
+        ).toISOString(),
+      });
     }
     if (dbCall.outreach_attempt_id) {
       if (!dbCall.campaign_id) {
@@ -270,13 +278,8 @@ const handleParticipantJoin = async (
         return;
       }
       await updateCampaignQueue(outreachStatus.contact_id, dbCall.campaign_id, {
-        ...buildProviderStatusQueueUpdate(
-          (typeof underCase.friendly_name === "string" ? underCase.friendly_name : null) ??
-            (typeof underCase.conference_sid === "string" ? underCase.conference_sid : null) ??
-            "in-progress",
-        ),
+        ...buildProviderStatusQueueUpdate(event.conferenceRef ?? "in-progress"),
       });
-
     }
   } catch (error) {
     logger.error("Error in handleParticipantJoin:", error);
@@ -289,10 +292,12 @@ export const action = defineAction({
     // Clone before reading — Bun yields empty params on re-read after consume.
     const formData = await request.clone().formData();
     const params = Object.fromEntries(formData.entries()) as Record<string, string>;
-    const underCase = twilioParamsToUnderCase(params);
+    // Parse the payload ONCE, here, into a discriminated union. Everything
+    // downstream takes a typed event instead of re-narrowing the same form
+    // fields with `typeof x === "string"` — see @/lib/twilio/voice-callback.
+    const event = parseTwilioVoiceCallback(params);
 
-    const callSidValue =
-      typeof underCase.call_sid === "string" ? underCase.call_sid : null;
+    const callSidValue = event.callSid;
     if (!callSidValue) {
       throw new Error("Missing CallSid");
     }
@@ -303,11 +308,11 @@ export const action = defineAction({
     });
     if (forbidden) return forbidden;
 
-    return { parsedBody: params, underCase, callSidValue };
+    return { event, callSidValue };
   },
   sideEffects: ["db-write", "credit", "twilio"],
   handler: async ({ auth }) => {
-    const { parsedBody, underCase, callSidValue } = auth;
+    const { event, callSidValue } = auth;
     try {
     const dbCall = await findCallBySid(callSidValue);
     if (!dbCall?.workspace) {
@@ -322,8 +327,10 @@ export const action = defineAction({
 
     const twilio = await createWorkspaceTwilioInstance({ workspace_id: requireValue(dbCall.workspace, "workspace"),
     });
-    const callStatusValue =
-      typeof underCase.call_status === "string" ? underCase.call_status : "";
+    // `""` when Twilio sent no CallStatus, on every union member — conference
+    // participant callbacks carry one too, and this switch runs before the
+    // event kind is ever consulted.
+    const callStatusValue = event.callStatus;
 
     // Predictive contact calls send their status callbacks HERE, not to
     // /api/call-status — so this route is the only place that can push
@@ -363,28 +370,17 @@ export const action = defineAction({
           }
         }
         await handleCallStatus(
-          parsedBody,
+          event,
           dbCall,
           twilio,
           callStatusValue?.toLowerCase() as Tables<"call">["status"],
         );
         break;
       default:
-        if (
-          (typeof underCase.status_callback_event === "string"
-            ? underCase.status_callback_event
-            : "") === "participant-leave" &&
-          (typeof underCase.reason_participant_left === "string"
-            ? underCase.reason_participant_left
-            : "") === "participant_hung_up"
-        ) {
-          await handleParticipantLeave(parsedBody, twilio);
-        } else if (
-          (typeof underCase.status_callback_event === "string"
-            ? underCase.status_callback_event
-            : "") === "participant-join"
-        ) {
-          await handleParticipantJoin(parsedBody, dbCall);
+        if (isParticipantHangup(event)) {
+          await handleParticipantLeave(event, twilio);
+        } else if (isParticipantJoin(event)) {
+          await handleParticipantJoin(event, dbCall);
         }
     }
 

--- a/app/routes/api+/call-status.action.server.ts
+++ b/app/routes/api+/call-status.action.server.ts
@@ -3,6 +3,7 @@ import {
   processCallStatusWebhook,
 } from "@/lib/twilio-call-status.server";
 import { data as routeData } from "react-router";
+import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { defineAction } from "@/lib/handler.server";
 import { enqueueRegisteredJob } from "@/lib/worker/job-params.server";
@@ -47,6 +48,9 @@ export const action = defineAction({
       return routeData({ error: "Missing CallSid" }, { status: 400 });
     }
 
+    // Parsed here so the side-effects job carries the discriminated event
+    // instead of the worker re-deriving its own view of the same body (#1243).
+    const event = parseTwilioVoiceCallback(params);
     const updateData = buildCallUpsertFromTwilioParams(params);
     const { call } = await processCallStatusWebhook(updateData, { skipBilling: true });
 
@@ -61,6 +65,7 @@ export const action = defineAction({
       params: {
         sid: callSidRaw,
         twilioParams: params,
+        event,
       },
     });
 

--- a/app/routes/api+/recording.action.server.ts
+++ b/app/routes/api+/recording.action.server.ts
@@ -1,5 +1,6 @@
 import { data as routeData } from "react-router";
 import { logger } from "@/lib/logger.server";
+import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { updateCallRecordingUrlBySid } from "@/lib/telephony-db.server";
 import { defineAction } from "@/lib/handler.server";
@@ -57,6 +58,9 @@ export const action = defineAction({
             params: {
               sid: callSid,
               twilioParams: params,
+              // The route's own handling is untouched here (that is E2); this
+              // only stops the worker from re-parsing the body a second time.
+              event: parseTwilioVoiceCallback(params),
             },
           });
         }

--- a/test/auto-dial-status.test.ts
+++ b/test/auto-dial-status.test.ts
@@ -1038,6 +1038,73 @@ describe("api.auto-dial.status", () => {
     expect(res.status).toBe(200);
   });
 
+  /**
+   * The payload is parsed once at the route boundary into a discriminated
+   * union (#1243 E1). A body that matches no known shape must still ack:
+   * Twilio retries 5xx for hours, and there is nothing about an unexpected
+   * shape that another delivery would fix.
+   */
+  test("an unrecognized payload acks instead of erroring", async () => {
+    const mod = await import("../app/routes/api+/auto-dial/status.route");
+    const fd = new FormData();
+    fd.set("CallSid", "CA1");
+    fd.set("SomethingTwilioAddedLater", "1");
+    const res = await asRouteResponse(mod.action({
+      request: new Request("http://localhost/api/auto-dial/status", {
+        method: "POST",
+        headers: { "x-twilio-signature": "good" },
+        body: fd,
+      }),
+    } as any));
+    expect(res.status).toBe(200);
+    expect(dequeueQueueEntryMock).not.toHaveBeenCalled();
+    expect(campaignQueueDbMocks.updateCampaignQueueByContactAndCampaign).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `call.conference_id` holds the conference NAME (`${userId}~${uuid}`), not
+   * the `CF…` SID — the two were previously collapsed into one
+   * `friendly_name ?? conference_sid` expression at each use, which is how the
+   * 22P02 incident (#1004) got its wrong value. The parsed event keeps them
+   * apart, so join must persist the name even when a SID is also present.
+   */
+  test("participant-join stores the conference NAME, not the conference SID", async () => {
+    const conferenceName = "u1~9f3ae1b2-0000-4000-8000-00000000abcd";
+    postgresStub = await usePostgresStub({
+      dbCall: {
+        sid: "CA1",
+        workspace: "w1",
+        outreach_attempt_id: 1,
+        conference_id: null,
+        contact_id: 1,
+        campaign_id: 1,
+      },
+    } as any);
+
+    const mod = await import("../app/routes/api+/auto-dial/status.route");
+    const fd = new FormData();
+    fd.set("CallSid", "CA1");
+    fd.set("CallStatus", "ringing");
+    fd.set("StatusCallbackEvent", "participant-join");
+    fd.set("Timestamp", new Date().toISOString());
+    fd.set("ConferenceSid", "CF_SID_NOT_A_NAME");
+    fd.set("FriendlyName", conferenceName);
+    const res = await asRouteResponse(mod.action({
+      request: new Request("http://localhost/api/auto-dial/status", {
+        method: "POST",
+        headers: { "x-twilio-signature": "good" },
+        body: fd,
+      }),
+    } as any));
+
+    expect(res.status).toBe(200);
+    expect(telephonyStubState.callUpdateCalls).toEqual([
+      expect.objectContaining({
+        patch: expect.objectContaining({ conference_id: conferenceName }),
+      }),
+    ]);
+  });
+
   test("action catch formats non-Error as Unknown error", async () => {
     const dbMod = await import("../app/lib/database/workspace.server");
     (dbMod.createWorkspaceTwilioInstance as any).mockRejectedValueOnce("nope");

--- a/test/call-status-billing.test.ts
+++ b/test/call-status-billing.test.ts
@@ -6,6 +6,7 @@ vi.hoisted(() => {
 
 import { asRouteResponse } from "./helpers/route-result";
 import { type TransactionRow } from "./helpers/transaction-history-stub";
+import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 
 // Avoid env validation noise when importing server modules in tests.
 vi.mock("@/lib/env.server", () => {
@@ -169,15 +170,15 @@ describe("api.call-status billing + idempotency", () => {
 
     await runCallStatusSideEffects({
       callSid: "CA1",
-      twilioParams: { CallSid: "CA1", CallStatus: "completed", Duration: "1" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: "completed", Duration: "1" }),
     });
     await runCallStatusSideEffects({
       callSid: "CA60",
-      twilioParams: { CallSid: "CA60", CallStatus: "completed", Duration: "60" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA60", CallStatus: "completed", Duration: "60" }),
     });
     await runCallStatusSideEffects({
       callSid: "CA61",
-      twilioParams: { CallSid: "CA61", CallStatus: "completed", Duration: "61" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA61", CallStatus: "completed", Duration: "61" }),
     });
 
     const amounts = transactionRowsState.rows.map((r) => r.amount);
@@ -201,15 +202,15 @@ describe("api.call-status billing + idempotency", () => {
 
     await runCallStatusSideEffects({
       callSid: "CA_FAILED",
-      twilioParams: { CallSid: "CA_FAILED", CallStatus: "failed", Duration: "0" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA_FAILED", CallStatus: "failed", Duration: "0" }),
     });
     await runCallStatusSideEffects({
       callSid: "CA_BUSY",
-      twilioParams: { CallSid: "CA_BUSY", CallStatus: "busy", Duration: "0" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA_BUSY", CallStatus: "busy", Duration: "0" }),
     });
     await runCallStatusSideEffects({
       callSid: "CA_NOANSWER",
-      twilioParams: { CallSid: "CA_NOANSWER", CallStatus: "no-answer", Duration: "0" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA_NOANSWER", CallStatus: "no-answer", Duration: "0" }),
     });
 
     expect(transactionRowsState.rows).toHaveLength(0);
@@ -232,11 +233,11 @@ describe("api.call-status billing + idempotency", () => {
 
     await runCallStatusSideEffects({
       callSid: "CA_DUP",
-      twilioParams: { CallSid: "CA_DUP", CallStatus: "completed", Duration: "61" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA_DUP", CallStatus: "completed", Duration: "61" }),
     });
     await runCallStatusSideEffects({
       callSid: "CA_DUP",
-      twilioParams: { CallSid: "CA_DUP", CallStatus: "completed", Duration: "61" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA_DUP", CallStatus: "completed", Duration: "61" }),
     });
 
     const matching = transactionRowsState.rows.filter(

--- a/test/job-registry.test.ts
+++ b/test/job-registry.test.ts
@@ -10,6 +10,7 @@ import {
   validateStoredJobParams,
 } from "@/lib/worker/handlers.server";
 import { jobParamsRegistry } from "@/lib/worker/job-params.server";
+import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 
 /**
  * Drift guard for #1239 A1: `jobHandlers`, `PAGING_JOB_TYPES`, and
@@ -236,7 +237,62 @@ describe("job registry — defineJob params validation (#1239 A2 migrations)", (
         messageSid: "SM_should_be_ignored",
         twilioParams: { CallStatus: "completed" },
       }),
-    ).toEqual({ sid: "CA1", twilioParams: { CallStatus: "completed" } });
+    ).toMatchObject({ sid: "CA1", twilioParams: { CallStatus: "completed" } });
+  });
+
+  /**
+   * #1243 E1 added a parsed `event` to the two VOICE side-effect job payloads.
+   * Rows queued before it exist in `job` right now and must still run — the
+   * schema re-derives `event` from the stored `twilioParams` rather than
+   * failing validation and dead-lettering a job that would have billed.
+   */
+  test("voice side-effect rows queued under the pre-E1 shape still parse, with the event re-derived", () => {
+    const callStatus = jobRegistry.find((r) => r.type === "call_status_side_effects");
+    const recording = jobRegistry.find((r) => r.type === "recording_side_effects");
+
+    const oldShape = callStatus!.params.parse({
+      callSid: "CA1",
+      twilioParams: { CallSid: "CA1", CallStatus: "completed", Duration: "61" },
+    });
+    expect(oldShape).toMatchObject({
+      sid: "CA1",
+      event: { kind: "call-status", callSid: "CA1", callStatus: "completed", durationSeconds: 61 },
+    });
+
+    const oldRecordingShape = recording!.params.parse({
+      callSid: "CA1",
+      twilioParams: { CallSid: "CA1", RecordingSid: "RE1", RecordingDuration: "12" },
+    });
+    expect(oldRecordingShape).toMatchObject({
+      sid: "CA1",
+      event: { kind: "recording", recordingSid: "RE1", recordingDuration: "12" },
+    });
+
+    // A payload written by the new enqueue sites is taken as-is.
+    const newShape = callStatus!.params.parse({
+      sid: "CA1",
+      twilioParams: { CallSid: "CA1", CallStatus: "busy" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: "busy" }),
+    });
+    expect(newShape.event).toEqual(
+      parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: "busy" }),
+    );
+
+    // A malformed `event` is not trusted: fall back to the raw params rather
+    // than handing a half-typed object to a handler.
+    const junkEvent = callStatus!.params.parse({
+      callSid: "CA1",
+      twilioParams: { CallSid: "CA1", CallStatus: "completed" },
+      event: { kind: "not-a-kind" },
+    });
+    expect(junkEvent.event).toMatchObject({ kind: "call-status", callStatus: "completed" });
+
+    // sms_status_side_effects is NOT a voice callback and keeps the plain shape.
+    expect(
+      jobRegistry
+        .find((r) => r.type === "sms_status_side_effects")!
+        .params.parse({ messageSid: "SM1", twilioParams: { SmsStatus: "delivered" } }),
+    ).toEqual({ sid: "SM1", twilioParams: { SmsStatus: "delivered" } });
   });
 
   test("webhook_delivery requires a valid eventType and rejects the same falsy payload/eventCategory the old bundled check did", () => {

--- a/test/twilio-voice-callback.test.ts
+++ b/test/twilio-voice-callback.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  isParticipantHangup,
+  isParticipantJoin,
+  isParticipantLeave,
+  parseTwilioVoiceCallback,
+  twilioVoiceCallbackSchema,
+  userIdFromConferenceName,
+} from "@/lib/twilio/voice-callback";
+
+describe("parseTwilioVoiceCallback", () => {
+  test("parses a plain call status callback", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      AccountSid: "AC1",
+      CallStatus: "completed",
+      Timestamp: "2026-08-14T00:00:00.000Z",
+      Duration: "60",
+      CallDuration: "61",
+      AnsweredBy: "machine_start",
+      Direction: "outbound-api",
+      From: "+15550000001",
+      To: "+15550000002",
+      ParentCallSid: "CA_PARENT",
+      SequenceNumber: "3",
+    });
+
+    expect(event.kind).toBe("call-status");
+    expect(event).toMatchObject({
+      kind: "call-status",
+      callSid: "CA1",
+      accountSid: "AC1",
+      callStatus: "completed",
+      answeredBy: "machine_start",
+      parentCallSid: "CA_PARENT",
+      // The max of Duration/CallDuration every caller used to compute by hand.
+      durationSeconds: 61,
+    });
+  });
+
+  test("call status with neither duration field reports null, not NaN", () => {
+    const event = parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: "ringing" });
+    expect(event.kind).toBe("call-status");
+    expect(event.durationSeconds).toBeNull();
+  });
+
+  test("parses a participant join event", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      CallStatus: "ringing",
+      StatusCallbackEvent: "participant-join",
+      ConferenceSid: "CF1",
+      FriendlyName: "u1~9f3ae1b2-0000-4000-8000-00000000abcd",
+      Timestamp: "2026-08-14T00:00:00.000Z",
+    });
+
+    expect(isParticipantJoin(event)).toBe(true);
+    expect(event).toMatchObject({
+      kind: "participant",
+      event: "participant-join",
+      conferenceSid: "CF1",
+      conferenceName: "u1~9f3ae1b2-0000-4000-8000-00000000abcd",
+      conferenceRef: "u1~9f3ae1b2-0000-4000-8000-00000000abcd",
+      conferenceUserId: "u1",
+      // CallStatus still travels on a participant event — the auto-dial route
+      // switches on it before it ever looks at StatusCallbackEvent.
+      callStatus: "ringing",
+    });
+  });
+
+  test("parses a participant leave event with its hangup reason", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      CallStatus: "ringing",
+      StatusCallbackEvent: "participant-leave",
+      ReasonParticipantLeft: "participant_hung_up",
+      ConferenceSid: "CF1",
+      FriendlyName: "u1~9f3ae1b2-0000-4000-8000-00000000abcd",
+      Duration: "1",
+      CallDuration: "2",
+    });
+
+    expect(isParticipantLeave(event)).toBe(true);
+    expect(isParticipantHangup(event)).toBe(true);
+    expect(event).toMatchObject({ durationSeconds: 2 });
+  });
+
+  test("a participant leave the platform caused is not a hangup", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      StatusCallbackEvent: "participant-leave",
+      ReasonParticipantLeft: "conference_ended",
+      ConferenceSid: "CF1",
+    });
+    expect(isParticipantLeave(event)).toBe(true);
+    expect(isParticipantHangup(event)).toBe(false);
+  });
+
+  /**
+   * REGRESSION (#1004, the 22P02 incident). Conference names are minted as
+   * `${userId}~${uuid}` and `dequeue_contact` binds the user argument as
+   * `::uuid`. Passing the conference NAME raised
+   * `invalid input syntax for type uuid` on every terminal call, so contacts
+   * were never dequeued and the dialer stopped after one call. The parser must
+   * keep the name, the SID and the user id as three separate values — never
+   * collapse them into one "conference id".
+   */
+  test("keeps the conference name, SID and user id distinct (22P02 regression)", () => {
+    const userId = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+    const conferenceName = `${userId}~9f3ae1b2-0000-4000-8000-00000000abcd`;
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      StatusCallbackEvent: "participant-join",
+      ConferenceSid: "CF_NOT_A_UUID",
+      FriendlyName: conferenceName,
+    });
+
+    expect(event.kind).toBe("participant");
+    if (event.kind !== "participant") return;
+    expect(event.conferenceName).toBe(conferenceName);
+    expect(event.conferenceSid).toBe("CF_NOT_A_UUID");
+    expect(event.conferenceUserId).toBe(userId);
+    expect(event.conferenceUserId).not.toBe(conferenceName);
+    expect(event.conferenceRef).toBe(conferenceName);
+  });
+
+  test("a conference name with no separator yields no user id", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      StatusCallbackEvent: "participant-join",
+      ConferenceSid: "CF1",
+      FriendlyName: "in-progress",
+    });
+    expect(event.kind).toBe("participant");
+    if (event.kind !== "participant") return;
+    expect(event.conferenceUserId).toBeNull();
+    expect(event.conferenceRef).toBe("in-progress");
+  });
+
+  test("falls back to the conference SID when there is no friendly name", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      StatusCallbackEvent: "participant-join",
+      ConferenceSid: "CF1",
+    });
+    expect(event.kind).toBe("participant");
+    if (event.kind !== "participant") return;
+    expect(event.conferenceName).toBeNull();
+    expect(event.conferenceRef).toBe("CF1");
+  });
+
+  test("parses a recording status callback", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      AccountSid: "AC1",
+      RecordingSid: "RE1",
+      RecordingUrl: "https://api.twilio.com/rec",
+      RecordingStatus: "completed",
+      RecordingDuration: "42",
+    });
+
+    expect(event).toMatchObject({
+      kind: "recording",
+      recordingSid: "RE1",
+      recordingUrl: "https://api.twilio.com/rec",
+      recordingStatus: "completed",
+      // A string, because it is written straight to a text column.
+      recordingDuration: "42",
+      accountSid: "AC1",
+    });
+  });
+
+  /**
+   * Recording wins over the participant check so a conference recording
+   * callback (which also carries ConferenceSid + StatusCallbackEvent) does not
+   * silently lose its recording fields. Callers depend on the converse:
+   * `kind !== "recording"` means there is nothing recording-shaped to read.
+   */
+  test("a conference recording callback parses as a recording, not a participant event", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      ConferenceSid: "CF1",
+      StatusCallbackEvent: "conference-end",
+      RecordingSid: "RE1",
+      RecordingUrl: "https://api.twilio.com/rec",
+    });
+    expect(event.kind).toBe("recording");
+    if (event.kind !== "recording") return;
+    expect(event.conferenceSid).toBe("CF1");
+  });
+
+  test("an unknown StatusCallbackEvent with a CallStatus is still a call status callback", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "CA1",
+      CallStatus: "ringing",
+      StatusCallbackEvent: "something-twilio-added-later",
+    });
+    expect(event.kind).toBe("call-status");
+  });
+
+  test("returns UnrecognizedCallback carrying the raw params instead of throwing", () => {
+    const raw = { Nonsense: "yes", Another: "1" };
+    const event = parseTwilioVoiceCallback(raw);
+    expect(event.kind).toBe("unrecognized");
+    expect(event.raw).toEqual(raw);
+    expect(event.callSid).toBeNull();
+    expect(event.callStatus).toBe("");
+  });
+
+  test("an empty body is unrecognized, not an error", () => {
+    expect(() => parseTwilioVoiceCallback({})).not.toThrow();
+    expect(parseTwilioVoiceCallback({}).kind).toBe("unrecognized");
+  });
+
+  test("a CallSid with no CallStatus is unrecognized", () => {
+    const event = parseTwilioVoiceCallback({ CallSid: "CA1" });
+    expect(event.kind).toBe("unrecognized");
+    expect(event.callSid).toBe("CA1");
+  });
+
+  test("blank and non-string field values read as absent", () => {
+    const event = parseTwilioVoiceCallback({
+      CallSid: "  CA1  ",
+      CallStatus: "completed",
+      AnsweredBy: "   ",
+      Duration: "not-a-number",
+      To: undefined as unknown as string,
+    });
+    expect(event.kind).toBe("call-status");
+    if (event.kind !== "call-status") return;
+    expect(event.callSid).toBe("CA1");
+    expect(event.answeredBy).toBeNull();
+    expect(event.to).toBeNull();
+    expect(event.durationSeconds).toBeNull();
+  });
+
+  test("every parse result satisfies the schema the job payload validates against", () => {
+    const bodies = [
+      { CallSid: "CA1", CallStatus: "completed", Duration: "10" },
+      { CallSid: "CA1", StatusCallbackEvent: "participant-join", ConferenceSid: "CF1" },
+      { CallSid: "CA1", RecordingSid: "RE1" },
+      { Nothing: "here" },
+    ];
+    for (const body of bodies) {
+      expect(twilioVoiceCallbackSchema.safeParse(parseTwilioVoiceCallback(body)).success).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe("userIdFromConferenceName", () => {
+  test("returns the prefix before the separator", () => {
+    expect(userIdFromConferenceName("u1~abc")).toBe("u1");
+  });
+
+  test("returns null for a name with no separator, so no ::uuid bind gets a conference name", () => {
+    expect(userIdFromConferenceName("CF1")).toBeNull();
+    expect(userIdFromConferenceName(null)).toBeNull();
+    expect(userIdFromConferenceName(undefined)).toBeNull();
+    expect(userIdFromConferenceName("")).toBeNull();
+    expect(userIdFromConferenceName("~abc")).toBeNull();
+  });
+});

--- a/test/webhook-side-effects.test.ts
+++ b/test/webhook-side-effects.test.ts
@@ -4,6 +4,11 @@ vi.hoisted(() => {
   process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/test";
 });
 
+// Voice side-effect runners take the callback the ROUTE parsed (#1243 E1), so
+// fixtures stay raw Twilio bodies and go through the real parser rather than
+// being hand-built union members that could drift from what a route produces.
+import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
+
 const mocks = vi.hoisted(() => ({
   findCallBySid: vi.fn(),
   billTerminalCallStatus: vi.fn(),
@@ -156,7 +161,7 @@ describe("webhook side-effect handlers", () => {
 
     await runCallStatusSideEffects({
       callSid: "CA1",
-      twilioParams: { CallSid: "CA1", CallStatus: "completed" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: "completed" }),
     });
 
     expect(mocks.billTerminalCallStatus).toHaveBeenCalled();
@@ -183,7 +188,7 @@ describe("webhook side-effect handlers", () => {
     );
     await runCallStatusSideEffects({
       callSid: "CA1",
-      twilioParams: { CallSid: "CA1", CallStatus: status },
+      event: parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: status }),
     });
     expect(mocks.updateOutreachAttemptForWorkspace).toHaveBeenCalledWith(
       "w1",
@@ -203,7 +208,7 @@ describe("webhook side-effect handlers", () => {
     );
     await runCallStatusSideEffects({
       callSid: "CA1",
-      twilioParams: { CallSid: "CA1", CallStatus: "completed" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: "completed" }),
     });
     expect(mocks.updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
   });
@@ -214,7 +219,7 @@ describe("webhook side-effect handlers", () => {
     );
     await runCallStatusSideEffects({
       callSid: "CA1",
-      twilioParams: { CallSid: "CA1", CallStatus: "in-progress" },
+      event: parseTwilioVoiceCallback({ CallSid: "CA1", CallStatus: "in-progress" }),
     });
     expect(mocks.updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
   });
@@ -284,12 +289,12 @@ describe("webhook side-effect handlers", () => {
 
     await runRecordingSideEffects({
       callSid: "CA1",
-      twilioParams: {
+      event: parseTwilioVoiceCallback({
         CallSid: "CA1",
         AccountSid: "ACmain",
         RecordingSid: "RE1",
         RecordingDuration: "12",
-      },
+      }),
     });
 
     expect(mocks.persistCallRecordingToStorage).toHaveBeenCalledWith({
@@ -317,12 +322,12 @@ describe("webhook side-effect handlers", () => {
 
     await runRecordingSideEffects({
       callSid: "CA1",
-      twilioParams: {
+      event: parseTwilioVoiceCallback({
         CallSid: "CA1",
         AccountSid: "ACmain",
         RecordingSid: "RE1",
         RecordingDuration: "12",
-      },
+      }),
     });
 
     // Default-off: the recording still persists, but no batch job is queued.
@@ -340,12 +345,12 @@ describe("webhook side-effect handlers", () => {
 
     await runRecordingSideEffects({
       callSid: "CA1",
-      twilioParams: {
+      event: parseTwilioVoiceCallback({
         CallSid: "CA1",
         AccountSid: "ACmain",
         RecordingSid: "RE1",
         RecordingDuration: "12",
-      },
+      }),
     });
 
     expect(mocks.enqueueJob).toHaveBeenCalledWith(
@@ -371,12 +376,12 @@ describe("webhook side-effect handlers", () => {
     await expect(
       runRecordingSideEffects({
         callSid: "CA1",
-        twilioParams: {
+        event: parseTwilioVoiceCallback({
           CallSid: "CA1",
           AccountSid: "ACmain",
           RecordingSid: "RE1",
           RecordingDuration: "12",
-        },
+        }),
       }),
     ).resolves.toEqual({ ok: true });
 


### PR DESCRIPTION
Part 1 of the E1/E2 tail of #1243 — typed voice callbacks

## The problem

Every Twilio voice callback route re-derived its own view of the same form body. `twilioParamsToUnderCase` widened it to `Record<string, unknown>`, and each read was re-narrowed inline:

```ts
typeof underCase.call_sid === "string" ? underCase.call_sid : null
```

Fifteen of those in `auto-dial/status` alone. They are not validation — they say "this might be a string" about a value that is always a form field — and they crowd out the question that actually matters: *is this a call status, a conference participant event, or a recording?* Nothing in the code ever asked it, so the answer was re-guessed at each use site with expressions like `friendly_name ?? conference_sid`. That expression is how the 22P02 incident (#1004) got its wrong value: a conference NAME (`${userId}~${uuid}`) fed to an argument bound as `::uuid`.

## What changed

`app/lib/twilio/voice-callback.ts` parses a voice webhook body **once**, at the route boundary, into a discriminated union. Zod schemas are the source of truth and the TS types are inferred from them, so the job-payload validation cannot drift from the types the routes consume. Follows the typed-Twilio-message pattern already in `services/media-stream/types.ts`.

**Union members** (`kind`):

| member | added fields |
| --- | --- |
| `CallStatusCallback` | `answeredBy`, `direction`, `from`, `to`, `parentCallSid`, `sequenceNumber` |
| `ParticipantEvent` | `event` (join/leave/modify/speech-start/speech-stop/conference-start/conference-end/announcement-*), `conferenceSid`, `conferenceName`, `conferenceRef`, `conferenceUserId`, `participantCallSid`, `reasonParticipantLeft` |
| `RecordingEvent` | `recordingSid`, `recordingUrl`, `recordingStatus`, `recordingDuration`, `conferenceSid` |
| `UnrecognizedCallback` | — |

Every member carries `raw`, `callSid`, `accountSid`, `callStatus`, `timestamp`, `durationSeconds` (the `max(Duration, CallDuration)` each caller used to compute by hand).

**Discriminator**, in order: any recording field present → `recording`; a recognized `StatusCallbackEvent` → `participant`; `CallSid` + non-empty `CallStatus` → `call-status`; otherwise `unrecognized`. Recording is checked first so a conference recording callback (which also carries `ConferenceSid` and a `StatusCallbackEvent`) cannot be misclassified and silently drop its recording fields — which buys the converse the worker relies on: `kind !== "recording"` means there is nothing recording-shaped to read.

**It never throws.** A webhook that 500s is retried for hours, so an unexpected body is `UnrecognizedCallback` carrying `raw`, and each route keeps whatever fallback it had.

**The 22P02 distinction is now three parsed fields**, not a cast: `conferenceName` (the `${userId}~${uuid}` name), `conferenceSid` (the `CF…` SID), and `conferenceUserId` (the name's user-id prefix, `null` when there is no `~`). `conferenceRef` is the value that addresses a conference. The route's `resolveUserIdFromConferenceName` now delegates to the parser and keeps its legacy "no separator → pass through whole" fallback for stored `call.conference_id` values.

## `typeof` narrowings, before → after

| file | before | after |
| --- | --- | --- |
| `app/routes/api+/auto-dial/status.action.server.ts` | 15 | 0 |
| `app/lib/twilio-call-status.server.ts` (payload narrowings in `persistCallStatusFromParams`) | 3 | 0 |
| `app/lib/worker/webhook-side-effects.server.ts` (loose `twilioParamsToUnderCase` re-read of the job payload) | 1 | 0 |

`handleParticipantJoin` / `handleParticipantLeave` now take `ParticipantJoinEvent` / `ParticipantLeaveEvent`; the branch that selects them is `isParticipantHangup` / `isParticipantJoin` instead of two string comparisons per branch.

## Job-payload compatibility

The two VOICE side-effect jobs get their own `voiceSideEffectsParamsSchema`, which is `{sid, twilioParams}` plus the route's parsed `event`. Both shapes parse:

- **Old rows** (queued before this PR, `{callSid|sid, twilioParams}`, no `event`) — `event` is re-derived from the stored `twilioParams` by the same parser the route would have used. An in-flight job still runs and still bills.
- **New rows** — `event` is validated against `twilioVoiceCallbackSchema` and taken as-is.
- **Malformed `event`** — falls back to re-deriving, rather than reaching a handler half-typed.

`twilioParams` deliberately stays on the payload: it is the raw evidence a dead-lettered job is inspected and requeued from, and E2's routes still read it. `sms_status_side_effects` is not a voice callback and keeps the plain `sidAndTwilioParamsSchema`.

## Scope

Auto-dial status route, `twilio-call-status.server.ts`, `webhook-side-effects.server.ts`, and the job registry. `call-status` and `recording` each gained one line at their **enqueue** site (passing the parsed event) — their own handling is untouched. `ivr/status`, `recording` and `sms status` remain E2; the union is designed so E2 is adoption, not redesign. **Not** `Closes #1243` — E2 remains.

## Behavioural notes

- `handleParticipantLeave` computed `Math.max(Number(Duration), Number(CallDuration))` with no NaN guard, so a payload missing both wrote the string `"NaN"` into `call.duration`. It now writes `"0"`, matching what `buildCallUpsertFromTwilioParams` and `persistCallStatusFromParams` already did.
- Field values are trimmed, and blank strings read as absent.
- A dead local in `handleCallStatus` (`const callSid = …`, assigned and never used) is gone.

## Tests / gates

- New `test/twilio-voice-callback.test.ts`: every union member, the unrecognized/empty-body paths, and the 22P02 conference-name case as a named regression.
- New job-registry test proving a pre-E1 row still parses with its event re-derived, in both voice job types.
- Two new auto-dial status route tests: an unrecognized payload acks, and participant-join persists the conference NAME when a SID is also present.
- Side-effect and billing suites now build fixtures by running raw Twilio bodies through the real parser, so they cannot drift from what a route produces.
- `tsc` clean; `node scripts/check-handlers.mjs` passes; node suite 352 files / 2700 tests green; bun portion green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
