### PR TITLE
refactor(twilio): adopt the voice-callback parser in the last three routes

### DIFF
--- a/app/lib/twilio-call-status.server.ts
+++ b/app/lib/twilio-call-status.server.ts
@@ -3,8 +3,6 @@ import type { Database, Tables, TablesInsert } from "@/lib/db-types";
 import {
   findCallBySid,
   upsertCallBySid,
-  updateCallBySid,
-  updateOutreachAttemptForWorkspace,
   findCampaignTypeByCampaignId,
 } from "@/lib/telephony-db.server";
 import {
@@ -19,7 +17,6 @@ import { callKey } from "@/lib/billing-keys";
 import { debitAmountFromCredits } from "@/lib/pricing";
 import { logger } from "@/lib/logger.server";
 import { emitPostgresChangeEvent } from "@/lib/workspace-events.server";
-import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 
 export {
   voiceBillingKindFromCampaignType,
@@ -284,88 +281,3 @@ export async function processCallStatusWebhook(
   return { call, billingResult };
 }
 
-/**
- * Persist a call status update from Twilio status-callback form params.
- * Routes `ivr/status` and `auto-dial/status` (and any future status callback
- * route) should route through this so that persistence + disposition use the
- * same canonical path as `call-status` (fixes the double-debit hazard from
- * issue #1004 by ensuring all status routes use `twilioParamsToUnderCase`).
- *
- * Behavior:
- * - Updates `call.end_time` / `call.status` / `call.duration` for `callSid`.
- * - Optionally updates `outreach_attempt.disposition` when provided.
- *
- * Returns the row from the call update (so callers can read
- * `outreach_attempt_id` / `workspace` for billing) when `selectResult` is true.
- */
-export async function persistCallStatusFromParams(args: {
-  params: Record<string, string>;
-  disposition?: string | null;
-  outreachAttemptId?: number | null;
-  selectResult?: boolean;
-}): Promise<Tables<"call"> | null> {
-  const event = parseTwilioVoiceCallback(args.params);
-  const callSid = event.callSid;
-  if (!callSid) {
-    throw new Error("Missing CallSid in status params");
-  }
-  const status = args.disposition
-    ? String(args.disposition).toLowerCase()
-    : event.callStatus.toLowerCase() || null;
-
-  const update: Record<string, unknown> = {};
-  if (event.timestamp) {
-    update.end_time = new Date(event.timestamp).toISOString();
-  }
-  if (status) {
-    update.status = status;
-  }
-  const duration = event.durationSeconds ?? 0;
-  if (duration > 0) {
-    update.duration = String(duration);
-  }
-
-  if (Object.keys(update).length === 0) {
-    return null;
-  }
-
-  const existing = await findCallBySid(callSid);
-  if (!existing?.workspace) {
-    throw new Error(`Call ${callSid} not found or missing workspace`);
-  }
-
-  let data: Tables<"call"> | null = null;
-  if (args.selectResult) {
-    data = (await updateCallBySid(
-      existing.workspace,
-      callSid,
-      update as Partial<Tables<"call">>,
-    )) as Tables<"call"> | null;
-  } else {
-    await updateCallBySid(
-      existing.workspace,
-      callSid,
-      update as Partial<Tables<"call">>,
-    );
-  }
-
-  const outreachAttemptId =
-    args.outreachAttemptId != null
-      ? args.outreachAttemptId
-      : (data as { outreach_attempt_id?: number | null } | null)?.outreach_attempt_id ??
-        existing.outreach_attempt_id ??
-        null;
-
-  if (args.disposition && outreachAttemptId != null && existing.workspace) {
-    const result = await updateOutreachAttemptForWorkspace(
-      existing.workspace,
-      outreachAttemptId,
-      { disposition: args.disposition },
-    );
-    if (result instanceof Response) {
-      throw new Error("Failed to update outreach disposition");
-    }
-  }
-
-  return data ?? (existing as Tables<"call">);
-}

--- a/app/lib/twilio/voice-callback.ts
+++ b/app/lib/twilio/voice-callback.ts
@@ -59,6 +59,14 @@ const voiceCallbackCommon = {
   callStatus: z.string(),
   timestamp: z.string().nullable(),
   durationSeconds: z.number().nullable(),
+  /**
+   * Answering-machine-detection result. Common (not `call-status`-only)
+   * because Twilio's async-AMD callback (`AsyncAmd`) posts `CallSid` +
+   * `AnsweredBy` with no `CallStatus` at all — that payload discriminates to
+   * `unrecognized`, and `dial/status` still needs to read `AnsweredBy` off it
+   * (#1243 E2).
+   */
+  answeredBy: z.string().nullable(),
 };
 
 /** A plain call status callback: `CallSid` + `CallStatus`, no conference, no recording. */
@@ -67,7 +75,6 @@ export const callStatusCallbackSchema = z.object({
   kind: z.literal("call-status"),
   callSid: z.string(),
   callStatus: z.string().min(1),
-  answeredBy: z.string().nullable(),
   direction: z.string().nullable(),
   from: z.string().nullable(),
   to: z.string().nullable(),
@@ -216,6 +223,7 @@ export function parseTwilioVoiceCallback(
       duration === null && callDuration === null
         ? null
         : Math.max(duration ?? 0, callDuration ?? 0),
+    answeredBy: readString(raw, "AnsweredBy"),
   };
 
   if (RECORDING_KEYS.some((key) => readString(raw, key) !== null)) {
@@ -254,7 +262,6 @@ export function parseTwilioVoiceCallback(
       kind: "call-status",
       callSid: common.callSid,
       callStatus: common.callStatus,
-      answeredBy: readString(raw, "AnsweredBy"),
       direction: readString(raw, "Direction"),
       from: readString(raw, "From"),
       to: readString(raw, "To"),

--- a/app/routes/api+/dial/status.action.server.ts
+++ b/app/routes/api+/dial/status.action.server.ts
@@ -12,11 +12,13 @@ import {
 } from "@/lib/telephony-db.server";
 import { defineAction } from "@/lib/handler.server";
 import type { ActionFunctionArgs } from "react-router";
+import {
+  parseTwilioVoiceCallback,
+  type TwilioVoiceCallback,
+} from "@/lib/twilio/voice-callback";
 
 type DialStatusAuth = {
-  callSid: string | null;
-  answeredBy: string | null;
-  callStatus: string | null;
+  event: TwilioVoiceCallback;
 };
 
 export const action = defineAction({
@@ -24,28 +26,27 @@ export const action = defineAction({
     // Clone before reading — Bun yields empty params on re-read after consume.
     const formData = await request.clone().formData();
     const params = Object.fromEntries(formData.entries()) as Record<string, string>;
-    const callSidValue = params.CallSid;
-    const answeredByValue = params.AnsweredBy;
-    const callStatusValue = params.CallStatus;
-
-    const callSid = typeof callSidValue === "string" && callSidValue ? callSidValue : null;
-    const answeredBy = typeof answeredByValue === "string" ? answeredByValue : null;
-    const callStatus = typeof callStatusValue === "string" ? callStatusValue : null;
+    // Parsed once here (#1243 E2) instead of each field being re-narrowed with
+    // `typeof x === "string"` below.
+    const event = parseTwilioVoiceCallback(params);
 
     // Validate the Twilio signature unconditionally (fail closed). Previously
     // this ran only when CallSid was present, so a request without CallSid
     // skipped the webhook auth boundary entirely.
     const forbidden = await requireTwilioSignature(request, {
-      callSid: callSid ?? undefined,
+      callSid: event.callSid ?? undefined,
       params,
     });
     if (forbidden) return forbidden;
 
-    return { callSid, answeredBy, callStatus };
+    return { event };
   },
   sideEffects: ["twilio", "db-write"],
   handler: async ({ auth }) => {
-    const { callSid, answeredBy, callStatus } = auth;
+    const { event } = auth;
+    const callSid = event.callSid;
+    const answeredBy = event.answeredBy;
+    const callStatus = event.callStatus || null;
 
     if (!callSid) {
       return routeData({ success: false, error: "CallSid is required and must be a string" });

--- a/app/routes/api+/ivr/status.action.server.ts
+++ b/app/routes/api+/ivr/status.action.server.ts
@@ -13,12 +13,12 @@ import {
 import {
   buildCallUpsertFromTwilioParams,
   processCallStatusWebhook,
-  twilioParamsToUnderCase,
 } from "@/lib/twilio-call-status.server";
 import { findCallBySid, updateOutreachAttemptForWorkspace } from "@/lib/telephony-db.server";
 import { createSignedObjectUrl } from "@/lib/object-storage.server";
 import { defineAction } from "@/lib/handler.server";
 import type Twilio from "twilio";
+import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
 
 export interface CallEvent {
     Called: string;
@@ -112,19 +112,21 @@ export const action = defineAction({
     auth: async ({ request }) => {
         const formData = await request.clone().formData();
         const params = Object.fromEntries(formData.entries()) as Record<string, string>;
-        const underCase = twilioParamsToUnderCase(params);
-        const callSid = typeof underCase.call_sid === "string" ? underCase.call_sid : null;
+        // Parsed once here (#1243 E2) instead of each field being re-narrowed
+        // with `typeof x === "string"` below.
+        const event = parseTwilioVoiceCallback(params);
+        const callSid = event.callSid;
         if (!callSid) {
             // Preserve the original order: the handler throws "Missing CallSid"
             // (caught into `{ success: false }`) before any signature check.
-            return { params, underCase, callSid };
+            return { params, event, callSid };
         }
         const forbidden = await requireTwilioSignature(request, { callSid });
-        return forbidden ?? { params, underCase, callSid };
+        return forbidden ?? { params, event, callSid };
     },
     sideEffects: ["db-write", "credit", "twilio", "external"],
     handler: async ({ auth }) => {
-    const { params, underCase, callSid } = auth;
+    const { params, event, callSid } = auth;
 
     try {
         if (!callSid) {
@@ -138,10 +140,8 @@ export const action = defineAction({
 
         const twilio = await createWorkspaceTwilioInstance({ workspace_id: dbCall.workspace });
 
-        const callStatus = typeof underCase.call_status === "string" ? underCase.call_status : "";
-        const timestamp = typeof underCase.timestamp === "string" ? underCase.timestamp : '';
-
-        const answeredBy = typeof underCase.answered_by === "string" ? underCase.answered_by : "";
+        const callStatus = event.callStatus;
+        const answeredBy = event.answeredBy ?? "";
         const isMachine =
             Boolean(answeredBy) &&
             answeredBy.includes('machine') &&

--- a/app/routes/api+/recording.action.server.ts
+++ b/app/routes/api+/recording.action.server.ts
@@ -1,6 +1,9 @@
 import { data as routeData } from "react-router";
 import { logger } from "@/lib/logger.server";
-import { parseTwilioVoiceCallback } from "@/lib/twilio/voice-callback";
+import {
+  parseTwilioVoiceCallback,
+  type TwilioVoiceCallback,
+} from "@/lib/twilio/voice-callback";
 import { requireTwilioSignature } from "@/lib/twilio-webhook.server";
 import { updateCallRecordingUrlBySid } from "@/lib/telephony-db.server";
 import { defineAction } from "@/lib/handler.server";
@@ -10,6 +13,7 @@ import type { ActionFunctionArgs } from "react-router";
 
 type RecordingAuth = {
   params: Record<string, string>;
+  event: TwilioVoiceCallback;
   callSid: string | null;
 };
 
@@ -25,26 +29,31 @@ export const action = defineAction({
     // Clone before reading — Bun yields empty params on re-read after consume.
     const formData = await request.clone().formData();
     const params = Object.fromEntries(formData.entries()) as Record<string, string>;
-    const callSid = params.CallSid?.trim();
+    // Parsed once here (#1243 E2) so the handler reads the typed `recording`
+    // member instead of `params.RecordingUrl?.trim()` directly.
+    const event = parseTwilioVoiceCallback(params);
+    const callSid = event.callSid;
 
     if (!callSid) {
-      return { params, callSid: null };
+      return { params, event, callSid: null };
     }
 
     const forbidden = await requireTwilioSignature(request, { callSid, params });
     if (forbidden) return forbidden;
 
-    return { params, callSid };
+    return { params, event, callSid };
   },
   sideEffects: ["db-write"],
   handler: async ({ auth }) => {
-    const { params, callSid } = auth;
+    const { params, event, callSid } = auth;
 
     if (!callSid) {
       return routeData({ error: "Missing CallSid" }, { status: 400 });
     }
 
-    const recordingUrl = params.RecordingUrl?.trim();
+    // Only a `recording` event carries recording fields — see the parser's
+    // discrimination order in @/lib/twilio/voice-callback.
+    const recordingUrl = event.kind === "recording" ? event.recordingUrl : null;
     if (recordingUrl) {
       try {
         const updated = await updateCallRecordingUrlBySid(callSid, recordingUrl);
@@ -58,9 +67,7 @@ export const action = defineAction({
             params: {
               sid: callSid,
               twilioParams: params,
-              // The route's own handling is untouched here (that is E2); this
-              // only stops the worker from re-parsing the body a second time.
-              event: parseTwilioVoiceCallback(params),
+              event,
             },
           });
         }

--- a/test/dial-status.route.test.ts
+++ b/test/dial-status.route.test.ts
@@ -260,6 +260,24 @@ describe("app/routes/api+/dial/status.route.tsx", () => {
     expect(mocks.requireTwilioSignature).toHaveBeenCalled();
   });
 
+  /**
+   * The payload is parsed once at the route boundary into a discriminated
+   * union (#1243 E1/E2). A `CallSid` with no `CallStatus` and no `AnsweredBy`
+   * discriminates to `unrecognized` — the route must still ack (not throw),
+   * and must not treat it as a machine-detection callback.
+   */
+  test("an unrecognized payload (CallSid only) acks without hitting the voicemail branch", async () => {
+    const { client, twilio } = makeDbClient();
+    mocks.createClient.mockReturnValueOnce(client);
+    mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce(twilio as any);
+    const mod = await import("../app/routes/api+/dial/status.route");
+    const res = await asRouteResponse(mod.action({
+      request: makeReq({ CallSid: "CA1", SomethingTwilioAddedLater: "1" }),
+    } as any));
+    await expect(res.json()).resolves.toMatchObject({ success: true });
+    expect(client._callUpdate).not.toHaveBeenCalled();
+  });
+
   test("callStatus missing covers null branch; callError/campaignError/voicemailError bubble to outer catch (Error message)", async () => {
     const { client, twilio } = makeDbClient();
     client._set.callError(new Error("call"));

--- a/test/ivr-status.route.test.ts
+++ b/test/ivr-status.route.test.ts
@@ -27,10 +27,6 @@ const campaignIvrMocks = vi.hoisted(() => ({
   resolveCampaignScript: vi.fn((campaign: any) => campaign?.script ?? null),
 }));
 
-const callStatusMocks = vi.hoisted(() => ({
-  persistCallStatusFromParams: vi.fn(),
-}));
-
 const objectStorageMocks = vi.hoisted(() => ({
   createSignedObjectUrl: vi.fn(),
 }));
@@ -60,13 +56,6 @@ vi.mock("@/lib/campaign-ivr.server", () => ({
   fetchCampaignWithScript: (...args: any[]) => campaignIvrMocks.fetchCampaignWithScript(...args),
   resolveCampaignScript: (...args: any[]) => campaignIvrMocks.resolveCampaignScript(...args),
 }));
-vi.mock("@/lib/twilio-call-status.server", async (importOriginal) => {
-  const actual = (await importOriginal()) as any;
-  return {
-    ...actual,
-    persistCallStatusFromParams: (...args: any[]) => callStatusMocks.persistCallStatusFromParams(...args),
-  };
-});
 vi.mock("@/lib/object-storage.server", () => ({
   createSignedObjectUrl: (...args: any[]) => objectStorageMocks.createSignedObjectUrl(...args),
 }));
@@ -122,7 +111,6 @@ describe("app/routes/api+/ivr/status.route.tsx", () => {
     telephonyDbMocks.updateOutreachAttemptForWorkspace.mockReset();
     campaignIvrMocks.fetchCampaignWithScript.mockReset();
     campaignIvrMocks.resolveCampaignScript.mockReset();
-    callStatusMocks.persistCallStatusFromParams.mockReset();
     objectStorageMocks.createSignedObjectUrl.mockReset();
     transactionHistoryMocks.insertTransactionHistoryIdempotent.mockReset();
     telephonyDbMocks.findCallBySid.mockResolvedValue(makeCallRow());
@@ -133,7 +121,6 @@ describe("app/routes/api+/ivr/status.route.tsx", () => {
     campaignIvrMocks.fetchCampaignWithScript.mockResolvedValue(makeCampaign({ type: "robocall" }));
     campaignIvrMocks.resolveCampaignScript.mockImplementation((campaign: any) => campaign?.script ?? null);
     telephonyDbMocks.updateOutreachAttemptForWorkspace.mockResolvedValue({});
-    callStatusMocks.persistCallStatusFromParams.mockResolvedValue(undefined);
     objectStorageMocks.createSignedObjectUrl.mockResolvedValue("https://signed");
     transactionHistoryMocks.insertTransactionHistoryIdempotent.mockResolvedValue({ inserted: true, existingId: 1 });
   });
@@ -235,7 +222,7 @@ describe("app/routes/api+/ivr/status.route.tsx", () => {
     telephonyDbMocks.findCallBySid.mockResolvedValueOnce(makeCallRow({ outreach_attempt_id: null }));
     mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce({ calls: () => ({ update: async () => ({}) }) });
     res = await asRouteResponse(mod.action({ request: makeReq({ CallSid: "CA1", CallStatus: "completed", Timestamp: new Date().toISOString() }) } as any));
-    // persistCallStatusFromParams accepts null outreachAttemptId; no updateResult call needed
+    // processCallStatusWebhook accepts a null outreachAttemptId; no updateResult call needed
     await expect(res.json()).resolves.toMatchObject({ success: true });
   });
 
@@ -417,5 +404,23 @@ describe("app/routes/api+/ivr/status.route.tsx", () => {
       request: makeReq({ CallSid: "CA1", CallStatus: "ringing", AnsweredBy: "human", Timestamp: new Date().toISOString() }),
     } as any));
     await expect(res.json()).resolves.toEqual({ success: true });
+  });
+
+  /**
+   * The payload is parsed once at the route boundary into a discriminated
+   * union (#1243 E1/E2). A `CallSid` with no `CallStatus` at all discriminates
+   * to `unrecognized` — the route must still ack (not throw), and must not
+   * treat it as machine detection or a terminal status.
+   */
+  test("an unrecognized payload (CallSid with no CallStatus) acks without billing or disposition writes", async () => {
+    const mod = await import("../app/routes/api+/ivr/status.route");
+    mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce({ calls: () => ({ update: async () => ({}) }) });
+    const res = await asRouteResponse(mod.action({
+      request: makeReq({ CallSid: "CA1", SomethingTwilioAddedLater: "1" }),
+    } as any));
+    await expect(res.json()).resolves.toEqual({ success: true });
+    expect(telephonyDbMocks.upsertCallBySid).not.toHaveBeenCalled();
+    expect(telephonyDbMocks.updateOutreachAttemptForWorkspace).not.toHaveBeenCalled();
+    expect(transactionHistoryMocks.insertTransactionHistoryIdempotent).not.toHaveBeenCalled();
   });
 });

--- a/test/recording.route.test.ts
+++ b/test/recording.route.test.ts
@@ -106,6 +106,31 @@ describe("app/routes/api+/recording", () => {
     expect(mocks.updateCallRecordingUrlBySid).not.toHaveBeenCalled();
   });
 
+  /**
+   * The payload is parsed once at the route boundary into a discriminated
+   * union (#1243 E1/E2). A `CallSid` with none of the recording fields (and
+   * no `CallStatus`) discriminates to `unrecognized`, and the route must
+   * still ack — echoing params back — rather than erroring.
+   */
+  test("an unrecognized payload acks and echoes params instead of erroring", async () => {
+    mocks.createClient.mockReturnValueOnce({ from: vi.fn() });
+    const mod = await import("../app/routes/api+/recording");
+    const fd = new FormData();
+    fd.set("CallSid", "CA1");
+    fd.set("SomethingTwilioAddedLater", "1");
+    const res = await asRouteResponse(mod.action({
+        request: new Request("http://x", { method: "POST", body: fd }),
+      } as never),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      CallSid: "CA1",
+      SomethingTwilioAddedLater: "1",
+    });
+    expect(mocks.updateCallRecordingUrlBySid).not.toHaveBeenCalled();
+    expect(enqueueJobMock).not.toHaveBeenCalled();
+  });
+
   test("still returns 200 with payload when persistence fails (webhook must not fail loudly)", async () => {
     mocks.createClient.mockReturnValueOnce({ from: vi.fn() });
     mocks.updateCallRecordingUrlBySid.mockRejectedValueOnce(new Error("db down"));

--- a/test/twilio-voice-callback.test.ts
+++ b/test/twilio-voice-callback.test.ts
@@ -219,6 +219,18 @@ describe("parseTwilioVoiceCallback", () => {
     expect(event.callSid).toBe("CA1");
   });
 
+  /**
+   * `answeredBy` is common (not `call-status`-only) because Twilio's
+   * async-AMD callback posts `CallSid` + `AnsweredBy` with no `CallStatus` at
+   * all (#1243 E2, `dial/status`) — that payload discriminates to
+   * `unrecognized`, and the field must still be readable off it.
+   */
+  test("AnsweredBy is readable on an unrecognized (CallStatus-less) AMD callback", () => {
+    const event = parseTwilioVoiceCallback({ CallSid: "CA1", AnsweredBy: "machine_start" });
+    expect(event.kind).toBe("unrecognized");
+    expect(event.answeredBy).toBe("machine_start");
+  });
+
   test("blank and non-string field values read as absent", () => {
     const event = parseTwilioVoiceCallback({
       CallSid: "  CA1  ",


### PR DESCRIPTION
Final part of #1243 (E2). Closes #1243.

## Summary

The last three voice callback routes narrowing raw Twilio params by hand now parse once via `parseTwilioVoiceCallback` (#1243 E1) and consume the typed union member, matching `auto-dial/status` and `call-status`:

| Route | Before | After |
|---|---|---|
| `app/routes/api+/ivr/status.action.server.ts` | 4 `typeof x === "string"` checks over `twilioParamsToUnderCase(params)` | parses once in `auth`, reads `event.callSid` / `event.callStatus` / `event.answeredBy` |
| `app/routes/api+/dial/status.action.server.ts` | 3 `typeof x === "string"` checks over raw form fields | parses once in `auth`, reads `event.callSid` / `event.answeredBy` / `event.callStatus` |
| `app/routes/api+/recording.action.server.ts` | sync path read `params.RecordingUrl?.trim()` directly (worker job path was already typed by E1) | sync path reads `event.recordingUrl` off the typed `recording` member |

Routes already covered by E1 (`call-status`, `auto-dial/status`, `twilio-call-status.server.ts`, `webhook-side-effects.server.ts`) are unchanged.

## Union change

`answeredBy` moves from a `call-status`-only field to a common field on every union member. Twilio's async-AMD callback (`AsyncAmd`) posts `CallSid` + `AnsweredBy` with **no** `CallStatus` at all — that payload discriminates to `unrecognized`, and `dial/status` still needs to read `AnsweredBy` off it. This mirrors why `callStatus` itself is already common.

## Dead code removed

- `persistCallStatusFromParams` (`app/lib/twilio-call-status.server.ts`) — census confirmed zero production callers. The only reference was a defensive `vi.fn()` mock in `test/ivr-status.route.test.ts` that no assertion ever exercised; the actual route has always gone through `buildCallUpsertFromTwilioParams` + `processCallStatusWebhook` instead. Deleted the function and the now-dead mock plumbing/imports.
- `twilioParamsToUnderCase` / `twilioParamToUnderCase` **were kept** — `twilioParamsToUnderCase` still has one internal consumer (`buildCallUpsertFromTwilioParams`), so it isn't dead.

## Tests

Added an explicit unrecognized-payload case to each migrated route's suite (`ivr-status.route.test.ts`, `dial-status.route.test.ts`, `recording.route.test.ts`), plus a case in `twilio-voice-callback.test.ts` covering `AnsweredBy` being readable on a `CallStatus`-less (AMD-only) callback.

## Gates run

- `npm run typecheck` — clean
- `npm run lint` — clean
- Full node suite (`vitest run -c vitest.node.config.ts`): 352 files / 2704 passed, 11 skipped
- `bun test test/server-runtime.test.ts test/twilio-webhook-prehandler.test.ts vendor/scriptkit/scriptkit-call-script-core/src/`: 22 passed
- `node scripts/check-handlers.mjs` — passed
- `npm run check:effects` — passed
- `npm run check:dry` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
