### PR TITLE
fix(queue): dequeue_contact must cover the caller's own assigned row

### DIFF
--- a/app/lib/auto-dial.server.ts
+++ b/app/lib/auto-dial.server.ts
@@ -323,9 +323,11 @@ export async function runAutoDialerTurn(
               workspaceId: workspace_id,
               // false, not omitted: the guarded RPC path, not plain Drizzle
               // — deliberately parks only this one row (no household
-              // fan-out) and no-ops rather than requeue-and-retry if the
-              // row isn't currently queued/null. See dequeueQueueEntry's
-              // doc comment for why this differs from the Drizzle default.
+              // fan-out) and no-ops rather than stomping a row this turn no
+              // longer holds. `user_id` is the claim holder
+              // claim_next_queue_contact stamped a few lines up, which is
+              // what lets the RPC dequeue the row while it is still
+              // `assigned` (#1260). See dequeueQueueEntry's doc comment.
               household: false,
               userId: user_id,
               reason:

--- a/app/lib/campaign-queue-db.server.ts
+++ b/app/lib/campaign-queue-db.server.ts
@@ -506,19 +506,25 @@ async function dequeueCampaignQueueByContact(args: {
  *    if omitted). `household: true` fans the dequeue out to every contact
  *    sharing the source contact's household_id — "household is the unit of
  *    contact" per CONTEXT.md. `household: false` is a real, distinct third
- *    mode, not a no-op alias for the Drizzle path: the RPC only touches rows
- *    currently `queued`/null (see the WHERE clause added in
- *    client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql),
- *    so it's a *guarded*, single-contact dequeue that silently no-ops on a
- *    row in any other queue_state (e.g. `assigned`). As of the B3 census
- *    (2026-08) exactly one call site relies on that guard —
- *    app/lib/auto-dial.server.ts's ambiguous-dial-park path, which
- *    deliberately avoids requeue-and-retry semantics — so `household: false`
- *    is preserved as a distinct, explicit choice rather than folded into the
- *    Drizzle default.
+ *    mode, not a no-op alias for the Drizzle path: the RPC touches a row only
+ *    when it is `queued`/null, or `assigned` to the very user passed as
+ *    `userId` (see
+ *    client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql).
+ *    So it's a *guarded*, single-contact dequeue that silently no-ops on a
+ *    row some other agent now holds — which is the point: it makes a dequeue
+ *    that raced a concurrent reclaim harmless instead of letting it kill
+ *    another agent's live call. app/lib/auto-dial.server.ts's
+ *    ambiguous-dial-park path is the call site that depends on that guard —
+ *    it deliberately avoids requeue-and-retry semantics — so `household:
+ *    false` is preserved as a distinct, explicit choice rather than folded
+ *    into the Drizzle default.
  *
- * Behavior-preserving refactor: this function does not change what any
- * existing call site does, only where the mechanism selection lives.
+ *    Corollary: on this path a `userId` of `null` (system-initiated dequeue)
+ *    can only ever reach `queued`/null rows — the assigned-row case needs a
+ *    claim holder to compare against.
+ *
+ * Mechanism selection here is a behavior-preserving refactor of the original
+ * call sites; what each mechanism does to an `assigned` row changed in #1260.
  */
 type DequeueQueueEntryByIdArgs = {
   by: { id: number };

--- a/app/lib/db-rpc.server.ts
+++ b/app/lib/db-rpc.server.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, isNull, or, sql, type SQL } from "drizzle-orm";
 import { rowsToCsv } from "@/lib/rpc-csv.server";
-import { QUEUE_STATUS_QUEUED } from "@/lib/queue-status";
+import { QUEUE_LIFECYCLE_ASSIGNED, QUEUE_STATUS_QUEUED } from "@/lib/queue-status";
 import { emitQueueEvent } from "@/lib/workspace-events.server";
 import { campaign_queue as campaignQueueTable, contact as contactTable } from "@/db/schema";
 import { db, type Database as DbInstance } from "@/server/db";
@@ -274,6 +274,14 @@ export async function rpcDequeueContact(
     }
   }
 
+  // Snapshot of the rows the RPC is about to change, taken so the realtime
+  // UPDATE events below carry a real `old` row. It MUST mirror the RPC's own
+  // WHERE predicate — a row the RPC dequeues but this misses gets no event at
+  // all, so the queue UI keeps showing it as live. See
+  // client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql
+  // for why `assigned` rows are included only for the caller who holds them
+  // (#1260).
+  const dequeuedById = args.dequeuedById ?? null;
   const oldRows = await db
     .select()
     .from(campaignQueueTable)
@@ -285,6 +293,14 @@ export async function rpcDequeueContact(
         or(
           isNull(campaignQueueTable.queue_state),
           eq(campaignQueueTable.queue_state, QUEUE_STATUS_QUEUED),
+          ...(dequeuedById
+            ? [
+                and(
+                  eq(campaignQueueTable.queue_state, QUEUE_LIFECYCLE_ASSIGNED),
+                  eq(campaignQueueTable.assigned_to_user_id, dequeuedById),
+                ),
+              ]
+            : []),
         ),
       ),
     );
