### PR TITLE
fix(export): use question text, not block id, for CSV column headers

### DIFF
--- a/app/lib/campaign-export-helpers.server.ts
+++ b/app/lib/campaign-export-helpers.server.ts
@@ -192,8 +192,11 @@ export function extractScriptQuestions(script: ExportScript | null | undefined):
         (block.type === "question" || block.type === "recorded" || block.type === "dtmf")
       ) {
         scriptQuestions.push({
+          // Must match the key the IVR webhook stores responses under (see ivr-results.ts).
           id: block.title || block.id,
-          title: block.title || block.id,
+          // Displayed label: block.content holds the actual question text authors write;
+          // block.title is a short, often-blank internal label — fall back to it, then the id.
+          title: block.content || block.title || block.id,
         });
       }
     }


### PR DESCRIPTION
## Summary
- Campaign result CSV export labeled question columns with the script block's title-or-id fallback, but most blocks are created with an empty `title` — the real question text lives in `block.content`. Headers were silently degrading to generated block ids (e.g. `block_lz3x4f_12`) instead of readable question text.
- `extractScriptQuestions()` now prefers `block.content` for the displayed header, falling back to `block.title`, then `block.id`. The response-lookup key (`id`) is unchanged, since it must keep matching the key the IVR webhook stores responses under (`app/lib/ivr-results.ts`).

Closes #1280

## Test plan
- [x] `npx tsc --noEmit` clean on the touched file
- [ ] Run a campaign export and confirm question columns show the question text instead of block ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)