### PR TITLE
fix(campaign): stop showing completed text campaigns as needs-attention

### DIFF
--- a/app/lib/campaign-readiness.ts
+++ b/app/lib/campaign-readiness.ts
@@ -332,6 +332,40 @@ export function getCampaignContentReadinessIssues(
     .filter((message): message is string => Boolean(message));
 }
 
+export type CampaignQueueAudienceCounts = {
+  /**
+   * Total dialable rows ever assigned to the campaign queue, regardless of
+   * dequeue/send status. This is the correct signal for "does this campaign
+   * have an audience" -- it stays stable (and positive) after the campaign
+   * finishes sending.
+   */
+  totalCount?: number | null;
+  /**
+   * Rows not yet dequeued/sent. Used only as a fallback when the total is
+   * unavailable to the caller. Do NOT use this alone to decide readiness:
+   * it legitimately drops to 0 once a campaign completes sending to every
+   * assigned contact, even though the campaign was never audience-empty.
+   */
+  queuedCount?: number | null;
+};
+
+/**
+ * Resolve the `queueCount` fed into {@link getCampaignReadiness}'s
+ * `queue_empty` check from a set of queue counters.
+ *
+ * Bug history (#1255): callers used to pass the *remaining* queued count
+ * (rows not yet dequeued). That count is 0 both before a campaign has any
+ * audience AND after a campaign finishes sending to everyone -- so a fully
+ * completed campaign was misreported as "needs attention: add at least one
+ * contact" on the launch screen. Always prefer the total-ever-assigned
+ * count; fall back to the remaining count only when total isn't available.
+ */
+export function resolveReadinessQueueCount(
+  counts: CampaignQueueAudienceCounts,
+): number {
+  return counts.totalCount ?? counts.queuedCount ?? 0;
+}
+
 export function hasCampaignReadinessCode(
   issues: readonly CampaignReadinessIssue[],
   code: CampaignReadinessCode,

--- a/app/lib/platform-data.server.ts
+++ b/app/lib/platform-data.server.ts
@@ -22,7 +22,7 @@ import {
 } from "@/lib/database/workspace.server";
 import type { Database } from "@/lib/db-types";
 import { AppError } from "@/lib/errors.server";
-import { getCampaignReadiness } from "@/lib/campaign-readiness";
+import { getCampaignReadiness, resolveReadinessQueueCount } from "@/lib/campaign-readiness";
 import { logger } from "@/lib/logger.server";
 import { isCampaignActive } from "@/lib/campaign-status";
 import { jsonError } from "@/lib/platform-api.server";
@@ -450,7 +450,12 @@ export async function transitionCampaignStatusApi(
       campaignRecord as Campaign,
       campaignDetails as Parameters<typeof getCampaignReadiness>[1],
       {
-        queueCount: queueCounts.queuedCount ?? queueCounts.fullCount ?? 0,
+        // Total assigned audience, not remaining/undequeued rows -- see
+        // resolveReadinessQueueCount for why (#1255).
+        queueCount: resolveReadinessQueueCount({
+          totalCount: queueCounts.fullCount,
+          queuedCount: queueCounts.queuedCount,
+        }),
       },
     );
     const readinessError =

--- a/app/routes/workspaces+/$id/campaigns/$selected_id.loader.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id.loader.server.ts
@@ -14,7 +14,7 @@ import {
 } from "@/lib/database/campaign.server";
 import { campaignTypeCollectsIvrResponses } from "@/lib/ivr-results";
 import { getUserRole } from "@/lib/database/workspace.server";
-import { getCampaignReadiness } from "@/lib/campaign-readiness";
+import { getCampaignReadiness, resolveReadinessQueueCount } from "@/lib/campaign-readiness";
 import { findCampaignInWorkspace } from "@/lib/campaign-ivr.server";
 import { MemberRole } from "@/lib/member-role";
 import { defineLoader } from "@/lib/handler.server";
@@ -71,8 +71,15 @@ export const loader = defineLoader({
         : Promise.resolve([]),
     ]);
 
+    // Total assigned audience, not remaining/undequeued rows -- the
+    // remaining count is 0 both pre-launch and after the campaign finishes
+    // sending, which would flip the "Launch" rail item and this readiness
+    // check to "needs attention" on a fully completed campaign (#1255).
     const readiness = getCampaignReadiness(campaignRow, campaignDetails, {
-      queueCount: queueCounts.queuedCount ?? queueCounts.fullCount,
+      queueCount: resolveReadinessQueueCount({
+        totalCount: queueCounts.fullCount,
+        queuedCount: queueCounts.queuedCount,
+      }),
     });
     const joinDisabled = readiness.startDisabledReason
       ? readiness.startDisabledReason

--- a/app/routes/workspaces+/$id/campaigns/$selected_id.route.tsx
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id.route.tsx
@@ -15,6 +15,7 @@ import { CampaignHeader } from "@/components/campaign/home/CampaignHomeScreen/Ca
 import { CampaignStatusRail } from "@/components/campaign/home/CampaignStatusRail";
 import { CampaignShellDirtyProvider } from "@/components/campaign/home/CampaignShellDirty";
 import { buildCampaignStatusRail } from "@/lib/campaign-status-rail";
+import { resolveReadinessQueueCount } from "@/lib/campaign-readiness";
 import {
   Audience,
   Campaign,
@@ -91,7 +92,14 @@ export default function CampaignScreen() {
       campaignData,
       campaignDetails,
       readinessIssues: readiness?.issues ?? [],
-      queueCount: safeQueueCounts.queuedCount,
+      // Defense-in-depth: buildCampaignStatusRail only recomputes readiness
+      // from this queueCount when readinessIssues is absent, but keep it
+      // consistent (total assigned audience, not remaining queue rows) so
+      // a completed campaign never appears "needs attention" here either.
+      queueCount: resolveReadinessQueueCount({
+        totalCount: safeQueueCounts.fullCount,
+        queuedCount: safeQueueCounts.queuedCount,
+      }),
       hasAccess,
       pathname: location.pathname,
       hash: location.hash,
@@ -108,6 +116,7 @@ export default function CampaignScreen() {
     location.pathname,
     readiness?.issues,
     results.length,
+    safeQueueCounts.fullCount,
     safeQueueCounts.queuedCount,
     selected_id,
     workspace,

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/settings.action.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/settings.action.server.ts
@@ -31,7 +31,11 @@ import {
   updateCampaign,
 } from "@/lib/database/campaign.server";
 import { enqueueContactsForCampaign } from "@/lib/queue.server";
-import { getCampaignReadiness, getScheduleValidation } from "@/lib/campaign-readiness";
+import {
+  getCampaignReadiness,
+  getScheduleValidation,
+  resolveReadinessQueueCount,
+} from "@/lib/campaign-readiness";
 import { launchCampaign } from "@/lib/campaign-execution.server";
 import { getWorkspacePhoneNumbers } from "@/lib/database/workspace.server";
 import { getWorkspaceMessagingOnboardingFromTwilioData } from "@/lib/messaging-onboarding.server";
@@ -229,7 +233,10 @@ export const action = defineAction({
               campaignDetails: campaignDetails as unknown as CampaignDetails,
               mode,
               userId: user.id,
-              queueCount: queueCounts.queuedCount ?? queueCounts.fullCount ?? 0,
+              queueCount: resolveReadinessQueueCount({
+                totalCount: queueCounts.fullCount,
+                queuedCount: queueCounts.queuedCount,
+              }),
             });
             if (!result.ok) {
               return routeData(
@@ -242,7 +249,10 @@ export const action = defineAction({
 
           // For voice campaigns, use readiness check + status update.
           const readiness = getCampaignReadiness(campaignRecord as Campaign, campaignDetails as unknown as CampaignDetails, {
-            queueCount: queueCounts.queuedCount ?? queueCounts.fullCount ?? 0,
+            queueCount: resolveReadinessQueueCount({
+              totalCount: queueCounts.fullCount,
+              queuedCount: queueCounts.queuedCount,
+            }),
             workspacePhoneNumbers: phoneNumbersResult.data ?? [],
             workspaceScriptIds: scripts.map((script) => script.id),
             workspaceAudioNames: audioList.ok

--- a/app/routes/workspaces+/$id/campaigns/$selected_id/settings.loader.server.ts
+++ b/app/routes/workspaces+/$id/campaigns/$selected_id/settings.loader.server.ts
@@ -13,7 +13,7 @@ import {
   getWorkspaceTwilioSyncSnapshotFromTwilioData,
 } from "@/lib/database/workspace.server";
 import { loadCampaignBillingSummary } from "@/lib/campaign-billing.server";
-import { getCampaignReadiness } from "@/lib/campaign-readiness";
+import { getCampaignReadiness, resolveReadinessQueueCount } from "@/lib/campaign-readiness";
 import { getWorkspaceMessagingOnboardingFromTwilioData } from "@/lib/messaging-onboarding.server";
 import { logger } from "@/lib/logger.server";
 import { loadActiveSurveysForWorkspace } from "@/lib/survey-db.server";
@@ -135,7 +135,14 @@ export const loader = defineLoader({
     campaignType as Campaign | null | undefined,
     campaignDetailsForReadiness,
     {
-      queueCount: campaignWithAudience.queue_count ?? 0,
+      // Use the TOTAL assigned audience, not the remaining/undequeued
+      // queue count -- the latter is 0 both pre-launch and after a
+      // campaign finishes sending, which misreports completed campaigns
+      // as "needs attention: add at least one contact" (#1255).
+      queueCount: resolveReadinessQueueCount({
+        totalCount: campaignWithAudience.total_count,
+        queuedCount: campaignWithAudience.queue_count,
+      }),
       smsSenderClass: outboundEstimateInputs.portalConfig.smsSenderClass,
       smsMessagingServiceSendersReady:
         campaignType?.type === "message" &&

--- a/test/campaign-readiness.test.ts
+++ b/test/campaign-readiness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   getCampaignContentReadinessIssues,
   getCampaignReadiness,
+  resolveReadinessQueueCount,
 } from "../app/lib/campaign-readiness";
 
 const validSchedule = {
@@ -512,5 +513,57 @@ describe("app/lib/campaign-readiness.ts", () => {
     expect(readiness.startIssues).toContain(
       "Bulk SMS at this queue size requires verified toll-free or a Canadian short code sender. Canadian local long codes are not recommended for campaign volume.",
     );
+  });
+});
+
+describe("app/lib/campaign-readiness.ts resolveReadinessQueueCount", () => {
+  // Regression test for #1255: a fully-sent campaign has 0 *remaining* queued
+  // rows (everything has been dequeued), but it was clearly never
+  // audience-empty. The readiness "queue_empty" check must be driven by the
+  // total number of contacts ever assigned to the campaign, not by how many
+  // are still waiting to be dequeued -- otherwise every campaign that
+  // finishes sending flips back into "needs attention" on the launch screen.
+  test("prefers total assigned count over remaining queued count", () => {
+    expect(
+      resolveReadinessQueueCount({ totalCount: 500, queuedCount: 0 }),
+    ).toBe(500);
+  });
+
+  test("treats a fully-dequeued completed campaign as audience-ready, not queue_empty", () => {
+    const count = resolveReadinessQueueCount({ totalCount: 500, queuedCount: 0 });
+    const readiness = getCampaignReadiness(
+      {
+        type: "message",
+        caller_id: "+15555550100",
+        start_date: "2026-03-10T10:00:00.000Z",
+        end_date: "2026-03-11T10:00:00.000Z",
+        schedule: {
+          monday: { active: true, intervals: [{ start: "09:00", end: "17:00" }] },
+        },
+      } as any,
+      {
+        body_text: "Hello there",
+        message_media: [],
+      } as any,
+      { queueCount: count },
+    );
+
+    expect(readiness.startIssues).not.toContain(
+      "Add at least one contact before starting or scheduling",
+    );
+  });
+
+  test("falls back to remaining queued count when total is unavailable", () => {
+    expect(
+      resolveReadinessQueueCount({ totalCount: null, queuedCount: 3 }),
+    ).toBe(3);
+    expect(resolveReadinessQueueCount({})).toBe(0);
+  });
+
+  test("does not fall back to 0 total (draft campaign with no queue yet) losing the real remaining count", () => {
+    // A brand-new campaign has totalCount 0 and queuedCount 0 -- still correctly queue_empty.
+    expect(
+      resolveReadinessQueueCount({ totalCount: 0, queuedCount: 0 }),
+    ).toBe(0);
   });
 });

--- a/test/campaign-status-derived.test.ts
+++ b/test/campaign-status-derived.test.ts
@@ -31,6 +31,10 @@ vi.mock("@/lib/database/campaign-stats.server", () => ({
 }));
 vi.mock("@/lib/campaign-readiness", () => ({
   getCampaignReadiness: mocks.getCampaignReadiness,
+  resolveReadinessQueueCount: (counts: {
+    totalCount?: number | null;
+    queuedCount?: number | null;
+  }) => counts.totalCount ?? counts.queuedCount ?? 0,
 }));
 vi.mock("@/lib/database/campaign.server", () => ({
   getWorkspaceCampaigns: mocks.getWorkspaceCampaigns,


### PR DESCRIPTION
## Summary

Closes #1255.

**Symptom:** a text campaign runs to completion, then the Launch screen shows a red "Campaign needs attention before it can start" banner ("Add at least one contact before starting or scheduling") instead of the campaign's completed state. The top status rail's Queue and Launch tabs also flip to needs-attention.

**Root cause:** every launch-readiness computation in the app fed `getCampaignReadiness`'s `queue_empty` check with the *remaining* (not-yet-dequeued) campaign_queue row count, via `?? fullCount` fallbacks that only kick in on `null`/`undefined`, never on `0`:

- `app/lib/campaign-readiness.ts` — `queueCount <= 0` → `"Add at least one contact before starting or scheduling"`
- Consumed by the Launch page loader (`settings.loader.server.ts`), the campaign parent loader that builds the Setup/Content/Queue/Launch/Results status rail (`$selected_id.loader.server.ts`, `$selected_id.route.tsx`), the status-change action (`settings.action.server.ts`), and the public campaign-status API (`platform-data.server.ts`).

Remaining-queued count is 0 in two very different situations: **before any contacts are assigned**, and **after every assigned contact has been dequeued/sent**. The check conflated them — a classic hand-maintained status-vocabulary drift, this repo's dominant bug class. Once a campaign fully sends, it always trips this "empty queue" path.

**Recent-merge verdict:** unrelated. `campaign-readiness.ts` (queue_empty check) hasn't changed since 2025-era commits `0f5919cc`/`907d01f4`; `campaign-status-rail.ts` and the Launch loader predate this week's job-registry/queue-RPC/credit-gate work too. The `campaign-sms-dispatch`/`campaign_dispatch` job pipeline (#1256, #1257, #1259) never touches this readiness code path — dispatch itself completes cleanly; only the *display* layer misreads a fully-drained queue as an empty one.

## Fix

Added `resolveReadinessQueueCount` in `app/lib/campaign-readiness.ts`: prefers the **total-ever-assigned** queue count (`countDialableCampaignQueueRows`, stable across dequeue progress) and only falls back to the remaining count when total isn't available. Pre-launch, remaining == total, so nothing changes there; post-completion, total stays positive so the banner and rail correctly show the completed state.

Wired all four call sites through it:
- `app/routes/workspaces+/$id/campaigns/$selected_id.loader.server.ts`
- `app/routes/workspaces+/$id/campaigns/$selected_id.route.tsx`
- `app/routes/workspaces+/$id/campaigns/$selected_id/settings.loader.server.ts`
- `app/routes/workspaces+/$id/campaigns/$selected_id/settings.action.server.ts` (both the message-campaign launch path and the voice-campaign readiness gate)
- `app/lib/platform-data.server.ts` (public campaign-status transition API)

Left `app/lib/campaign-billing.server.ts`'s use of the remaining count alone — that's a cost *estimate* for work left to do, a legitimately different question from "does this campaign have an audience."

Noted (not fixed, out of scope): `app/lib/campaign-setup-steps.ts`'s `isQueueStepComplete` has the identical remaining-count pattern but the function isn't called from any live route today (grepped — only imported for types elsewhere, plus its own test). Flagging in case it gets wired up later.

## Test plan

- [x] New regression tests in `test/campaign-readiness.test.ts` for `resolveReadinessQueueCount` and the `getCampaignReadiness` contract it feeds (fully-dequeued completed campaign no longer produces the `queue_empty` issue)
- [x] `npm run typecheck` — clean
- [x] `npm run test:node` — 352 files / 2716 tests passed (0 failed, 3 skipped), plus bun test suite green
- [x] `npm run check:effects` — passed
- [x] `node scripts/check-handlers.mjs` — passed
- [x] Updated one pre-existing test's `vi.mock("@/lib/campaign-readiness")` (`test/campaign-status-derived.test.ts`) to export the new helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)