### PR TITLE
fix(call-screen): recover client hangup when SSE/webhook signal is lost

### DIFF
--- a/app/hooks/call/useCampaignCallFlow.ts
+++ b/app/hooks/call/useCampaignCallFlow.ts
@@ -87,8 +87,12 @@ export function useCampaignCallFlow({
   lifecycleRef.current = lifecycle;
   const previousFsmRef = useRef(fsmState);
 
+  // Fall back to callSid so polling can bootstrap even before any SSE event
+  // has arrived — otherwise a dropped/missed realtime message leaves polling
+  // permanently disabled (pollingTargetSid is only ever set from inside the
+  // SSE/poll callback itself), and a client hangup can go undetected forever.
   const pollingEnabled =
-    !!pollingTargetSid &&
+    !!(pollingTargetSid ?? callSid) &&
     !!workspaceId &&
     (lifecycle.phase === "dialing" || lifecycle.phase === "connected");
 
@@ -109,6 +113,15 @@ export function useCampaignCallFlow({
     if (isTerminalForOutcome(normalized)) {
       const outcome = normalizedToOutcome(normalized);
       dispatch({ type: "PROVIDER_ENDED", outcome });
+
+      // The provider (Twilio) has already ended the customer leg, but that
+      // doesn't guarantee the agent's own WebRTC leg got told — e.g. a
+      // conference customer leg with no statusCallback relies solely on
+      // endConferenceOnExit reaching the browser. If activeCall is still
+      // live here, force it closed so the SDK's own 'disconnect' handling
+      // (including its built-in hangup tone) actually runs instead of the
+      // call silently lingering. A no-op if the SDK already tore it down.
+      activeCall?.disconnect?.();
     }
 
     // Also drive the legacy FSM for backward compat (all statuses).

--- a/test/ui/campaign-call-flow-display-state.test.ts
+++ b/test/ui/campaign-call-flow-display-state.test.ts
@@ -4,14 +4,17 @@ import { describe, expect, test, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   onPollStatus: null as ((status: string, resolvedSid?: string) => void) | null,
   onCallRowChange: null as ((payload: unknown) => void) | null,
+  pollingEnabled: null as boolean | null,
   send: vi.fn(),
 }));
 
 vi.mock("@/hooks/call/useCallStatusPolling", () => ({
   useCallStatusPolling: (opts: {
+    enabled: boolean;
     onStatus: (status: string, resolvedSid?: string) => void;
   }) => {
     mocks.onPollStatus = opts.onStatus;
+    mocks.pollingEnabled = opts.enabled;
   },
 }));
 
@@ -306,6 +309,68 @@ describe("useCampaignCallFlow displayState", () => {
 
       // Canonical lifecycle retains "completed" outcome — no terminal latch needed.
       expect(result.current.displayState).toBe("completed");
+    });
+
+    test("polling fallback is live on a connected call with no prior SSE event", () => {
+      // Regression: if the customer-leg SSE event that reports the hangup
+      // is ever dropped (missed realtime message, tab backgrounded, etc.),
+      // the 5s poll is the only remaining way to learn the call ended. But
+      // polling was gated on `pollingTargetSid`, which is only set inside
+      // the SSE/poll callback itself — a call that has NEVER received an
+      // SSE event (this test's exact setup) could poll only after SSE
+      // already worked, defeating its purpose as a fallback.
+      const { rerender } = renderFlow({
+        state: "idle",
+        callSid: null,
+        agentLegSid: null,
+        activeCall: null,
+      });
+
+      rerender(baseProps({
+        state: "dialing",
+        callSid: "CA-live",
+        agentLegSid: "CA-live",
+        activeCall: null,
+      }));
+
+      rerender(baseProps({
+        state: "connected",
+        callSid: "CA-live",
+        agentLegSid: "CA-live",
+        activeCall: {} as any,
+      }));
+
+      expect(mocks.pollingEnabled).toBe(true);
+    });
+
+    test("terminal customer-leg status forces the live SDK call to disconnect", () => {
+      // Regression: a provider-detected hangup (SSE/poll) only ever flipped
+      // FSM/UI state — it never told the still-live Twilio SDK Call object
+      // the leg was over. That's why a client hangup could update the
+      // display yet play no hangup tone and leave the WebRTC session open:
+      // the built-in SDK sound only fires off the SDK's own 'disconnect'
+      // event, which nothing forced here.
+      const mockCall = { disconnect: vi.fn() };
+      const { rerender } = renderFlow({
+        state: "connected",
+        callSid: "CA-live",
+        agentLegSid: "CA-live",
+        activeCall: mockCall as any,
+      });
+
+      act(() => {
+        mocks.onCallRowChange?.({
+          new: { sid: "CA-child", parent_call_sid: "CA-live", status: "completed" },
+        });
+      });
+      rerender(baseProps({
+        state: "connected",
+        callSid: "CA-live",
+        agentLegSid: "CA-live",
+        activeCall: mockCall as any,
+      }));
+
+      expect(mockCall.disconnect).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- `pollingEnabled` required `pollingTargetSid`, which is only ever set from inside the SSE/poll callback itself. A call that never received an SSE event (dropped realtime message, missed webhook) could never bootstrap the 5s polling fallback either, so nothing ever caught the hangup.
- `acceptCustomerStatus` only updated FSM/UI state on a provider-detected terminal status — it never told the still-live Twilio SDK `Call` object the leg was over, so the SDK's own disconnect handling (and its built-in hangup tone) never ran, and the WebRTC session lingered.

Both gaps together explain the reported symptom: a client hangs up, no hangup tone plays, and the call screen never reflects it.

## Test plan
- [x] `test/ui/campaign-call-flow-display-state.test.ts` — new regression tests for both gaps (21/21 pass)
- [x] Verified each new test fails against pre-fix code, passes after

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)