### PR TITLE
fix(queue): surface the manual dequeue that silently no-ops (#1278)

### DIFF
--- a/app/hooks/call/useCampaignQueueFlow.ts
+++ b/app/hooks/call/useCampaignQueueFlow.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { useFetcher } from "react-router";
 import { handleContact, handleQueue } from "@/lib/callscreenActions";
+import { useActionFeedback } from "@/hooks/utils/useActionFeedback";
 import type { Call, Campaign, OutreachAttempt, QueueItem } from "@/lib/types";
 
 type UseCampaignQueueFlowOptions = {
@@ -39,7 +40,22 @@ export function useCampaignQueueFlow({
   setNextRecipient,
   setQueue,
 }: UseCampaignQueueFlowOptions) {
-  const queueFetcher = useFetcher<{ queueError?: boolean }>();
+  const queueFetcher = useFetcher<{
+    queueError?: boolean;
+    error?: string;
+    code?: string;
+  }>();
+
+  // POST /api/queues answers a manual dequeue with 409 + `{ error, code }`
+  // when the row was NOT dequeued — it is `assigned` to another agent, so the
+  // guarded RPC left it alone (#1278). Without this the agent saw the contact
+  // vanish from their list and nothing else: the fetcher result was read by no
+  // one. Success carries no message on purpose (the row disappearing is the
+  // feedback), and an already-dequeued contact answers 200, so the routine
+  // "next contact" dequeue after a hangup stays silent.
+  useActionFeedback(queueFetcher.data, {
+    enabled: queueFetcher.state === "idle",
+  });
 
   const { switchQuestionContact, nextNumber } = handleContact({
     setQuestionContact,

--- a/app/lib/campaign-queue-db.server.ts
+++ b/app/lib/campaign-queue-db.server.ts
@@ -525,6 +525,13 @@ async function dequeueCampaignQueueByContact(args: {
  *
  * Mechanism selection here is a behavior-preserving refactor of the original
  * call sites; what each mechanism does to an `assigned` row changed in #1260.
+ *
+ * All three mechanisms report {@link DequeueQueueEntryResult}: whether the
+ * target row itself was actually dequeued. Callers that dequeue their own
+ * claim (auto-dial's park, the hangup and status-callback paths) always match
+ * and are free to ignore it, as they did before #1278; the manual queue-UI
+ * path in app/routes/api+/queues.action.server.ts is the one that must not
+ * report success for a write that no-oped.
  */
 type DequeueQueueEntryByIdArgs = {
   by: { id: number };
@@ -547,6 +554,22 @@ export type DequeueQueueEntryArgs =
   | DequeueQueueEntryByIdArgs
   | DequeueQueueEntryByContactArgs;
 
+/**
+ * What the dequeue actually did to the row it was called for (#1278).
+ *
+ * `dequeuedPrimary: false` is not an error — on the guarded RPC path it is the
+ * concurrency guard doing its job, and on the Drizzle paths it means the
+ * target row no longer exists or is already terminal. Only callers that report
+ * an outcome to a human need to look at it; see
+ * {@link explainDequeueNoOp} for turning a `false` into a reason.
+ *
+ * Household siblings are deliberately excluded: a fan-out that dequeues three
+ * siblings but misses the contact the agent clicked is still a failed dequeue.
+ */
+export type DequeueQueueEntryResult = {
+  dequeuedPrimary: boolean;
+};
+
 // A plain `"id" in args.by` inline check narrows `args.by`'s type but not
 // sibling properties of `args` (e.g. `userId`) back at the call site — a
 // named type predicate narrows the whole `args` union instead.
@@ -554,15 +577,17 @@ function isByIdArgs(args: DequeueQueueEntryArgs): args is DequeueQueueEntryByIdA
   return "id" in args.by;
 }
 
-export async function dequeueQueueEntry(args: DequeueQueueEntryArgs): Promise<void> {
+export async function dequeueQueueEntry(
+  args: DequeueQueueEntryArgs,
+): Promise<DequeueQueueEntryResult> {
   if (isByIdArgs(args)) {
-    await dequeueCampaignQueueById({
+    const rows = await dequeueCampaignQueueById({
       queueId: args.by.id,
       userId: args.userId,
       reason: args.reason,
       workspaceId: args.workspaceId,
     });
-    return;
+    return { dequeuedPrimary: rows.length > 0 };
   }
 
   const { contactId, campaignId } = args.by;
@@ -574,23 +599,82 @@ export async function dequeueQueueEntry(args: DequeueQueueEntryArgs): Promise<vo
       );
     }
     const exec = args.exec ?? createTenantDb(args.workspaceId);
-    await rpcDequeueContact(exec, {
+    const primaryRowsDequeued = await rpcDequeueContact(exec, {
       contactId,
       workspaceId: args.workspaceId,
       groupOnHousehold: args.household,
       dequeuedById: args.userId,
       dequeuedReasonText: args.reason,
     });
-    return;
+    return { dequeuedPrimary: primaryRowsDequeued > 0 };
   }
 
-  await dequeueCampaignQueueByContact({
+  const rows = await dequeueCampaignQueueByContact({
     contactId,
     campaignId,
     userId: args.userId,
     reason: args.reason,
     workspaceId: args.workspaceId,
   });
+  return { dequeuedPrimary: rows.length > 0 };
+}
+
+/**
+ * Why a dequeue reported `dequeuedPrimary: false` (#1278).
+ *
+ * A plain read, run only on the no-op path, so the API can say something true
+ * instead of "assigned to another agent" for every zero-row dequeue — the
+ * manual-dial "next contact" flow dequeues a contact the hangup route has
+ * usually already dequeued, and calling that a conflict would be a new lie in
+ * place of the old one.
+ *
+ * Best-effort by construction: the row can change again between the RPC and
+ * this read. It decides a message, never a write.
+ */
+export type DequeueNoOpReason =
+  | "already_dequeued"
+  | "assigned_elsewhere"
+  | "not_found"
+  | "unknown";
+
+export async function explainDequeueNoOp(args: {
+  contactId: number;
+  workspaceId: string;
+  userId: string | null;
+}): Promise<DequeueNoOpReason> {
+  const rows = await db
+    .select({
+      queue_state: campaignQueueTable.queue_state,
+      assigned_to_user_id: campaignQueueTable.assigned_to_user_id,
+      dequeued_at: campaignQueueTable.dequeued_at,
+    })
+    .from(campaignQueueTable)
+    .where(
+      and(
+        eq(campaignQueueTable.contact_id, args.contactId),
+        eq(campaignQueueTable.workspace, args.workspaceId),
+      ),
+    );
+
+  if (rows.length === 0) {
+    return "not_found";
+  }
+
+  const heldByAnotherAgent = rows.some(
+    (row) =>
+      row.dequeued_at == null &&
+      row.assigned_to_user_id != null &&
+      row.assigned_to_user_id !== args.userId,
+  );
+  if (heldByAnotherAgent) {
+    return "assigned_elsewhere";
+  }
+
+  if (rows.every((row) => row.dequeued_at != null)) {
+    return "already_dequeued";
+  }
+
+  return "unknown";
 }
 
 export async function releaseAssignedQueueForUser(

--- a/app/lib/db-rpc.server.ts
+++ b/app/lib/db-rpc.server.ts
@@ -235,6 +235,12 @@ export async function rpcClaimQueueEntryForDial(
  * caller-facing dequeue entry point — can import it across the module
  * boundary; no other file should call this directly. Call
  * `dequeueQueueEntry` instead.
+ *
+ * @returns how many rows the RPC dequeued for `contactId` itself — 0 or 1.
+ * Household siblings are NOT counted (see
+ * client/migrations/20260815130000_dequeue_contact_returns_rows_affected.sql).
+ * 0 means the guarded predicate matched nothing: the row is already dequeued,
+ * or it is `assigned` to someone other than `dequeuedById` (#1278).
  */
 export async function rpcDequeueContact(
   executor: RpcExecutor,
@@ -245,7 +251,7 @@ export async function rpcDequeueContact(
     dequeuedById?: string | null;
     dequeuedReasonText?: string | null;
   },
-): Promise<void> {
+): Promise<number> {
   const contactIds = new Set<number>([args.contactId]);
   if (args.groupOnHousehold) {
     const [sourceContact] = await db
@@ -305,19 +311,21 @@ export async function rpcDequeueContact(
       ),
     );
 
-  await execVoid(
-    executor,
-    sql`select dequeue_contact(
+  const primaryRowsDequeued =
+    (await queryScalarNumber(
+      executor,
+      sql`select dequeue_contact(
       ${args.contactId}::bigint,
       ${args.groupOnHousehold},
       ${args.workspaceId}::uuid,
       ${dequeuedById}::uuid,
       ${args.dequeuedReasonText ?? null}
-    )`,
-  );
+    ) as primary_rows_dequeued`,
+      "dequeue_contact",
+    )) ?? 0;
 
   if (oldRows.length === 0) {
-    return;
+    return primaryRowsDequeued;
   }
 
   const newRows = await db
@@ -338,6 +346,8 @@ export async function rpcDequeueContact(
         ),
       ),
   );
+
+  return primaryRowsDequeued;
 }
 
 export async function rpcGetCampaignQueue(

--- a/app/routes/api+/queues.action.server.ts
+++ b/app/routes/api+/queues.action.server.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/platform-telephony.server";
 import {
   dequeueQueueEntry,
+  explainDequeueNoOp,
   requeueAllCampaignQueueForCampaign,
 } from "@/lib/campaign-queue-db.server";
 import { jsonError } from "@/lib/platform-api.server";
@@ -37,7 +38,7 @@ export const action = defineAction({
         workspaceId,
       });
 
-      await dequeueQueueEntry({
+      const { dequeuedPrimary } = await dequeueQueueEntry({
         by: { contactId: Number(contact_id) },
         workspaceId,
         household,
@@ -45,7 +46,54 @@ export const action = defineAction({
         reason: "Manually dequeued by user",
       });
 
-      return routeData({ success: true });
+      if (!dequeuedPrimary) {
+        // The RPC's predicate only touches a row that is queued/null or
+        // `assigned` to the caller — so nothing happened, and reporting
+        // success left the row sitting in another agent's hands (#1278).
+        // Which no-op it was decides whether this is worth telling the agent
+        // about: re-dequeuing an already-dequeued contact is the manual-dial
+        // "next contact" flow doing exactly what it should, since the hangup
+        // route already dequeued it.
+        const reason = await explainDequeueNoOp({
+          contactId: Number(contact_id),
+          workspaceId,
+          userId: auth.user.id,
+        });
+
+        if (reason === "not_found") {
+          return jsonError("Contact queue entry not found", 404);
+        }
+
+        if (reason === "assigned_elsewhere") {
+          logger.info("queue.dequeue_conflict", {
+            contactId: Number(contact_id),
+            workspaceId,
+            userId: auth.user.id,
+          });
+          return routeData(
+            {
+              error: "This contact is assigned to another agent.",
+              code: "assigned_elsewhere",
+            },
+            { status: 409 },
+          );
+        }
+
+        if (reason === "unknown") {
+          return routeData(
+            {
+              error: "This contact could not be dequeued.",
+              code: "not_dequeued",
+            },
+            { status: 409 },
+          );
+        }
+
+        // already_dequeued — idempotent, not a conflict.
+        return routeData({ success: true, dequeued: false });
+      }
+
+      return routeData({ success: true, dequeued: true });
     }
 
     if (request.method === "DELETE") {

--- a/client/migrations/20260815130000_dequeue_contact_returns_rows_affected.sql
+++ b/client/migrations/20260815130000_dequeue_contact_returns_rows_affected.sql
@@ -1,0 +1,126 @@
+-- dequeue_contact returns how many PRIMARY rows it actually dequeued.
+--
+-- #1278. The predicate 20260815120000 (#1260) settled on is
+-- `queue_state is null or 'queued', or 'assigned' with
+-- assigned_to_user_id = dequeued_by_id` — deliberately a no-op for a caller
+-- who does not hold the claim. That is right for the agent paths (a stale
+-- dequeue must never kill another agent's live call), but the manual queue-UI
+-- dequeue (POST /api/queues → dequeueQueueEntry → this function) had no way to
+-- tell the difference: a supervisor dequeuing a contact another agent holds
+-- got `{ success: true }` while the row sat there untouched. The predicate is
+-- the guard, not the defect; the defect is that the guard was silent.
+--
+-- So: same predicate, same household fan-out, same column writes — the
+-- function now just reports the row count of its PRIMARY update via
+-- GET DIAGNOSTICS. 0 means "nothing was dequeued for the contact you named",
+-- which the caller can surface instead of claiming success.
+--
+-- Why the primary count only, not the household total. The callers that care
+-- asked about ONE contact; a fan-out that reaches three siblings but misses
+-- the contact the agent clicked is still a failed dequeue, and summing the two
+-- updates would hide exactly that. The fan-out's own partial no-ops are the
+-- guard working as designed (a sibling another agent holds must be skipped)
+-- and are not an error at any call site.
+--
+-- WHY DROP + CREATE. `CREATE OR REPLACE FUNCTION` cannot change a function's
+-- return type — `RETURNS void` → `RETURNS integer` raises
+-- `cannot change return type of existing function`. The DROP must name the
+-- exact argument signature, and the two historical signatures are dropped
+-- alongside it: leaving an orphaned overload behind is a failure mode this
+-- repo has already paid for (see 20260722120000, items 2–4 — an unnoticed
+-- extra overload made `campaign_queue_has_pending_work(integer)` calls throw
+-- `function ... is not unique`). After this migration exactly one
+-- dequeue_contact exists:
+--
+--   (integer, boolean, uuid, text)         baseline; dropped by 20260716140000
+--   (bigint,  boolean, uuid, text)         dropped by 20260807120000
+--   (bigint,  boolean, uuid, uuid, text)   the live one, recreated here
+--
+-- All three DROPs are `IF EXISTS`, so replaying this on a database where the
+-- earlier migrations already ran is a no-op for the first two.
+--
+-- No SQL-side caller is affected: no plpgsql function in the lineage calls
+-- dequeue_contact (verified by grep for `perform`/`select dequeue_contact`),
+-- so nothing depends on its `void` return. The application calls it through
+-- rpcDequeueContact (app/lib/db-rpc.server.ts), which reads the scalar.
+--
+-- Column vocabulary is unchanged (still the full QUEUE_ENTRY_TRANSITIONS
+-- `dequeued` set), so scripts/check-queue-rpc-contract.mjs is unaffected.
+--
+-- Closes #1278.
+
+DROP FUNCTION IF EXISTS public.dequeue_contact(integer, boolean, uuid, text);
+DROP FUNCTION IF EXISTS public.dequeue_contact(bigint, boolean, uuid, text);
+DROP FUNCTION IF EXISTS public.dequeue_contact(bigint, boolean, uuid, uuid, text);
+
+CREATE OR REPLACE FUNCTION public.dequeue_contact(
+  passed_contact_id bigint,
+  group_on_household boolean,
+  p_workspace uuid,
+  dequeued_by_id uuid DEFAULT NULL::uuid,
+  dequeued_reason_text text DEFAULT NULL::text
+)
+ RETURNS integer
+ LANGUAGE plpgsql
+AS $function$
+declare
+  primary_rows integer;
+begin
+  update public.campaign_queue
+  set
+    queue_state = 'dequeued',
+    assigned_to_user_id = null,
+    provider_status = null,
+    dequeued_by = dequeued_by_id,
+    dequeued_at = now(),
+    dequeued_reason = dequeued_reason_text
+  where contact_id = passed_contact_id
+    and workspace = p_workspace
+    and (
+      queue_state is null
+      or queue_state = 'queued'
+      -- #1260: the caller's own claim. Narrower than "any assigned row" on
+      -- purpose — see 20260815120000 for why this is the race guard, not a
+      -- hole. #1278 reports when it holds instead of hiding it.
+      or (
+        queue_state = 'assigned'
+        and dequeued_by_id is not null
+        and assigned_to_user_id = dequeued_by_id
+      )
+    );
+
+  get diagnostics primary_rows = row_count;
+
+  if group_on_household then
+    update public.campaign_queue cq
+    set
+      queue_state = 'dequeued',
+      assigned_to_user_id = null,
+      provider_status = null,
+      dequeued_by = dequeued_by_id,
+      dequeued_at = now(),
+      dequeued_reason = dequeued_reason_text
+    from public.contact c1
+    join public.contact c2 on c1.household_id is not null and c1.household_id = c2.household_id
+    where
+      c1.id = passed_contact_id
+      and c1.workspace = p_workspace
+      and c2.workspace = p_workspace
+      and cq.contact_id = c2.id
+      and cq.workspace = p_workspace
+      and (
+        cq.queue_state is null
+        or cq.queue_state = 'queued'
+        -- Same widening, same guard: a household fan-out must never dequeue
+        -- a sibling row another agent is currently holding.
+        or (
+          cq.queue_state = 'assigned'
+          and dequeued_by_id is not null
+          and cq.assigned_to_user_id = dequeued_by_id
+        )
+      );
+  end if;
+
+  return primary_rows;
+end;
+$function$;

--- a/scripts/db/bootstrap-fresh-db.mjs
+++ b/scripts/db/bootstrap-fresh-db.mjs
@@ -108,6 +108,7 @@ const steps = [
   "client/migrations/20260814000000_drop_supabase_era_orphans.sql",
   "client/migrations/20260814120000_requeue_clears_assigned_user.sql",
   "client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql",
+  "client/migrations/20260815130000_dequeue_contact_returns_rows_affected.sql",
 ];
 
 /**

--- a/scripts/e2e/bootstrap-compose-db.mjs
+++ b/scripts/e2e/bootstrap-compose-db.mjs
@@ -66,6 +66,7 @@ const steps = [
   "client/migrations/20260814000000_drop_supabase_era_orphans.sql",
   "client/migrations/20260814120000_requeue_clears_assigned_user.sql",
   "client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql",
+  "client/migrations/20260815130000_dequeue_contact_returns_rows_affected.sql",
 ];
 
 /**

--- a/test/dequeue-queue-entry.test.ts
+++ b/test/dequeue-queue-entry.test.ts
@@ -16,7 +16,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
  * wholesale mock of the RPC.
  */
 
-const rpcDequeueContactMock = vi.hoisted(() => vi.fn(async () => undefined));
+const rpcDequeueContactMock = vi.hoisted(() => vi.fn(async () => 1));
 
 const dbMocks = vi.hoisted(() => ({
   select: vi.fn(),
@@ -74,7 +74,7 @@ beforeEach(() => {
   dbMocks.execute.mockReset();
   emitQueueEventMock.mockClear();
   rpcDequeueContactMock.mockReset();
-  rpcDequeueContactMock.mockResolvedValue(undefined);
+  rpcDequeueContactMock.mockResolvedValue(1);
   updateSetCalls = [];
   updateCount = 0;
   installDbMockImplementations();
@@ -199,6 +199,61 @@ describe("dequeueQueueEntry routing", () => {
     const [execArg] = rpcDequeueContactMock.mock.calls[0] as [unknown, unknown];
     expect(execArg).not.toBe(undefined);
     expect(typeof (execArg as { execute?: unknown }).execute).toBe("function");
+  });
+
+  // ── #1278: the outcome the manual queue path reports to the agent ───────
+
+  test("reports dequeuedPrimary: false when the guarded RPC matched no row", async () => {
+    rpcDequeueContactMock.mockResolvedValueOnce(0);
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await expect(
+      dequeueQueueEntry({
+        by: { contactId: 7 },
+        userId: "user-1",
+        reason: "Manually dequeued by user",
+        workspaceId: "workspace-1",
+        household: false,
+      }),
+    ).resolves.toEqual({ dequeuedPrimary: false });
+  });
+
+  test("reports dequeuedPrimary: true when the guarded RPC dequeued the row", async () => {
+    rpcDequeueContactMock.mockResolvedValueOnce(1);
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await expect(
+      dequeueQueueEntry({
+        by: { contactId: 7 },
+        userId: "user-1",
+        reason: "Manually dequeued by user",
+        workspaceId: "workspace-1",
+        household: true,
+      }),
+    ).resolves.toEqual({ dequeuedPrimary: true });
+  });
+
+  test("the plain-Drizzle mechanisms report the same shape", async () => {
+    // Unconditional UPDATEs: `false` there means the row simply wasn't there.
+    const { dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server");
+
+    await expect(
+      dequeueQueueEntry({
+        by: { id: 42 },
+        userId: "user-1",
+        reason: "SMS message sent",
+        workspaceId: "workspace-1",
+      }),
+    ).resolves.toEqual({ dequeuedPrimary: true });
+
+    await expect(
+      dequeueQueueEntry({
+        by: { contactId: 7, campaignId: 99 },
+        userId: null,
+        reason: "Contact opted out via SMS",
+        workspaceId: "workspace-1",
+      }),
+    ).resolves.toEqual({ dequeuedPrimary: true });
   });
 
   test("household routing throws without a workspaceId (the RPC requires one)", async () => {

--- a/test/integration-db/dequeue-contact-assigned.test.ts
+++ b/test/integration-db/dequeue-contact-assigned.test.ts
@@ -3,7 +3,10 @@ import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { RpcExecutor } from "@/lib/db-rpc.server";
-import type { dequeueQueueEntry as DequeueFn } from "@/lib/campaign-queue-db.server";
+import type {
+  dequeueQueueEntry as DequeueFn,
+  explainDequeueNoOp as ExplainFn,
+} from "@/lib/campaign-queue-db.server";
 
 /**
  * The real `dequeue_contact` plpgsql function, exercised through the app's
@@ -24,6 +27,14 @@ import type { dequeueQueueEntry as DequeueFn } from "@/lib/campaign-queue-db.ser
  * who no longer holds it still no-ops. The race-guard tests below are the
  * half of that contract that must not regress if someone later "simplifies"
  * the predicate to an unconditional UPDATE.
+ *
+ * Issue #1278: that no-op was invisible. `20260815130000` makes the function
+ * return the row count of its PRIMARY update, `dequeueQueueEntry` reports it
+ * as `dequeuedPrimary`, and POST /api/queues answers 409 instead of
+ * `{ success: true }` when a supervisor dequeues a row another agent holds.
+ * Every case below now asserts the reported outcome alongside the row state —
+ * a predicate that matched and a count that said so are two separate claims,
+ * and this is the only tier where either can be checked for real.
  *
  * No other automated test runs this function against a real database: the
  * unit tier mocks the db client, and
@@ -86,6 +97,7 @@ describeDb("dequeue_contact against real Postgres", () => {
   let client: postgres.Sql;
   let exec: RpcExecutor;
   let dequeueQueueEntry: typeof DequeueFn;
+  let explainDequeueNoOp: typeof ExplainFn;
   let workspaceId: string;
   let campaignId: string;
   let householdId: string;
@@ -146,7 +158,9 @@ describeDb("dequeue_contact against real Postgres", () => {
       execute: (query) => database.execute(query) as unknown as Promise<unknown[]>,
     };
 
-    ({ dequeueQueueEntry } = await import("@/lib/campaign-queue-db.server"));
+    ({ dequeueQueueEntry, explainDequeueNoOp } = await import(
+      "@/lib/campaign-queue-db.server"
+    ));
 
     await client`
       insert into public."user" (id, username, first_name, last_name)
@@ -231,7 +245,7 @@ describeDb("dequeue_contact against real Postgres", () => {
       provider_status: "initiated",
     });
 
-    await dequeueQueueEntry({
+    const result = await dequeueQueueEntry({
       by: { contactId: Number(loneContactId) },
       workspaceId,
       // The park path: guarded RPC, no household fan-out.
@@ -240,6 +254,8 @@ describeDb("dequeue_contact against real Postgres", () => {
       reason: "Ambiguous dial failure — parked for review",
       exec,
     });
+
+    expect(result).toEqual({ dequeuedPrimary: true });
 
     const row = await queueRow(loneContactId);
     expect(row.queue_state).toBe("dequeued");
@@ -260,7 +276,7 @@ describeDb("dequeue_contact against real Postgres", () => {
       assigned_to_user_id: AGENT_A,
     });
 
-    await dequeueQueueEntry({
+    const result = await dequeueQueueEntry({
       by: { contactId: Number(primaryContactId) },
       workspaceId,
       household: true,
@@ -268,6 +284,9 @@ describeDb("dequeue_contact against real Postgres", () => {
       reason: "Predictive Dialer called contact",
       exec,
     });
+
+    // The count is the PRIMARY row's, not the fan-out total.
+    expect(result).toEqual({ dequeuedPrimary: true });
 
     const primary = await queueRow(primaryContactId);
     const sibling = await queueRow(siblingContactId);
@@ -278,7 +297,7 @@ describeDb("dequeue_contact against real Postgres", () => {
   });
 
   test("a queued row still dequeues (the pre-existing path is unchanged)", async () => {
-    await dequeueQueueEntry({
+    const result = await dequeueQueueEntry({
       by: { contactId: Number(loneContactId) },
       workspaceId,
       household: false,
@@ -286,6 +305,8 @@ describeDb("dequeue_contact against real Postgres", () => {
       reason: "Manually dequeued by user",
       exec,
     });
+
+    expect(result).toEqual({ dequeuedPrimary: true });
 
     const row = await queueRow(loneContactId);
     expect(row.queue_state).toBe("dequeued");
@@ -295,7 +316,7 @@ describeDb("dequeue_contact against real Postgres", () => {
   test("a row with a null queue_state (legacy) still dequeues", async () => {
     await setState(loneContactId, { queue_state: null });
 
-    await dequeueQueueEntry({
+    const result = await dequeueQueueEntry({
       by: { contactId: Number(loneContactId) },
       workspaceId,
       household: false,
@@ -304,6 +325,7 @@ describeDb("dequeue_contact against real Postgres", () => {
       exec,
     });
 
+    expect(result).toEqual({ dequeuedPrimary: true });
     expect((await queueRow(loneContactId)).queue_state).toBe("dequeued");
   });
 
@@ -320,7 +342,7 @@ describeDb("dequeue_contact against real Postgres", () => {
       provider_status: "in-progress",
     });
 
-    await dequeueQueueEntry({
+    const result = await dequeueQueueEntry({
       by: { contactId: Number(loneContactId) },
       workspaceId,
       household: false,
@@ -328,6 +350,10 @@ describeDb("dequeue_contact against real Postgres", () => {
       reason: "Stale dequeue from agent A",
       exec,
     });
+
+    // #1278: the guard held AND said so. Before, this returned nothing and
+    // POST /api/queues answered `{ success: true }`.
+    expect(result).toEqual({ dequeuedPrimary: false });
 
     const row = await queueRow(loneContactId);
     expect(row.queue_state).toBe("assigned");
@@ -347,7 +373,7 @@ describeDb("dequeue_contact against real Postgres", () => {
       provider_status: "ringing",
     });
 
-    await dequeueQueueEntry({
+    const result = await dequeueQueueEntry({
       by: { contactId: Number(primaryContactId) },
       workspaceId,
       household: true,
@@ -355,6 +381,10 @@ describeDb("dequeue_contact against real Postgres", () => {
       reason: "Predictive Dialer called contact",
       exec,
     });
+
+    // The primary landed, so this is a success even though the fan-out skipped
+    // a sibling — the skip is the guard, not a failure the caller reports.
+    expect(result).toEqual({ dequeuedPrimary: true });
 
     expect((await queueRow(primaryContactId)).queue_state).toBe("dequeued");
     const sibling = await queueRow(siblingContactId);
@@ -373,7 +403,7 @@ describeDb("dequeue_contact against real Postgres", () => {
       assigned_to_user_id: AGENT_A,
     });
 
-    await dequeueQueueEntry({
+    const result = await dequeueQueueEntry({
       by: { contactId: Number(loneContactId) },
       workspaceId,
       household: false,
@@ -382,9 +412,111 @@ describeDb("dequeue_contact against real Postgres", () => {
       exec,
     });
 
+    expect(result).toEqual({ dequeuedPrimary: false });
+
     const row = await queueRow(loneContactId);
     expect(row.queue_state).toBe("assigned");
     expect(row.assigned_to_user_id).toBe(AGENT_A);
+  });
+
+  // ── #1278: the no-op is surfaced, and named ─────────────────────────────
+
+  test("a supervisor's manual dequeue of another agent's row is reported, not silent", async () => {
+    // The reported defect: POST /api/queues → dequeueQueueEntry with
+    // household following the campaign setting. Agent B holds the row; the
+    // supervisor is a different user, so the claim token does not match.
+    await setState(primaryContactId, {
+      queue_state: "assigned",
+      assigned_to_user_id: AGENT_B,
+      provider_status: "in-progress",
+    });
+
+    const result = await dequeueQueueEntry({
+      by: { contactId: Number(primaryContactId) },
+      workspaceId,
+      household: true,
+      userId: AGENT_A,
+      reason: "Manually dequeued by user",
+      exec,
+    });
+
+    expect(result).toEqual({ dequeuedPrimary: false });
+
+    // The guard: agent B's live claim is untouched.
+    const row = await queueRow(primaryContactId);
+    expect(row.queue_state).toBe("assigned");
+    expect(row.assigned_to_user_id).toBe(AGENT_B);
+    expect(row.provider_status).toBe("in-progress");
+    expect(row.dequeued_at).toBeNull();
+
+    // ...and the route can say why, rather than answering `{ success: true }`.
+    await expect(
+      explainDequeueNoOp({
+        contactId: Number(primaryContactId),
+        workspaceId,
+        userId: AGENT_A,
+      }),
+    ).resolves.toBe("assigned_elsewhere");
+  });
+
+  test("re-dequeuing an already-dequeued contact is a no-op the route can tell apart", async () => {
+    // The manual-dial flow dequeues on "next contact" after the hangup route
+    // already dequeued the same row. Zero rows affected, but nothing is wrong
+    // — calling it a conflict would toast on every completed call.
+    await dequeueQueueEntry({
+      by: { contactId: Number(loneContactId) },
+      workspaceId,
+      household: false,
+      userId: AGENT_A,
+      reason: "Call completed",
+      exec,
+    });
+
+    const second = await dequeueQueueEntry({
+      by: { contactId: Number(loneContactId) },
+      workspaceId,
+      household: false,
+      userId: AGENT_A,
+      reason: "Manually dequeued by user",
+      exec,
+    });
+
+    expect(second).toEqual({ dequeuedPrimary: false });
+    await expect(
+      explainDequeueNoOp({
+        contactId: Number(loneContactId),
+        workspaceId,
+        userId: AGENT_A,
+      }),
+    ).resolves.toBe("already_dequeued");
+  });
+
+  test("explainDequeueNoOp reports not_found for a contact with no queue row", async () => {
+    await expect(
+      explainDequeueNoOp({ contactId: -1, workspaceId, userId: AGENT_A }),
+    ).resolves.toBe("not_found");
+  });
+
+  test("exactly one dequeue_contact overload exists, and it returns integer", async () => {
+    // The return-type change had to go through DROP + CREATE. An orphaned
+    // overload left behind by a partial DROP is how this repo previously got
+    // `function ... is not unique` at runtime (20260722120000).
+    const overloads = await client<{ args: string; result: string }[]>`
+      select
+        pg_get_function_identity_arguments(p.oid) as args,
+        pg_get_function_result(p.oid) as result
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where n.nspname = 'public'
+        and p.proname = 'dequeue_contact'
+    `;
+
+    expect(overloads).toHaveLength(1);
+    expect(overloads[0].args).toBe(
+      "passed_contact_id bigint, group_on_household boolean, p_workspace uuid, " +
+        "dequeued_by_id uuid, dequeued_reason_text text",
+    );
+    expect(overloads[0].result).toBe("integer");
   });
 
   test("the workspace predicate still scopes every write", async () => {
@@ -403,7 +535,7 @@ describeDb("dequeue_contact against real Postgres", () => {
     const otherWorkspaceId = otherWorkspaces[0].id;
 
     try {
-      await dequeueQueueEntry({
+      const result = await dequeueQueueEntry({
         by: { contactId: Number(loneContactId) },
         workspaceId: otherWorkspaceId,
         household: false,
@@ -411,6 +543,8 @@ describeDb("dequeue_contact against real Postgres", () => {
         reason: "Cross-tenant dequeue attempt",
         exec,
       });
+
+      expect(result).toEqual({ dequeuedPrimary: false });
 
       const row = await queueRow(loneContactId);
       expect(row.queue_state).toBe("assigned");

--- a/test/queues.route.test.ts
+++ b/test/queues.route.test.ts
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => {
     resolveCampaignWorkspaceId: vi.fn(async () => "w1"),
     resolveContactWorkspaceId: vi.fn(async () => "w1"),
     rpcSelectAndUpdateCampaignContacts: vi.fn(async () => []),
-    dequeueQueueEntry: vi.fn(async () => undefined),
+    dequeueQueueEntry: vi.fn(async () => ({ dequeuedPrimary: true })),
+    explainDequeueNoOp: vi.fn(async () => "unknown"),
   };
 });
 
@@ -31,6 +32,7 @@ vi.mock("@/lib/campaign-queue-db.server", () => ({
   requeueAllCampaignQueueForCampaign: (...args: unknown[]) =>
     mocks.requeueAllCampaignQueueForCampaign(...args),
   dequeueQueueEntry: (...args: unknown[]) => mocks.dequeueQueueEntry(...args),
+  explainDequeueNoOp: (...args: unknown[]) => mocks.explainDequeueNoOp(...args),
 }));
 vi.mock("@/lib/platform-telephony.server", () => ({
   resolveCampaignWorkspaceId: (...args: unknown[]) => mocks.resolveCampaignWorkspaceId(...args),
@@ -51,6 +53,9 @@ describe("app/routes/api+/queues/route.tsx", () => {
     mocks.resolveContactWorkspaceId.mockReset();
     mocks.rpcSelectAndUpdateCampaignContacts.mockReset();
     mocks.dequeueQueueEntry.mockReset();
+    mocks.explainDequeueNoOp.mockReset();
+    mocks.dequeueQueueEntry.mockResolvedValue({ dequeuedPrimary: true });
+    mocks.explainDequeueNoOp.mockResolvedValue("unknown");
     mocks.resolveCampaignWorkspaceId.mockResolvedValue("w1");
     mocks.resolveContactWorkspaceId.mockResolvedValue("w1");
     mocks.fetchCampaignQueueRowsByIds.mockResolvedValue([]);
@@ -124,7 +129,7 @@ describe("app/routes/api+/queues/route.tsx", () => {
   });
 
   test("action POST returns data on success", async () => {
-    mocks.dequeueQueueEntry.mockResolvedValueOnce(undefined);
+    mocks.dequeueQueueEntry.mockResolvedValueOnce({ dequeuedPrimary: true });
     queueJsonAuthSession({ user: { id: "u1" } });
     mocks.safeParseJson.mockResolvedValueOnce({ contact_id: 2, household: false });
 
@@ -134,13 +139,93 @@ describe("app/routes/api+/queues/route.tsx", () => {
     } as any)));
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({ success: true });
+    await expect(res.json()).resolves.toEqual({ success: true, dequeued: true });
     expect(mocks.dequeueQueueEntry).toHaveBeenCalledWith({
       by: { contactId: 2 },
       workspaceId: "w1",
       household: false,
       userId: "u1",
       reason: "Manually dequeued by user",
+    });
+    // The reason lookup is the no-op path's cost only.
+    expect(mocks.explainDequeueNoOp).not.toHaveBeenCalled();
+  });
+
+  // ── #1278: a dequeue that changed nothing must not report success ────────
+
+  test("action POST returns 409 when the row is assigned to another agent", async () => {
+    mocks.dequeueQueueEntry.mockResolvedValueOnce({ dequeuedPrimary: false });
+    mocks.explainDequeueNoOp.mockResolvedValueOnce("assigned_elsewhere");
+    queueJsonAuthSession({ user: { id: "u1" } });
+    mocks.safeParseJson.mockResolvedValueOnce({ contact_id: 3, household: false });
+
+    const mod = await import("../app/routes/api+/queues");
+    const res = await asRouteResponse(mod.action(withRouteUrl({
+      request: new Request("http://localhost/api/queues", { method: "POST" }),
+    } as any)));
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: "This contact is assigned to another agent.",
+      code: "assigned_elsewhere",
+    });
+    expect(mocks.explainDequeueNoOp).toHaveBeenCalledWith({
+      contactId: 3,
+      workspaceId: "w1",
+      userId: "u1",
+    });
+  });
+
+  test("action POST stays a 200 when the contact was already dequeued", async () => {
+    // The manual-dial "next contact" flow: the hangup route already dequeued
+    // this contact, so the second dequeue legitimately changes nothing. A 409
+    // here would put a conflict toast on every completed call.
+    mocks.dequeueQueueEntry.mockResolvedValueOnce({ dequeuedPrimary: false });
+    mocks.explainDequeueNoOp.mockResolvedValueOnce("already_dequeued");
+    queueJsonAuthSession({ user: { id: "u1" } });
+    mocks.safeParseJson.mockResolvedValueOnce({ contact_id: 4, household: true });
+
+    const mod = await import("../app/routes/api+/queues");
+    const res = await asRouteResponse(mod.action(withRouteUrl({
+      request: new Request("http://localhost/api/queues", { method: "POST" }),
+    } as any)));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ success: true, dequeued: false });
+  });
+
+  test("action POST returns 409 with a generic code for an unexplained no-op", async () => {
+    mocks.dequeueQueueEntry.mockResolvedValueOnce({ dequeuedPrimary: false });
+    mocks.explainDequeueNoOp.mockResolvedValueOnce("unknown");
+    queueJsonAuthSession({ user: { id: "u1" } });
+    mocks.safeParseJson.mockResolvedValueOnce({ contact_id: 5, household: false });
+
+    const mod = await import("../app/routes/api+/queues");
+    const res = await asRouteResponse(mod.action(withRouteUrl({
+      request: new Request("http://localhost/api/queues", { method: "POST" }),
+    } as any)));
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: "This contact could not be dequeued.",
+      code: "not_dequeued",
+    });
+  });
+
+  test("action POST returns 404 when the queue row disappeared under the dequeue", async () => {
+    mocks.dequeueQueueEntry.mockResolvedValueOnce({ dequeuedPrimary: false });
+    mocks.explainDequeueNoOp.mockResolvedValueOnce("not_found");
+    queueJsonAuthSession({ user: { id: "u1" } });
+    mocks.safeParseJson.mockResolvedValueOnce({ contact_id: 6, household: false });
+
+    const mod = await import("../app/routes/api+/queues");
+    const res = await asRouteResponse(mod.action(withRouteUrl({
+      request: new Request("http://localhost/api/queues", { method: "POST" }),
+    } as any)));
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({
+      error: "Contact queue entry not found",
     });
   });
 

--- a/test/scope-dequeue-and-outreach-attempt.integration.test.ts
+++ b/test/scope-dequeue-and-outreach-attempt.integration.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, test } from "vitest";
 
 /**
@@ -28,14 +31,38 @@ import { describe, expect, test } from "vitest";
  * predicate from a broken one (see #1260).
  *
  * Note that 20260807120000 is no longer the CURRENT definition of
- * dequeue_contact — 20260815120000 replaced it — so the assertions below are
- * applied to both files: the historical one for the fix it introduced, and
- * the current one because that is what actually runs.
+ * dequeue_contact — 20260815120000 replaced it, then 20260815130000 (#1278)
+ * replaced that. The assertions below run against EVERY migration that defines
+ * the function, discovered by scanning the lineage rather than listed by hand:
+ * a redefinition that quietly dropped a workspace predicate is exactly what
+ * this guards, and a hand-maintained list would have let the next one skip it.
  */
-const DEQUEUE_CONTACT_DEFINITIONS = [
-  "client/migrations/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql",
-  "client/migrations/20260815120000_dequeue_contact_covers_assigned_rows.sql",
-];
+const MIGRATIONS_DIR = "client/migrations";
+
+/**
+ * Migrations that (re)define dequeue_contact, from the one that introduced
+ * workspace scoping onward. Earlier definitions predate `p_workspace` — that
+ * is the bug — so they are excluded by version, not by omission from a list
+ * someone has to remember to extend.
+ */
+const WORKSPACE_SCOPING_MIGRATION =
+  `${MIGRATIONS_DIR}/20260807120000_scope_dequeue_and_outreach_attempt_by_workspace.sql`;
+
+const DEQUEUE_CONTACT_DEFINITIONS = readdirSync(resolve(process.cwd(), MIGRATIONS_DIR))
+  .filter((file) => file.endsWith(".sql"))
+  .map((file) => `${MIGRATIONS_DIR}/${file}`)
+  .sort()
+  .filter(
+    (path) =>
+      path >= WORKSPACE_SCOPING_MIGRATION &&
+      readFileSync(resolve(process.cwd(), path), "utf8").includes(
+        "CREATE OR REPLACE FUNCTION public.dequeue_contact(",
+      ),
+  );
+
+/** What actually runs: the last definition in the lineage. */
+const CURRENT_DEQUEUE_CONTACT_DEFINITION =
+  DEQUEUE_CONTACT_DEFINITIONS[DEQUEUE_CONTACT_DEFINITIONS.length - 1];
 
 describe("scope dequeue_contact / create_outreach_attempt by workspace SQL harness", () => {
   test.each(DEQUEUE_CONTACT_DEFINITIONS)(
@@ -58,6 +85,33 @@ describe("scope dequeue_contact / create_outreach_attempt by workspace SQL harne
       expect(sql).toContain("cq.workspace = p_workspace");
     },
   );
+
+  test("the lineage scan found every definition, not an empty list", () => {
+    // A filter that silently matched nothing would make the guard above pass
+    // vacuously — the failure mode the hand-maintained list had.
+    expect(DEQUEUE_CONTACT_DEFINITIONS).toContain(WORKSPACE_SCOPING_MIGRATION);
+    expect(DEQUEUE_CONTACT_DEFINITIONS.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("the current definition still reports its rows affected (#1278)", () => {
+    // POST /api/queues answers 409 when the primary row was not dequeued, so
+    // a later redefinition that went back to `RETURNS void` — only possible
+    // via DROP + CREATE — would turn every manual dequeue into a no-op the
+    // API cannot see. Runtime coverage lives in
+    // test/integration-db/dequeue-contact-assigned.test.ts.
+    const sql = readFileSync(
+      resolve(process.cwd(), CURRENT_DEQUEUE_CONTACT_DEFINITION),
+      "utf8",
+    );
+
+    expect(sql).toMatch(/RETURNS integer/i);
+    expect(sql).toMatch(/get diagnostics\s+\w+\s*=\s*row_count/i);
+    // Only the PRIMARY update's count: the fan-out's own no-ops are the guard
+    // working, not a failure.
+    expect(sql).toMatch(
+      /get diagnostics[\s\S]*?\n\s*if group_on_household then/i,
+    );
+  });
 
   test("create_outreach_attempt scopes the attempts-counter UPDATE by workspace", async () => {
     const { readFile } = await import("node:fs/promises");


### PR DESCRIPTION
## What

`POST /api/queues` answered `{ success: true }` for a manual dequeue that changed nothing. Since #1260 the `dequeue_contact` predicate is "queued/null, or `assigned` to the caller" — a deliberate race guard — so a supervisor dequeuing a contact another agent holds matched no row and the API said it worked anyway.

Option (b) from the issue: surface the no-op. Option (a) — a force-dequeue that overrides a live claim — stays out; it builds on this if wanted.

## The migration

`client/migrations/20260815130000_dequeue_contact_returns_rows_affected.sql` — same predicate, same household fan-out, same column writes; `GET DIAGNOSTICS` after the primary UPDATE and `RETURNS integer`.

A return-type change cannot go through `CREATE OR REPLACE` (verified against a live PG 18: `cannot change return type of existing function`), so the migration DROPs first. Overload census across the lineage, all three DROPped `IF EXISTS` so a replay is a no-op:

| signature | status |
| --- | --- |
| `(integer, boolean, uuid, text)` | baseline; dropped by 20260716140000 |
| `(bigint, boolean, uuid, text)` | dropped by 20260807120000 |
| `(bigint, boolean, uuid, uuid, text)` | live; recreated here |

Exactly one function survives — asserted at runtime against real Postgres via `pg_proc`, since an orphaned overload is how this repo previously got `function ... is not unique` (20260722120000). No plpgsql function anywhere in the lineage calls `dequeue_contact`, so nothing depended on its `void` return.

Only the PRIMARY row's count is reported. A fan-out that dequeues three siblings but misses the contact the agent clicked is still a failed dequeue, and the fan-out's own skips are the guard working as designed.

## Wrapper

`rpcDequeueContact` returns the count; `dequeueQueueEntry` returns `{ dequeuedPrimary: boolean }` from all three mechanisms. Every existing caller ignores the value and is unchanged in behaviour — auto-dial's park, the hangup and status-callback paths dequeue their own claim and always match:

| call site | mechanism | uses the signal? |
| --- | --- | --- |
| `app/lib/auto-dial.server.ts` (park, post-dial) | guarded RPC | no |
| `app/routes/api+/auto-dial/status`, `$roomId` | guarded RPC | no |
| `app/routes/api+/hangup` | guarded RPC | no |
| `app/routes/api+/queues` (manual) | guarded RPC | **yes** |
| SMS/IVR/questions/inbound-sms paths | plain Drizzle | no |

## The 409, and why not every zero-row dequeue

`{ error: "This contact is assigned to another agent.", code: "assigned_elsewhere" }` at 409, via the same `routeData(..., { status: 409 })` shape `/api/dial` uses for claim refusals.

But zero rows affected is not always a conflict: the manual-dial "next contact" flow dequeues a contact the hangup route already dequeued. A blanket 409 would have put a conflict toast on every completed call — a new lie in place of the old one. So the no-op path does one read (`explainDequeueNoOp`) and answers accordingly: `assigned_elsewhere` → 409, `already_dequeued` → `{ success: true, dequeued: false }`, gone → 404, otherwise → 409 `not_dequeued`. Best-effort by construction — it decides a message, never a write.

The call screen's queue fetcher result was read by nobody, so a 409 would have rendered as nothing at all. It now goes through the standard `useActionFeedback`, which toasts `data.error`; success carries no message (the row leaving the list is the feedback).

## Verification

- integration-db tier against compose Postgres 18, bootstrapped from the full lineage: 20/20 green.
- Red proof: reverting the function to the 20260815120000 body turned 6 of them red (every "and it said so" assertion), then green again on re-apply. With the old `void` function the wrapper degrades to `dequeuedPrimary: false` and the reason lookup answers `already_dequeued`, so an unmigrated environment gets a 200, not a false 409.
- `typecheck`, `lint`, `test:node` (2741), `test:ui` (686), `check-queue-rpc-contract` (no new drift, baseline unchanged), `check-db-rpcs`, `db:bootstrap:check` (52 migrations, both wiring lists updated), `db:orphans:check`, `db:schema:check` (no drift), `check:effects`, `check:dry`, `check:handlers`, `check:type-safety`, `tools:api:surface:check` — all green.

The SQL harness that guards the workspace predicates now discovers every `dequeue_contact` definition by scanning the lineage instead of a hand-maintained list, and pins that the current one still reports its rows affected.

Closes #1278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
