### PR TITLE
fix(call-screen): stop the previous outcome flashing on a new dial

### DIFF
--- a/app/hooks/call/useCallScreen.ts
+++ b/app/hooks/call/useCallScreen.ts
@@ -200,7 +200,7 @@ export function useCallScreen() {
 
   const agentLegSid = getCallSid(activeCall) ?? null;
 
-  const { displayState, displayColor } = useCampaignCallFlow({
+  const { displayState, displayColor, beginDial } = useCampaignCallFlow({
     callSid,
     agentLegSid,
     workspaceId,
@@ -311,6 +311,7 @@ export function useCallScreen() {
     recentAttempt,
     selectedDevice: phoneVerification.selectedDevice,
     send: send as unknown as (action: { type: string }) => void,
+    beginDial,
   });
 
   const handleDequeueNext = useCampaignDequeueActions({

--- a/app/hooks/call/useCampaignCallFlow.ts
+++ b/app/hooks/call/useCampaignCallFlow.ts
@@ -183,6 +183,29 @@ export function useCampaignCallFlow({
   });
 
   /**
+   * Start a new dial in the *same batch* as the click that triggered it.
+   *
+   * The FSM→lifecycle bridge below is an effect, so it cannot run until after
+   * the browser has painted the render in which the FSM moved to `dialing` —
+   * and that render still derives its display from the finished call's
+   * terminal lifecycle (or, on a re-dial, from the contact's last attempt
+   * disposition). The result was "Call Failed" / "No Answer" repainting for a
+   * single frame on every dial: #1220 removed the version of this that stuck
+   * around, but the flash survived it. Resetting here, alongside the FSM's own
+   * START_DIALING, closes the gap — the first render after the click already
+   * reads `phase: "dialing"`, so there is no stale frame to paint.
+   *
+   * The bridge still fires afterwards; a second START_DIALING from `dialing`
+   * is a no-op in the reducer.
+   */
+  const beginDial = useCallback(() => {
+    setCustomerLegSid(null);
+    setPollingTargetSid(null);
+    setProviderStatus(null);
+    setLifecycle((prev) => callLifecycleReducer(prev, { type: "START_DIALING" }));
+  }, []);
+
+  /**
    * @effect Bridge the legacy FSM (useCallState) transitions into the canonical lifecycle.
    * Only dispatches when fsmState actually changes (not on every render).
    * Skips the initial idle → idle no-op.
@@ -289,7 +312,14 @@ export function useCampaignCallFlow({
       }
     }
 
-    // 5. Recent attempt fallback for terminal displays.
+    // 5. A live FSM outranks any *previous* attempt's disposition: the agent
+    //    has dialed this contact again, so their last outcome is history.
+    //    Below rule 6 this showed the old "No Answer"/"Call Failed" for the
+    //    render between the click and the bridge effect.
+    if (fsmState === "dialing") return "dialing";
+    if (fsmState === "connected") return "connected";
+
+    // 6. Recent attempt fallback for terminal displays.
     if (recentAttemptDisposition && lifecycle.phase !== "dialing" && lifecycle.phase !== "connected") {
       const d = recentAttemptDisposition;
       if (d === "voicemail") return "voicemail";
@@ -297,12 +327,8 @@ export function useCampaignCallFlow({
       if (d === "completed" || d === "failed" || d === "busy") return d;
     }
 
-    // 6. Legacy FSM terminal state as fallback (bridge effect hasn't fired yet).
+    // 7. Legacy FSM terminal state as fallback (bridge effect hasn't fired yet).
     if (FSM_TERMINAL.has(fsmState)) return fsmState;
-
-    // 7. FSM dialing/connected as fallback for initial render (before bridge).
-    if (fsmState === "dialing") return "dialing";
-    if (fsmState === "connected") return "connected";
 
     return "idle";
   })();
@@ -317,6 +343,7 @@ export function useCampaignCallFlow({
   return {
     displayState,
     displayColor,
+    beginDial,
     getDisplayState: (
       callStateValue: string,
       _statusValue: string | undefined,

--- a/app/hooks/call/useCampaignDialActions.ts
+++ b/app/hooks/call/useCampaignDialActions.ts
@@ -33,6 +33,14 @@ type UseCampaignDialActionsOptions = {
   recentAttempt: OutreachAttempt | null;
   selectedDevice: string;
   send: (action: { type: string }) => void;
+  /**
+   * Resets the canonical call lifecycle for the new dial, in the same batch as
+   * the FSM's START_DIALING. Without it the finished call's outcome (or this
+   * contact's last attempt disposition) paints for one frame before the
+   * FSM→lifecycle bridge effect can clear it — the residual flash left over
+   * from #1220.
+   */
+  beginDial: () => void;
 };
 
 export function useCampaignDialActions({
@@ -49,6 +57,7 @@ export function useCampaignDialActions({
   recentAttempt,
   selectedDevice,
   send,
+  beginDial,
 }: UseCampaignDialActionsOptions) {
   return useCallback(() => {
     if (!campaign) return;
@@ -64,6 +73,7 @@ export function useCampaignDialActions({
       if (callState === "dialing" || callState === "connected") return;
 
       send({ type: "START_DIALING" });
+      beginDial();
       startCall({
         contact: nextRecipient.contact,
         campaign,
@@ -88,6 +98,7 @@ export function useCampaignDialActions({
     recentAttempt,
     selectedDevice,
     send,
+    beginDial,
   ]);
 }
 

--- a/test/ui/use-campaign-call-flow.test.tsx
+++ b/test/ui/use-campaign-call-flow.test.tsx
@@ -127,4 +127,70 @@ describe("useCampaignCallFlow", () => {
     rerender({ state: "idle" });
     expect(result.current.displayState).toBe("idle");
   });
+
+  // The #1220 tests above assert displayState *after* effects have flushed, so
+  // they cannot see a stale value that is painted and then corrected. These
+  // record every render instead: pressing Dial must not paint the old outcome
+  // for even one frame, which is what the agent saw as an error flash.
+  describe("pressing Dial paints no stale frame", () => {
+    /**
+     * Mirrors the real click: useCampaignDialActions sends START_DIALING to the
+     * FSM (whose state lives above this hook) and calls beginDial() in the same
+     * handler, so both land in one batch.
+     */
+    function renderDialProbe(disposition: string | null) {
+      const renders: string[] = [];
+      const send = vi.fn();
+      const view = renderHook(() => {
+        const [fsmState, setFsmState] = useState("idle");
+        const flow = useCampaignCallFlow({
+          callSid: "CA1",
+          agentLegSid: null,
+          workspaceId: "w1",
+          state: fsmState,
+          activeCall: null,
+          recentAttemptDisposition: disposition,
+          predictiveState: { status: "unknown", contact_id: null },
+          isPredictive: false,
+          send,
+        });
+        renders.push(flow.displayState);
+        return { ...flow, setFsmState };
+      });
+
+      const pressDial = () =>
+        act(() => {
+          view.result.current.setFsmState("dialing");
+          view.result.current.beginDial();
+        });
+
+      return { ...view, renders, pressDial };
+    }
+
+    test("the finished call's outcome never repaints on the next dial", () => {
+      const probe = renderDialProbe(null);
+
+      probe.pressDial();
+      act(() => polling.onStatus?.("failed"));
+      act(() => probe.result.current.setFsmState("failed"));
+      expect(probe.result.current.displayState).toBe("failed");
+
+      probe.renders.length = 0;
+      probe.pressDial();
+      expect(probe.renders).not.toContain("failed");
+      expect(probe.result.current.displayState).toBe("dialing");
+    });
+
+    test("a re-dialed contact's last disposition never repaints", () => {
+      // nextNumber loads the new contact's existing attempt, so a contact who
+      // was reached once already carries a disposition into the dial.
+      const probe = renderDialProbe("no-answer");
+      expect(probe.result.current.displayState).toBe("no-answer");
+
+      probe.renders.length = 0;
+      probe.pressDial();
+      expect(probe.renders).not.toContain("no-answer");
+      expect(probe.result.current.displayState).toBe("dialing");
+    });
+  });
 });

--- a/test/ui/use-campaign-dial-actions.test.ts
+++ b/test/ui/use-campaign-dial-actions.test.ts
@@ -24,6 +24,7 @@ const nextRecipient = {
 
 describe("useCampaignDialActions", () => {
   test("predictive dial calls begin when device is ready", () => {
+    const beginDial = vi.fn();
     const begin = vi.fn();
     const startCall = vi.fn();
     const { result } = renderHook(() =>
@@ -39,6 +40,7 @@ describe("useCampaignDialActions", () => {
         workspaceId: "ws",
         recentAttempt: null,
         selectedDevice: "computer",
+        beginDial,
       }),
     );
 
@@ -48,6 +50,7 @@ describe("useCampaignDialActions", () => {
   });
 
   test("predictive dial is blocked when device is busy or not registered", () => {
+    const beginDial = vi.fn();
     const begin = vi.fn();
     const startCall = vi.fn();
     const { result: busyResult } = renderHook(() =>
@@ -63,6 +66,7 @@ describe("useCampaignDialActions", () => {
         workspaceId: "ws",
         recentAttempt: null,
         selectedDevice: "computer",
+        beginDial,
       }),
     );
 
@@ -82,6 +86,7 @@ describe("useCampaignDialActions", () => {
         workspaceId: "ws",
         recentAttempt: null,
         selectedDevice: "computer",
+        beginDial,
       }),
     );
     act(() => notReadyResult.current());
@@ -89,6 +94,7 @@ describe("useCampaignDialActions", () => {
   });
 
   test("manual dial starts call for next recipient", () => {
+    const beginDial = vi.fn();
     const begin = vi.fn();
     const startCall = vi.fn();
     const send = vi.fn();
@@ -107,6 +113,7 @@ describe("useCampaignDialActions", () => {
         recentAttempt: null,
         selectedDevice: "computer",
         send,
+        beginDial,
       }),
     );
 
@@ -121,6 +128,35 @@ describe("useCampaignDialActions", () => {
       selectedDevice: "computer",
     });
     expect(begin).not.toHaveBeenCalled();
+    // Same handler, so both land in one batch and no render sees the previous
+    // call's outcome (#1220 residual flash).
+    expect(send).toHaveBeenCalledWith({ type: "START_DIALING" });
+    expect(beginDial).toHaveBeenCalledTimes(1);
+  });
+
+  test("a blocked manual dial does not reset the call lifecycle", () => {
+    const beginDial = vi.fn();
+    const { result } = renderHook(() =>
+      useCampaignDialActions({
+        campaign: baseCampaign,
+        deviceIsBusy: false,
+        incomingCall: null,
+        deviceStatus: "Registered",
+        callState: "connected",
+        begin: vi.fn(),
+        startCall: vi.fn(),
+        nextRecipient,
+        user: { id: "u1" },
+        workspaceId: "ws",
+        recentAttempt: null,
+        selectedDevice: "computer",
+        send: vi.fn(),
+        beginDial,
+      }),
+    );
+
+    act(() => result.current());
+    expect(beginDial).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #1286

## What

- `beginDial()` on `useCampaignCallFlow`: the dial click resets the canonical call lifecycle in the same batch as the FSM's `START_DIALING`, so the first render after the click already reads `phase: "dialing"` — no stale frame for the browser to paint. The FSM→lifecycle bridge still fires afterwards; a second `START_DIALING` from `dialing` is a reducer no-op.
- Display derivation: a live `dialing`/`connected` FSM now outranks the re-dialed contact's *previous* attempt disposition. Rules 1–4 (terminal lifecycle, provider status, lifecycle phase, predictive broadcasts) keep their precedence, so #1206 is unaffected.
- `useCampaignDialActions` wires `beginDial` into the manual-dial click handler; a blocked dial (busy device, live call) does not reset the lifecycle.

## Why

Residual flash from #1220: the bridge is a `useEffect`, so the render in which the FSM moves to `dialing` paints before the lifecycle resets, and that render still shows the finished call's outcome or the contact's last disposition. The #1220 tests assert `displayState` after `act()` flushes effects and structurally cannot see a painted-then-corrected value.

## Verification

- New tests record **every render** and assert the stale value never appears; both verified red against the unfixed base (only the harness hook added): `['failed', 'dialing']` and `['no-answer', 'dialing']`.
- 8/8 in `use-campaign-call-flow`, 8/8 in `use-campaign-dial-actions` (incl. new blocked-dial case), full UI suite 697-scale green, `typecheck` / `check:effects` / `lint` green.

## Note

This is the cosmetic sibling of #1285 — the mechanism that actually produces a *visible* error flash on dial (SSE pool starvation + 409 claim refusal) is fixed in #1287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)