### PR TITLE
fix(auto-dial): give the contact's conference leg a statusCallback

### DIFF
--- a/app/routes/api+/auto-dial/$roomId.action.server.ts
+++ b/app/routes/api+/auto-dial/$roomId.action.server.ts
@@ -166,10 +166,20 @@ const handleHumanAnswer = async (dbCall: NonNullable<Partial<Call>>, called: str
         );
     }
 
+    // A statusCallback here — mirroring the agent's own leg in
+    // addToConference — is what lets a CLIENT hangup be detected at all.
+    // Without it, Twilio never posts a participant-leave event for this
+    // leg, so the app has no server-driven signal and depends entirely on
+    // Twilio's platform-level endConferenceOnExit reaching the agent's
+    // browser. handleParticipantLeave (auto-dial/status) already forces the
+    // conference closed on `participant_hung_up` for whichever leg posts
+    // it — it just never received the contact's events before.
     const dial = twiml.dial();
     dial.conference({
         beep: 'onExit',
         endConferenceOnExit: true,
+        statusCallback: `${env.BASE_URL()}/api/auto-dial/status`,
+        statusCallbackEvent: ['join', 'leave', 'modify'],
     }, `${conferenceName}`);
 
     return new Response(twiml.toString(), {

--- a/test/auto-dial-room.route.test.ts
+++ b/test/auto-dial-room.route.test.ts
@@ -892,6 +892,78 @@ describe("app/routes/api+/auto-dial/route.$roomId.tsx", () => {
     expect(telephonyDbMocks.updateOutreachAttemptForWorkspace).toHaveBeenCalled();
   });
 
+  test("human answer: conference dial carries a statusCallback so a contact hangup is detected", async () => {
+    // Regression (#1282 follow-up): only the agent's conference leg had a
+    // statusCallback wired (addToConference). The contact's own
+    // <Dial><Conference> had none, so Twilio never posted a
+    // participant-leave event when the CLIENT hung up — the app had no
+    // server-driven signal and depended entirely on Twilio's platform-level
+    // endConferenceOnExit reaching the agent's browser.
+    mocks.createWorkspaceTwilioInstance.mockResolvedValueOnce({
+      calls: () => ({ update: vi.fn() }),
+      conferences: Object.assign((_sid: string) => ({ update: vi.fn() }), { list: vi.fn(async () => []) }),
+    } as any);
+
+    const outreachSelect = vi.fn(async () => ({ data: [{ ok: 1 }], error: null }));
+    const client = makeDbClient({});
+    roomRpcState.client = client;
+    client.from.mockImplementation((table: string) => {
+      if (table === "call") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({
+                data: { campaign_id: 1, outreach_attempt_id: 1, contact_id: 2, workspace: "w1", conference_id: "u1~00000000-0000-0000-0000-000000000000" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === "campaign") {
+        return { select: () => ({ eq: () => ({ single: async () => ({ data: { voicemail_file: "vm.mp3", group_household_queue: false, caller_id: "+1555" }, error: null }) }) }) };
+      }
+      if (table === "user") {
+        return { select: () => ({ eq: () => ({ single: async () => ({ data: { verified_audio_numbers: null }, error: null }) }) }) };
+      }
+      if (table === "outreach_attempt") {
+        return { update: () => ({ eq: () => ({ select: outreachSelect }) }) };
+      }
+      if (table === "campaign_queue") {
+        return { update: () => ({ eq: () => ({ select: async () => ({ data: [], error: null }) }) }) };
+      }
+      if (table === "workspace") {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: async () => ({
+                data: { twilio_data: { sid: "ACtest", authToken: "auth" } },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+    useRoomPostgres(client);
+
+    const mod = await import("../app/routes/api+/auto-dial/$roomId.route");
+    const fd = new FormData();
+    fd.set("CallSid", "CA1");
+    fd.set("AnsweredBy", "");
+    fd.set("CallStatus", "in-progress");
+    fd.set("Called", "+1888");
+    const res = await asRouteResponse(mod.action({
+      request: new Request("http://localhost/api/auto-dial/u1~00000000-0000-0000-0000-000000000000", { method: "POST", body: fd }),
+      params: { roomId: "u1~00000000-0000-0000-0000-000000000000" },
+    } as any));
+
+    const body = await res.text();
+    expect(body).toContain('statusCallback="https://base.example/api/auto-dial/status"');
+    expect(body).toContain('statusCallbackEvent="join leave modify"');
+  });
+
   test("errors are caught and return Hangup response", async () => {
     const client = makeDbClient({});
     roomRpcState.client = client;

--- a/test/auto-dial-status.test.ts
+++ b/test/auto-dial-status.test.ts
@@ -609,6 +609,64 @@ describe("api.auto-dial.status", () => {
     expect(res.status).toBe(200);
   });
 
+  test("participant-leave for the CONTACT's own leg force-completes the conference (#1282 follow-up)", async () => {
+    // Regression: before the contact's conference Dial had a statusCallback
+    // (fixed in $roomId.action.server.ts's handleHumanAnswer), Twilio never
+    // posted this event for the contact's own leg at all, so a client
+    // hangup had no server-driven backstop — only Twilio's platform-level
+    // endConferenceOnExit reaching the agent's browser. handleParticipantLeave
+    // is leg-agnostic (keys off the leaving participant's own CallSid), so
+    // once the event arrives it must force the conference closed exactly
+    // like it already does for the agent leg.
+    const conferenceUpdateSpy = vi.fn(async () => ({ status: "completed" }));
+    const originalConferences = twilioClientMock.conferences;
+    (twilioClientMock as any).conferences = Object.assign(
+      (sid: string) => ({ update: (patch: unknown) => conferenceUpdateSpy(sid, patch) }),
+      { list: vi.fn(async () => [{ sid: "CONF_CONTACT" }]) },
+    );
+
+    postgresStub = await usePostgresStub({
+      dbCall: {
+        sid: "CA_CONTACT",
+        workspace: "w1",
+        outreach_attempt_id: 1,
+        conference_id: "u1~00000000-0000-0000-0000-000000000000",
+        contact_id: 1,
+        campaign_id: 1,
+      },
+    } as any);
+
+    const mod = await import("../app/routes/api+/auto-dial/status.route");
+    const fd = new FormData();
+    fd.set("CallSid", "CA_CONTACT");
+    fd.set("CallStatus", "ringing");
+    fd.set("StatusCallbackEvent", "participant-leave");
+    fd.set("ReasonParticipantLeft", "participant_hung_up");
+    fd.set("Timestamp", new Date().toISOString());
+    fd.set("Duration", "1");
+    fd.set("CallDuration", "2");
+    fd.set("FriendlyName", "u1~00000000-0000-0000-0000-000000000000");
+    fd.set("ConferenceSid", "conf1");
+    let res: Response;
+    try {
+      res = await asRouteResponse(mod.action({
+        request: new Request("http://localhost/api/auto-dial/status", {
+          method: "POST",
+          headers: { "x-twilio-signature": "good" },
+          body: fd,
+        }),
+      } as any));
+    } finally {
+      (twilioClientMock as any).conferences = originalConferences;
+    }
+
+    expect(res.status).toBe(200);
+    expect(conferenceUpdateSpy).toHaveBeenCalledWith(
+      "CONF_CONTACT",
+      expect.objectContaining({ status: "completed" }),
+    );
+  });
+
   test("call status busy triggers dialer in-process (no HTTP self-fetch) when conferences exist and status not completed", async () => {
     twilioClientMock.conferences.list.mockResolvedValueOnce([{ sid: "CONF1" }]);
     const mod = await import("../app/routes/api+/auto-dial/status.route");


### PR DESCRIPTION
## Summary

Follow-up to #1282 / #1283. Only the agent's conference Dial (`addToConference`) had a `statusCallback` wired to `/api/auto-dial/status` — the contact's own `<Dial><Conference>` in `handleHumanAnswer` had none, so Twilio never posted a `participant-leave` event for that leg. A client hangup therefore had no server-driven signal at all: the app depended entirely on Twilio's platform-level `endConferenceOnExit` reaching the agent's browser, with no backstop if that propagation was lost or delayed.

`handleParticipantLeave`/`isParticipantHangup` already operate generically on the leaving participant's own CallSid and call row — no agent/customer special-casing needed. Mirroring the agent leg's statusCallback wiring on the contact leg is enough for the existing forced conference-teardown path to also cover a client hangup.

## Test plan
- [x] `test/auto-dial-room.route.test.ts` — new test asserts the TwiML now carries the statusCallback
- [x] `test/auto-dial-status.test.ts` — new test asserts a contact-leg `participant_hung_up` event force-completes the conference
- [x] Full auto-dial suite (75 tests / 5 files) passes

References #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)