@@ -295,7 +311,7 @@ export async function rpcDequeueContact(
       ${args.contactId}::bigint,
       ${args.groupOnHousehold},
       ${args.workspaceId}::uuid,
-      ${args.dequeuedById ?? null}::uuid,
+      ${dequeuedById}::uuid,
       ${args.dequeuedReasonText ?? null}
     )`,
   );

--- a/client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql
+++ b/client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql
@@ -1,0 +1,121 @@
+-- dequeue_contact silently no-oped on the row it is almost always called for.
+--
+-- Both UPDATEs in the deployed definition (20260807120000) were guarded with
+-- `queue_state is null or queue_state = 'queued'`. Every RPC-mode call site
+-- fires AFTER the row has been claimed, i.e. while it is `assigned`:
+--
+--   app/lib/auto-dial.server.ts            park path (household=false) and the
+--                                          post-dial dequeue (household=true),
+--                                          both immediately after
+--                                          claim_next_queue_contact set
+--                                          queue_state='assigned'
+--   app/routes/api+/auto-dial/status...    terminal call-status dequeue
+--   app/routes/api+/auto-dial/$roomId...   machine-answer dequeue
+--   app/routes/api+/hangup...              agent hangup dequeue
+--   app/routes/api+/queues...              manual dequeue from the queue UI
+--
+-- Verified against a live Postgres 18 (docker-compose.dev.yml) before this
+-- migration: with the primary row in queue_state='assigned' and a household
+-- sibling in 'queued', `dequeue_contact(contact, false, ws, assignee, ...)`
+-- left the primary completely untouched (queue_state 'assigned', dequeued_at
+-- null), and `dequeue_contact(contact, true, ws, assignee, ...)` dequeued only
+-- the SIBLING. The assigned row then sat there until
+-- reset_stale_campaign_queue_claims flipped it back to 'queued' — so a contact
+-- deliberately PARKED after an ambiguous dial failure ("call may exist at
+-- Twilio; parked for review, not redialed") gets re-surfaced and redialed,
+-- which is the exact outcome the park path exists to prevent.
+--
+-- WHY NOT JUST DROP THE PREDICATE. It is a real race guard, not an accident:
+-- between an agent deciding to dequeue and the RPC running, the row can be
+-- reclaimed (reset_stale_campaign_queue_claims requeues it, then another
+-- agent's claim takes it). An unconditional UPDATE would let a stale dequeue
+-- kill a call another agent is actively placing. The same applies to the
+-- household fan-out, which must never reach a sibling another agent holds.
+--
+-- WHY `assigned_to_user_id = dequeued_by_id` IS THE RIGHT WIDENING. Every
+-- writer that puts a row into 'assigned' stamps the claiming user in the same
+-- UPDATE — claim_next_queue_contact (20260803130000),
+-- select_and_update_campaign_contacts (20260807130000), and
+-- claim_queue_entry_for_dial (20260805120000) — and every writer that releases
+-- a claim clears it: reset_stale_campaign_queue_claims,
+-- fail_exhausted_campaign_queue_contacts, and requeue (20260814120000, #1250,
+-- which is what made assigned_to_user_id trustworthy as a claim token in the
+-- first place). So `assigned_to_user_id = dequeued_by_id` means precisely
+-- "the caller still holds this claim": the dequeue lands for the agent who
+-- owns the row and no-ops for everyone else, keeping the guard's protection
+-- while removing its false negative.
+--
+-- A NULL dequeued_by_id (system-initiated dequeue, e.g. a status callback
+-- whose conference name did not parse into a user id) matches nothing under
+-- `=`, so those callers keep exactly today's behaviour rather than gaining an
+-- unguarded write.
+--
+-- Column vocabulary is unchanged (still the full QUEUE_ENTRY_TRANSITIONS
+-- `dequeued` set), so scripts/check-queue-rpc-contract.mjs is unaffected.
+--
+-- Closes #1260.
+
+CREATE OR REPLACE FUNCTION public.dequeue_contact(
+  passed_contact_id bigint,
+  group_on_household boolean,
+  p_workspace uuid,
+  dequeued_by_id uuid DEFAULT NULL::uuid,
+  dequeued_reason_text text DEFAULT NULL::text
+)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+begin
+  update public.campaign_queue
+  set
+    queue_state = 'dequeued',
+    assigned_to_user_id = null,
+    provider_status = null,
+    dequeued_by = dequeued_by_id,
+    dequeued_at = now(),
+    dequeued_reason = dequeued_reason_text
+  where contact_id = passed_contact_id
+    and workspace = p_workspace
+    and (
+      queue_state is null
+      or queue_state = 'queued'
+      -- #1260: the caller's own claim. Narrower than "any assigned row" on
+      -- purpose — see the header for why this is the race guard, not a hole.
+      or (
+        queue_state = 'assigned'
+        and dequeued_by_id is not null
+        and assigned_to_user_id = dequeued_by_id
+      )
+    );
+
+  if group_on_household then
+    update public.campaign_queue cq
+    set
+      queue_state = 'dequeued',
+      assigned_to_user_id = null,
+      provider_status = null,
+      dequeued_by = dequeued_by_id,
+      dequeued_at = now(),
+      dequeued_reason = dequeued_reason_text
+    from public.contact c1
+    join public.contact c2 on c1.household_id is not null and c1.household_id = c2.household_id
+    where
+      c1.id = passed_contact_id
+      and c1.workspace = p_workspace
+      and c2.workspace = p_workspace
+      and cq.contact_id = c2.id
+      and cq.workspace = p_workspace
+      and (
+        cq.queue_state is null
+        or cq.queue_state = 'queued'
+        -- Same widening, same guard: a household fan-out must never dequeue
+        -- a sibling row another agent is currently holding.
+        or (
+          cq.queue_state = 'assigned'
+          and dequeued_by_id is not null
+          and cq.assigned_to_user_id = dequeued_by_id
+        )
+      );
+  end if;
+end;
+$function$;

--- a/scripts/db/bootstrap-fresh-db.mjs
+++ b/scripts/db/bootstrap-fresh-db.mjs
@@ -107,6 +107,7 @@ const steps = [
   "client/migrations/20260813120000_drop_campaign_is_active.sql",
   "client/migrations/20260814000000_drop_supabase_era_orphans.sql",
   "client/migrations/20260814120000_requeue_clears_assigned_user.sql",
+  "client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql",
 ];
 
 /**

--- a/scripts/e2e/bootstrap-compose-db.mjs
+++ b/scripts/e2e/bootstrap-compose-db.mjs
@@ -65,6 +65,7 @@ const steps = [
   "client/migrations/20260813120000_drop_campaign_is_active.sql",
   "client/migrations/20260814000000_drop_supabase_era_orphans.sql",
   "client/migrations/20260814120000_requeue_clears_assigned_user.sql",
+  "client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql",
 ];
 
 /**

--- a/test/dequeue-queue-entry.test.ts
+++ b/test/dequeue-queue-entry.test.ts
@@ -9,8 +9,11 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
  * `@/lib/db-rpc.server` is mocked wholesale so these tests exercise only the
  * routing decision (which mechanism gets called, with what args), not the
  * RPC's own household-lookup/emit behavior — that's covered by
- * scope-dequeue-and-outreach-attempt.integration.test.ts and manual
- * verification against a live Postgres instance (see that file's header).
+ * test/integration-db/dequeue-contact-assigned.test.ts, which runs the real
+ * plpgsql function against a real Postgres. Anything about WHICH ROWS the RPC
+ * touches belongs there, not here: a predicate bug (#1260 — the dequeue
+ * silently no-oped on the claimed row it was called for) is invisible to a
+ * wholesale mock of the RPC.
  */
 
 const rpcDequeueContactMock = vi.hoisted(() => vi.fn(async () => undefined));

--- a/test/integration-db/dequeue-contact-assigned.test.ts
+++ b/test/integration-db/dequeue-contact-assigned.test.ts
@@ -1,0 +1,422 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { RpcExecutor } from "@/lib/db-rpc.server";
+import type { dequeueQueueEntry as DequeueFn } from "@/lib/campaign-queue-db.server";
+
+/**
+ * The real `dequeue_contact` plpgsql function, exercised through the app's
+ * single caller-facing dequeue interface (`dequeueQueueEntry`, #1240 B3).
+ *
+ * Issue #1260: both UPDATEs in `dequeue_contact` were guarded with
+ * `queue_state is null or queue_state = 'queued'`, but every RPC-mode call
+ * site fires after the row has been claimed to `assigned`. The dequeue
+ * silently no-oped on exactly the row it was called for — most damagingly on
+ * auto-dial's ambiguous-dial park path, where the RPC is the only dequeue, so
+ * a contact deliberately parked ("call may exist at Twilio; parked for
+ * review, not redialed") was left `assigned` until
+ * `reset_stale_campaign_queue_claims` requeued it for redial.
+ *
+ * `client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql`
+ * widens the predicate to also cover `assigned` rows whose
+ * `assigned_to_user_id` equals the caller — the claim is a token, so a caller
+ * who no longer holds it still no-ops. The race-guard tests below are the
+ * half of that contract that must not regress if someone later "simplifies"
+ * the predicate to an unconditional UPDATE.
+ *
+ * No other automated test runs this function against a real database: the
+ * unit tier mocks the db client, and
+ * test/scope-dequeue-and-outreach-attempt.integration.test.ts asserts on the
+ * migration's SQL *text*, which a predicate bug like this one passes happily.
+ */
+
+// The realtime side channel is covered by test/queue-events*.test.ts and is
+// explicitly non-fatal in production; stubbing it keeps this suite to one
+// subject (the RPC + its TS wrapper's row selection).
+vi.mock("@/lib/workspace-events.server", () => ({
+  emitQueueEvent: vi.fn(async () => undefined),
+  emitPostgresChangeEvent: vi.fn(async () => undefined),
+}));
+
+const DATABASE_URL = process.env.INTEGRATION_DB_URL ?? process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+  process.stderr.write(
+    [
+      "",
+      "!".repeat(72),
+      "!! integration-db SKIPPED: no INTEGRATION_DB_URL / DATABASE_URL set.",
+      "!!",
+      "!! test/integration-db/dequeue-contact-assigned.test.ts is the ONLY test",
+      "!! that runs the real dequeue_contact plpgsql function. Skipping it means",
+      "!! issue #1260 (dequeue silently no-ops on the claimed row) is UNGUARDED",
+      "!! in this run.",
+      "!!",
+      "!! To run it:",
+      "!!   docker compose -f docker-compose.dev.yml up -d postgres",
+      "!!   export DATABASE_URL=postgresql://callcaster:callcaster@127.0.0.1:5433/callcaster",
+      "!!   node scripts/e2e/bootstrap-compose-db.mjs",
+      "!!   npm run test:integration-db",
+      "!!",
+      "!! CI runs it as part of `npm run test:e2e:compose`.",
+      "!".repeat(72),
+      "",
+    ].join("\n"),
+  );
+}
+
+const describeDb = DATABASE_URL ? describe : describe.skip;
+
+const AGENT_A = "1d1e0000-0000-4000-8000-00000000000a";
+const AGENT_B = "1d1e0000-0000-4000-8000-00000000000b";
+
+type QueueRow = {
+  id: string;
+  contact_id: string;
+  queue_state: string | null;
+  assigned_to_user_id: string | null;
+  dequeued_at: string | null;
+  dequeued_by: string | null;
+  dequeued_reason: string | null;
+  provider_status: string | null;
+};
+
+describeDb("dequeue_contact against real Postgres", () => {
+  let client: postgres.Sql;
+  let exec: RpcExecutor;
+  let dequeueQueueEntry: typeof DequeueFn;
+  let workspaceId: string;
+  let campaignId: string;
+  let householdId: string;
+  let primaryContactId: string;
+  let siblingContactId: string;
+  let loneContactId: string;
+
+  async function queueRow(contactId: string): Promise<QueueRow> {
+    const rows = await client<QueueRow[]>`
+      select
+        id::text as id,
+        contact_id::text as contact_id,
+        queue_state,
+        assigned_to_user_id::text as assigned_to_user_id,
+        dequeued_at::text as dequeued_at,
+        dequeued_by::text as dequeued_by,
+        dequeued_reason,
+        provider_status
+      from public.campaign_queue
+      where campaign_id = ${campaignId}::bigint
+        and contact_id = ${contactId}::bigint
+    `;
+    return rows[0];
+  }
+
+  /** Put a queue row into exactly the state a claim RPC leaves behind. */
+  async function setState(
+    contactId: string,
+    state: {
+      queue_state: string | null;
+      assigned_to_user_id?: string | null;
+      provider_status?: string | null;
+    },
+  ) {
+    await client`
+      update public.campaign_queue
+      set queue_state = ${state.queue_state},
+          assigned_to_user_id = ${state.assigned_to_user_id ?? null}::uuid,
+          provider_status = ${state.provider_status ?? null},
+          claimed_at = ${state.queue_state === "assigned" ? client`now()` : null},
+          dequeued_at = null,
+          dequeued_by = null,
+          dequeued_reason = null
+      where campaign_id = ${campaignId}::bigint
+        and contact_id = ${contactId}::bigint
+    `;
+  }
+
+  beforeAll(async () => {
+    client = postgres(DATABASE_URL as string, {
+      max: 5,
+      prepare: false,
+      connect_timeout: 10,
+      onnotice: () => {},
+    });
+    const database = drizzle(client);
+    exec = {
+      execute: (query) => database.execute(query) as unknown as Promise<unknown[]>,
+    };
+
+    ({ dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server"));
+
+    await client`
+      insert into public."user" (id, username, first_name, last_name)
+      values
+        (${AGENT_A}::uuid, 'integration-db-dequeue-a@example.test', 'Agent', 'A'),
+        (${AGENT_B}::uuid, 'integration-db-dequeue-b@example.test', 'Agent', 'B')
+      on conflict (id) do nothing
+    `;
+
+    const workspaces = await client<{ id: string }[]>`
+      insert into public.workspace (name, credits, twilio_data, feature_flags, disabled)
+      values ('Integration DB Dequeue Fixture', 0, '{}'::jsonb, '{}'::jsonb, false)
+      returning id::text as id
+    `;
+    workspaceId = workspaces[0].id;
+
+    const campaigns = await client<{ id: string }[]>`
+      insert into public.campaign (title, workspace, group_household_queue, dial_type)
+      values ('Integration DB Dequeue Campaign', ${workspaceId}::uuid, true, 'call')
+      returning id::text as id
+    `;
+    campaignId = campaigns[0].id;
+
+    const households = await client<{ id: string }[]>`
+      insert into public.households (household_key, workspace_id, address)
+      values ('integration-db-dequeue', ${workspaceId}::uuid, '1 Integration Way')
+      returning id::text as id
+    `;
+    householdId = households[0].id;
+
+    const contacts = await client<{ id: string }[]>`
+      insert into public.contact (firstname, surname, phone, address, workspace, household_id)
+      values
+        ('Primary', 'Household', '+15550100001', '1 Integration Way', ${workspaceId}::uuid, ${householdId}::uuid),
+        ('Sibling', 'Household', '+15550100002', '1 Integration Way', ${workspaceId}::uuid, ${householdId}::uuid),
+        ('Lone', 'Contact', '+15550100003', '2 Integration Way', ${workspaceId}::uuid, null)
+      returning id::text as id
+    `;
+    [primaryContactId, siblingContactId, loneContactId] = contacts.map((row) => row.id);
+
+    await client`
+      insert into public.campaign_queue (contact_id, campaign_id, workspace, queue_state, queue_order)
+      values
+        (${primaryContactId}::bigint, ${campaignId}::bigint, ${workspaceId}::uuid, 'queued', 1),
+        (${siblingContactId}::bigint, ${campaignId}::bigint, ${workspaceId}::uuid, 'queued', 2),
+        (${loneContactId}::bigint, ${campaignId}::bigint, ${workspaceId}::uuid, 'queued', 3)
+    `;
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    if (workspaceId) {
+      // campaign_queue/contact/campaign/households all cascade from workspace.
+      await client`delete from public.workspace where id = ${workspaceId}::uuid`;
+    }
+    await client`delete from public."user" where id in (${AGENT_A}::uuid, ${AGENT_B}::uuid)`;
+    await client.end({ timeout: 5 });
+  });
+
+  beforeEach(async () => {
+    await setState(primaryContactId, { queue_state: "queued" });
+    await setState(siblingContactId, { queue_state: "queued" });
+    await setState(loneContactId, { queue_state: "queued" });
+  });
+
+  test("the fixture starts with three queued rows", async () => {
+    for (const contactId of [primaryContactId, siblingContactId, loneContactId]) {
+      const row = await queueRow(contactId);
+      expect(row.queue_state).toBe("queued");
+      expect(row.dequeued_at).toBeNull();
+    }
+  });
+
+  // ── #1260: the claimed row must actually dequeue ────────────────────────
+
+  test("the park path dequeues a row the caller holds as 'assigned'", async () => {
+    // Exactly what claim_next_queue_contact leaves behind before
+    // auto-dial.server.ts's ambiguous-dial-failure park runs.
+    await setState(loneContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_A,
+      provider_status: "initiated",
+    });
+
+    await dequeueQueueEntry({
+      by: { contactId: Number(loneContactId) },
+      workspaceId,
+      // The park path: guarded RPC, no household fan-out.
+      household: false,
+      userId: AGENT_A,
+      reason: "Ambiguous dial failure — parked for review",
+      exec,
+    });
+
+    const row = await queueRow(loneContactId);
+    expect(row.queue_state).toBe("dequeued");
+    expect(row.dequeued_at).not.toBeNull();
+    expect(row.dequeued_by).toBe(AGENT_A);
+    expect(row.dequeued_reason).toBe("Ambiguous dial failure — parked for review");
+    // The dequeue transition owns the whole column set: a parked row must not
+    // keep a stale claim or a stale provider status.
+    expect(row.assigned_to_user_id).toBeNull();
+    expect(row.provider_status).toBeNull();
+  });
+
+  test("household fan-out dequeues both the caller's assigned row and its queued sibling", async () => {
+    // The auto-dial happy path: primary claimed by the agent, sibling still
+    // queued. Before #1260 only the SIBLING was dequeued.
+    await setState(primaryContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_A,
+    });
+
+    await dequeueQueueEntry({
+      by: { contactId: Number(primaryContactId) },
+      workspaceId,
+      household: true,
+      userId: AGENT_A,
+      reason: "Predictive Dialer called contact",
+      exec,
+    });
+
+    const primary = await queueRow(primaryContactId);
+    const sibling = await queueRow(siblingContactId);
+    expect(primary.queue_state).toBe("dequeued");
+    expect(primary.dequeued_at).not.toBeNull();
+    expect(sibling.queue_state).toBe("dequeued");
+    expect(sibling.dequeued_at).not.toBeNull();
+  });
+
+  test("a queued row still dequeues (the pre-existing path is unchanged)", async () => {
+    await dequeueQueueEntry({
+      by: { contactId: Number(loneContactId) },
+      workspaceId,
+      household: false,
+      userId: AGENT_A,
+      reason: "Manually dequeued by user",
+      exec,
+    });
+
+    const row = await queueRow(loneContactId);
+    expect(row.queue_state).toBe("dequeued");
+    expect(row.dequeued_by).toBe(AGENT_A);
+  });
+
+  test("a row with a null queue_state (legacy) still dequeues", async () => {
+    await setState(loneContactId, { queue_state: null });
+
+    await dequeueQueueEntry({
+      by: { contactId: Number(loneContactId) },
+      workspaceId,
+      household: false,
+      userId: AGENT_A,
+      reason: "Legacy null state",
+      exec,
+    });
+
+    expect((await queueRow(loneContactId)).queue_state).toBe("dequeued");
+  });
+
+  // ── the race guard the widened predicate must keep ──────────────────────
+
+  test("a stale dequeue does NOT touch a row another agent now holds", async () => {
+    // The race the original queued-only predicate existed to prevent: agent A
+    // decides to dequeue, the row is reclaimed in the meantime (stale-claim
+    // reset + a fresh claim), and A's dequeue arrives late. Killing agent B's
+    // live call here is strictly worse than leaving the row alone.
+    await setState(loneContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_B,
+      provider_status: "in-progress",
+    });
+
+    await dequeueQueueEntry({
+      by: { contactId: Number(loneContactId) },
+      workspaceId,
+      household: false,
+      userId: AGENT_A,
+      reason: "Stale dequeue from agent A",
+      exec,
+    });
+
+    const row = await queueRow(loneContactId);
+    expect(row.queue_state).toBe("assigned");
+    expect(row.assigned_to_user_id).toBe(AGENT_B);
+    expect(row.provider_status).toBe("in-progress");
+    expect(row.dequeued_at).toBeNull();
+  });
+
+  test("household fan-out does NOT reach a sibling another agent holds", async () => {
+    await setState(primaryContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_A,
+    });
+    await setState(siblingContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_B,
+      provider_status: "ringing",
+    });
+
+    await dequeueQueueEntry({
+      by: { contactId: Number(primaryContactId) },
+      workspaceId,
+      household: true,
+      userId: AGENT_A,
+      reason: "Predictive Dialer called contact",
+      exec,
+    });
+
+    expect((await queueRow(primaryContactId)).queue_state).toBe("dequeued");
+    const sibling = await queueRow(siblingContactId);
+    expect(sibling.queue_state).toBe("assigned");
+    expect(sibling.assigned_to_user_id).toBe(AGENT_B);
+    expect(sibling.dequeued_at).toBeNull();
+  });
+
+  test("a system dequeue with no user id does not gain an unguarded write", async () => {
+    // status.action.server.ts passes `null` when a conference name does not
+    // parse into a user id. `assigned_to_user_id = null` is never true, so
+    // those callers keep the pre-#1260 behaviour rather than becoming able to
+    // dequeue any agent's claimed row.
+    await setState(loneContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_A,
+    });
+
+    await dequeueQueueEntry({
+      by: { contactId: Number(loneContactId) },
+      workspaceId,
+      household: false,
+      userId: null,
+      reason: "Call completed",
+      exec,
+    });
+
+    const row = await queueRow(loneContactId);
+    expect(row.queue_state).toBe("assigned");
+    expect(row.assigned_to_user_id).toBe(AGENT_A);
+  });
+
+  test("the workspace predicate still scopes every write", async () => {
+    // 20260807120000's cross-tenant fix, re-asserted at runtime now that the
+    // state predicate next to it has changed.
+    await setState(loneContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_A,
+    });
+
+    const otherWorkspaces = await client<{ id: string }[]>`
+      insert into public.workspace (name, credits, twilio_data, feature_flags, disabled)
+      values ('Integration DB Dequeue Other Workspace', 0, '{}'::jsonb, '{}'::jsonb, false)
+      returning id::text as id
+    `;
+    const otherWorkspaceId = otherWorkspaces[0].id;
+
+    try {
+      await dequeueQueueEntry({
+        by: { contactId: Number(loneContactId) },
+        workspaceId: otherWorkspaceId,
+        household: false,
+        userId: AGENT_A,
+        reason: "Cross-tenant dequeue attempt",
+        exec,
+      });
+
+      const row = await queueRow(loneContactId);
+      expect(row.queue_state).toBe("assigned");
+      expect(row.dequeued_at).toBeNull();
+    } finally {
+      await client`delete from public.workspace where id = ${otherWorkspaceId}::uuid`;
+    }
+  });
+});

--- a/test/scope-dequeue-and-outreach-attempt.integration.test.ts
+++ b/test/scope-dequeue-and-outreach-attempt.integration.test.ts
@@ -19,14 +19,47 @@ import { describe, expect, test } from "vitest";
  *     2's campaign_queue.attempts at 0. The same call with a same-workspace
  *     queue_id correctly bumped attempts.
  *
- * This repo has no automated live-Postgres test tier (see
- * campaign-queue-throughput.integration.test.ts for the established
- * pattern), so this guards the property that made the bug real — an
- * accidental revert of either workspace predicate would reintroduce a
- * cross-tenant write without any other automated test catching it.
+ * This guards the property that made the bug real — an accidental revert of
+ * either workspace predicate would reintroduce a cross-tenant write. The
+ * dequeue_contact half is now ALSO checked at runtime by
+ * test/integration-db/dequeue-contact-assigned.test.ts, which calls the real
+ * function against a real Postgres; that test is the authority on which rows
+ * the function touches, since asserting on SQL text cannot tell a correct
+ * predicate from a broken one (see #1260).
+ *
+ * Note that 20260807120000 is no longer the CURRENT definition of
+ * dequeue_contact — 20260815120000 replaced it — so the assertions below are
+ * applied to both files: the historical one for the fix it introduced, and
+ * the current one because that is what actually runs.
  */
+const DEQUEUE_CONTACT_DEFINITIONS = [
+  "client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql",
+  "client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql",
+];
+
 describe("scope dequeue_contact / create_outreach_attempt by workspace SQL harness", () => {
-  test("dequeue_contact filters every write (and the household lookup) by workspace", async () => {
+  test.each(DEQUEUE_CONTACT_DEFINITIONS)(
+    "%s: dequeue_contact filters every write (and the household lookup) by workspace",
+    async (migration) => {
+      const { readFile } = await import("node:fs/promises");
+      const { resolve } = await import("node:path");
+      const sql = await readFile(resolve(process.cwd(), migration), "utf8");
+
+      expect(sql).toContain("CREATE OR REPLACE FUNCTION public.dequeue_contact(");
+      expect(sql).toContain("p_workspace uuid");
+      // The non-household UPDATE.
+      expect(sql).toMatch(
+        /where contact_id = passed_contact_id\s*\n\s*and workspace = p_workspace/,
+      );
+      // The household UPDATE: both joined contacts AND the queue row itself
+      // must be workspace-checked, not just one side of the join.
+      expect(sql).toContain("c1.workspace = p_workspace");
+      expect(sql).toContain("c2.workspace = p_workspace");
+      expect(sql).toContain("cq.workspace = p_workspace");
+    },
+  );
+
+  test("create_outreach_attempt scopes the attempts-counter UPDATE by workspace", async () => {
     const { readFile } = await import("node:fs/promises");
     const { resolve } = await import("node:path");
     const sql = await readFile(
@@ -36,18 +69,6 @@ describe("scope dequeue_contact / create_outreach_attempt by workspace SQL harne
       ),
       "utf8",
     );
-
-    expect(sql).toContain("CREATE OR REPLACE FUNCTION public.dequeue_contact(");
-    expect(sql).toContain("p_workspace uuid");
-    // The non-household UPDATE.
-    expect(sql).toMatch(
-      /where contact_id = passed_contact_id\s*\n\s*and workspace = p_workspace/,
-    );
-    // The household UPDATE: both joined contacts AND the queue row itself
-    // must be workspace-checked, not just one side of the join.
-    expect(sql).toContain("c1.workspace = p_workspace");
-    expect(sql).toContain("c2.workspace = p_workspace");
-    expect(sql).toContain("cq.workspace = p_workspace");
 
     expect(sql).toContain("CREATE OR REPLACE FUNCTION public.create_outreach_attempt(");
     expect(sql).toMatch(


### PR DESCRIPTION
Closes #1260

## The bug, reproduced at runtime

`dequeue_contact` guarded both of its UPDATEs with `queue_state is null or queue_state = 'queued'`, but **every** RPC-mode call site fires *after* the row has been claimed to `assigned`. Reproduced against a live Postgres 18 (compose stack) with the primary row `assigned` to agent A and a household sibling still `queued`:

**Before**

| call | primary row (assigned) | sibling row (queued) |
| --- | --- | --- |
| `dequeue_contact(contact, false, ws, agentA, 'park')` | `assigned`, `dequeued_at` null — **untouched** | `queued` |
| `dequeue_contact(contact, true, ws, agentA, 'dialed')` | `assigned`, `dequeued_at` null — **untouched** | `dequeued` |

**After**

| call | primary row (assigned) | sibling row (queued) |
| --- | --- | --- |
| `dequeue_contact(contact, false, ws, agentA, 'park')` | `dequeued` | `queued` |
| `dequeue_contact(contact, true, ws, agentA, 'dialed')` | `dequeued` | `dequeued` |

## Which flows were actually broken

The issue guessed the happy path was covered by a by-id Drizzle dequeue from the status callback. It is not — the by-id path is used only by SMS dispatch, IVR and campaign-split. Every RPC-mode dequeue was affected:

| call site | mode | broken before |
| --- | --- | --- |
| `auto-dial.server.ts` ambiguous-dial **park** | `household: false` | yes — the RPC is the only dequeue for the row |
| `auto-dial.server.ts` post-dial dequeue | `household: true` | yes for the primary row; siblings were fine |
| `api/auto-dial/status` terminal call status | `household: true` | yes for the primary row |
| `api/auto-dial/$roomId` machine answer | `household: true` | yes for the primary row |
| `api/hangup` | campaign's `group_household_queue` | yes when the row was assigned |
| `api/queues` manual dequeue | caller-supplied | yes when the row was assigned |

Impact is worst on the park path. `reset_stale_campaign_queue_claims` flips a stranded `assigned` row back to `queued`, so a contact deliberately parked with *"call may exist at Twilio; parked for review, not redialed"* gets re-surfaced and redialed — the exact outcome the park exists to prevent. On the other paths the row sat `assigned` until the same sweep, inflating `attempt_count` on rows that had already been reached.

## Fix chosen: option (a), widen only for the claim holder

Predicate becomes `queued`/null **or** (`assigned` **and** `assigned_to_user_id = dequeued_by_id`), on both the primary UPDATE and the household fan-out.

**Why not drop the predicate (option c).** It is a genuine race guard. Between an agent deciding to dequeue and the RPC running, the row can be reclaimed (stale-claim reset, then another agent's claim). An unconditional UPDATE lets a stale dequeue kill a call another agent is actively placing, and lets a household fan-out reach a sibling another agent holds.

**Why `assigned_to_user_id` is a sound claim token.** Every writer that sets `queue_state = 'assigned'` stamps the claiming user in the same UPDATE — `claim_next_queue_contact` (20260803130000), `select_and_update_campaign_contacts` (20260807130000), `claim_queue_entry_for_dial` (20260805120000) — and every release clears it: `reset_stale_campaign_queue_claims`, `fail_exhausted_campaign_queue_contacts`, and requeue since #1250/PR #1250 (which is what made the column trustworthy here — the two findings really did interact). So `assigned_to_user_id = dequeued_by_id` means precisely *"the caller still holds this claim"*: the dequeue lands for the owner and no-ops for everyone else. The guard keeps its protection and loses its false negative.

**Why not option (b)** (park path switches to the by-id dequeue): it fixes one call site and leaves the other five, and it would swap a guarded write for an unconditional one on exactly the path where the race matters most.

A `NULL` `dequeued_by_id` (system-initiated dequeue — e.g. a status callback whose conference name did not parse into a user id) matches nothing under `=`, so those callers keep today's behaviour rather than gaining an unguarded write.

## Also changed

- `rpcDequeueContact`'s pre-UPDATE snapshot used the same queued-only predicate to decide which rows get a realtime `UPDATE` event. Left alone, a row the RPC now dequeues would emit no event and the queue UI would keep showing it live. Mirrored.
- Both migration wiring lists (`scripts/e2e/bootstrap-compose-db.mjs`, `scripts/db/bootstrap-fresh-db.mjs`). The second one's guard caught the omission.
- Stale doc comments on `dequeueQueueEntry` and the auto-dial park path that described the old queued-only semantics.

`QUEUE_ENTRY_TRANSITIONS` needs no change: the column vocabulary is still the full `dequeued` set, only the WHERE moved. The contract baseline does not grow.

## Tests

New `test/integration-db/dequeue-contact-assigned.test.ts` — the real plpgsql function against a real Postgres, driven through `dequeueQueueEntry`. Committed red first (3 failures), green after the migration. It covers both halves of the contract:

- the park path dequeues a row the caller holds as `assigned`, clearing `assigned_to_user_id` and `provider_status`
- household fan-out dequeues the caller's assigned primary **and** its queued sibling
- queued and legacy-null rows still dequeue
- **race guard:** a stale dequeue does not touch a row another agent now holds
- **race guard:** household fan-out does not reach a sibling another agent holds
- **race guard:** a null `dequeued_by` gains no unguarded write
- the workspace predicate (20260807120000) still scopes every write

`test/scope-dequeue-and-outreach-attempt.integration.test.ts` asserted on a migration that is no longer the current definition; its workspace-predicate checks now run against both.

## Gates

| gate | result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run test:node` | 352 files, 2714 pass / 3 skip |
| `npm run test:integration-db` (compose) | 2 files, 16 pass |
| `node scripts/check-queue-rpc-contract.mjs` | no new drift; baseline unchanged |
| `node scripts/check-db-rpcs.mjs` | 32 functions, all created by migrations |
| `npm run db:bootstrap:check` | 51 migrations, none unwired |
| `npm run db:schema:check` (compose) | no drift |
| `npm run db:orphans:check` | 0 orphaned |

## Known, out of scope

Manual dequeue from the queue UI (`POST /api/queues`) still no-ops on a row assigned to a *different* agent — that is the race guard working as designed, but a supervisor override has no path today. Worth its own issue rather than a hole punched in this predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
