### PR TITLE
fix(db): repair stuck non-terminal call rows — broken enum guards + blind sweep window

### DIFF
--- a/app/lib/message-db.server.ts
+++ b/app/lib/message-db.server.ts
@@ -221,7 +221,11 @@ export async function updateMessageBySid(
       ? update
       : ({
           ...update,
-          status: sql`CASE WHEN LOWER(${messageTable.status}) = ANY(${TERMINAL_MESSAGE_STATUSES_SQL}) AND LOWER(${update.status}) <> ALL(${TERMINAL_MESSAGE_STATUSES_SQL}) THEN ${messageTable.status} ELSE ${update.status} END`,
+          // ::text — message.status is the message_status ENUM in every real
+          // database; lower(message_status) does not exist and the uncast
+          // guard threw instead of guarding (#1289, sibling of the call
+          // guard in telephony-db.server.ts).
+          status: sql`CASE WHEN LOWER(${messageTable.status}::text) = ANY(${TERMINAL_MESSAGE_STATUSES_SQL}) AND LOWER(${update.status}) <> ALL(${TERMINAL_MESSAGE_STATUSES_SQL}) THEN ${messageTable.status} ELSE ${update.status} END`,
         } as unknown as Partial<MessageRow>);
 
   const [row] = await tdb.message.update({

--- a/app/lib/telephony-db.server.ts
+++ b/app/lib/telephony-db.server.ts
@@ -144,7 +144,10 @@ export async function claimTerminalCallStatus(
     set: { status: normalized } as unknown as Partial<CallRow>,
     where: and(
       eq(callTable.sid, sid),
-      or(isNull(callTable.status), sql`LOWER(${callTable.status}) <> ${normalized}`),
+      // ::text — call.status is the call_status ENUM in every real database
+      // and lower(call_status) does not exist; without the cast this guard
+      // throws instead of guarding (#1289).
+      or(isNull(callTable.status), sql`LOWER(${callTable.status}::text) <> ${normalized}`),
     ),
   });
   return rows.length > 0;
@@ -173,7 +176,13 @@ export async function updateCallBySid(
   // not, otherwise apply the incoming status. Doing this in one statement
   // removes the read-then-write round trip and the race between the guard
   // check and the write.
-  const guardedStatus = sql`CASE WHEN LOWER(${callTable.status}) = ANY(${TERMINAL_CALL_STATUSES_SQL}) AND LOWER(${update.status}) <> ALL(${TERMINAL_CALL_STATUSES_SQL}) THEN ${callTable.status} ELSE ${update.status} END`;
+  // ::text on the column: call.status is the call_status ENUM in every real
+  // database, and lower(call_status) does not exist — without the cast this
+  // UPDATE throws, so every status-bearing webhook/sync write failed and rows
+  // accumulated in 'queued' forever (#1289). The unit tier mocks the db
+  // client and could not see it; test/integration-db/call-status-guard.test.ts
+  // runs this statement against a real database.
+  const guardedStatus = sql`CASE WHEN LOWER(${callTable.status}::text) = ANY(${TERMINAL_CALL_STATUSES_SQL}) AND LOWER(${update.status}) <> ALL(${TERMINAL_CALL_STATUSES_SQL}) THEN ${callTable.status} ELSE ${update.status} END`;
 
   const [row] = await tdb.call.update({
     set: {

--- a/app/lib/twilio-open-sync.server.ts
+++ b/app/lib/twilio-open-sync.server.ts
@@ -1,4 +1,4 @@
-import { and, gte, inArray } from "drizzle-orm";
+import { asc, inArray } from "drizzle-orm";
 import { createWorkspaceTwilioInstance } from "@/lib/database/workspace.server";
 import { call, message } from "@/db/schema";
 import { createTenantDb } from "@/server/tenant-db";
@@ -26,6 +26,10 @@ const OPEN_MESSAGE_STATUSES = [
 /**
  * Reconcile stale LOCAL call/message statuses against Twilio REST for a
  * workspace.
+ *
+ * `maxAgeMinutes` bounds the bulk list() prefetch window and sets the grace
+ * age before a Twilio-404 call row is terminalized — it does NOT bound which
+ * rows are swept. Selection is every locally-open row, oldest first (#1289).
  *
  * The sync is driven by local rows stuck in an open (non-terminal) status —
  * the population left behind when a Twilio status callback was lost. Each
@@ -59,18 +63,23 @@ export async function triggerTwilioOpenSync({
 
     const tdb = createTenantDb(workspaceId);
     const since = new Date(Date.now() - maxAgeMinutes * 60_000);
-    const sinceIso = since.toISOString();
 
     // ─── Calls ─────────────────────────────────────────────
     let callsUpdated = 0;
     let callsBilled = 0;
     let callsSkipped = 0;
 
+    // Sweep EVERY open row, oldest first — not just rows created inside the
+    // prefetch window. The previous `date_created >= since` selection meant a
+    // row that stayed open longer than maxAgeMinutes graduated permanently
+    // out of the sweep: the dev environment accumulated 19 calls stuck in
+    // 'queued' for weeks (#1289), each blocking its contact from being
+    // re-dialed while inside claim_queue_entry_for_dial's active_call window.
+    // Once a row is repaired it leaves this population, so the backlog drains
+    // at callLimit rows per run.
     const localOpenCalls = await tdb.call.findMany({
-      where: and(
-        inArray(call.status, [...OPEN_CALL_STATUSES]),
-        gte(call.date_created, sinceIso),
-      ),
+      where: inArray(call.status, [...OPEN_CALL_STATUSES]),
+      orderBy: [asc(call.date_created)],
       limit: callLimit,
     });
 
@@ -89,7 +98,34 @@ export async function triggerTwilioOpenSync({
         if (!remote) {
           try {
             remote = await twilio.calls(local.sid).fetch();
-          } catch {
+          } catch (error) {
+            // Twilio definitively not knowing the SID (REST 404 / 20404) is
+            // an answer, not an outage: the call never existed there or was
+            // purged. Left as a skip, such a row stays open forever and gets
+            // re-fetched every run (#1289). Terminalize it as 'failed' once
+            // it is old enough that a race with call creation is impossible;
+            // the canonical processor writes the guarded status, and billing
+            // never debits a terminal call without a duration. Transient
+            // failures (auth, 5xx, network) still skip and retry next run.
+            const status = (error as { status?: number; code?: number }) ?? {};
+            const isNotFound = status.status === 404 || status.code === 20404;
+            const rowAgeMs = Date.now() - new Date(local.date_created).getTime();
+            if (isNotFound && rowAgeMs > maxAgeMinutes * 60_000) {
+              await processCallStatusWebhook(
+                {
+                  sid: local.sid,
+                  date_created: local.date_created,
+                  is_last: local.is_last,
+                  status: "failed",
+                },
+                {
+                  workspaceId,
+                  note: `Call ${local.sid} (open-sync 404 terminalization)`,
+                },
+              );
+              callsUpdated++;
+              continue;
+            }
             callsSkipped++;
             continue;
           }
@@ -121,11 +157,14 @@ export async function triggerTwilioOpenSync({
     let messagesUpdated = 0;
     let messagesSkipped = 0;
 
+    // Same open-population sweep as calls (#1289): the old windowed selection
+    // let a message stuck longer than maxAgeMinutes escape the sweep forever.
+    // A Twilio 404 still skips (never terminalizes) here: the SMS side-effects
+    // job debits terminal messages per SID, and fabricating a terminal status
+    // for a message Twilio never had risks billing a send that never happened.
     const localOpenMessages = await tdb.message.findMany({
-      where: and(
-        inArray(message.status, [...OPEN_MESSAGE_STATUSES]),
-        gte(message.date_created, sinceIso),
-      ),
+      where: inArray(message.status, [...OPEN_MESSAGE_STATUSES]),
+      orderBy: [asc(message.date_created)],
       limit: messageLimit,
     });
 

--- a/scripts/db/reconcile-stuck-calls.ts
+++ b/scripts/db/reconcile-stuck-calls.ts
@@ -1,0 +1,168 @@
+/**
+ * Reconcile call/message rows stuck in a non-terminal status against Twilio
+ * (#1289). One-off backlog drain for the population the periodic
+ * `twilio_open_sync` job could not see before its selection-window fix — rows
+ * stuck longer than `maxAgeMinutes` had graduated permanently out of the
+ * sweep.
+ *
+ * Dry-run by default: prints every stuck row with its workspace and age.
+ * `--apply` runs the SAME code path as the worker job
+ * (`triggerTwilioOpenSync`), so status writes go through the guarded
+ * canonical processor and billing stays idempotent — this script contains no
+ * SQL writes of its own.
+ *
+ * Usage (bun resolves the `@/` tsconfig paths):
+ *   DATABASE_URL=postgresql://… bun run scripts/db/reconcile-stuck-calls.ts
+ *   DATABASE_URL=postgresql://… bun run scripts/db/reconcile-stuck-calls.ts --apply
+ *
+ * Options:
+ *   --apply                 actually reconcile (default: report only)
+ *   --min-age-minutes <n>   only report/sweep rows older than this (default 120)
+ *   --limit <n>             per-workspace per-round sweep size (default 100)
+ *   --max-rounds <n>        safety bound on apply rounds (default 10)
+ */
+// The app's env module soft-validates the full server key set at import
+// time; this script only needs DATABASE_URL (workspace Twilio credentials
+// come from the workspace rows). Fill the rest with inert placeholders BEFORE
+// importing any app module so the run isn't buried in missing-env noise.
+if (!process.env.DATABASE_URL) {
+  console.error("DATABASE_URL is required.");
+  process.exit(1);
+}
+for (const key of [
+  "BETTER_AUTH_SECRET",
+  "TWILIO_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_APP_SID",
+  "TWILIO_PHONE_NUMBER",
+  "BASE_URL",
+  "STRIPE_SECRET_KEY",
+  "RESEND_API_KEY",
+  // Object-storage group: required-env-keys wants either the S3_* set or
+  // Railway bucket credentials; satisfy the S3_* arm.
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_ACCESS_KEY_ID",
+  "S3_SECRET_ACCESS_KEY",
+  "S3_BUCKET",
+]) {
+  process.env[key] ??= "reconcile-script-placeholder";
+}
+
+const { sql } = await import("drizzle-orm");
+const { adminDb } = await import("@/server/admin-db");
+const { triggerTwilioOpenSync } = await import("@/lib/twilio-open-sync.server");
+
+const OPEN_CALL_STATUSES = ["queued", "ringing", "in-progress", "initiated"];
+
+function argValue(flag: string, fallback: number): number {
+  const index = process.argv.indexOf(flag);
+  if (index === -1 || index + 1 >= process.argv.length) return fallback;
+  const parsed = Number(process.argv[index + 1]);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.error(`Invalid value for ${flag}: ${process.argv[index + 1]}`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
+const apply = process.argv.includes("--apply");
+const minAgeMinutes = argValue("--min-age-minutes", 120);
+const limit = argValue("--limit", 100);
+const maxRounds = argValue("--max-rounds", 10);
+
+type StuckRow = {
+  sid: string;
+  workspace: string;
+  campaign_id: number | null;
+  contact_id: number | null;
+  status: string;
+  date_created: string;
+  age_hours: number;
+};
+
+async function listStuckCalls(): Promise<StuckRow[]> {
+  const rows = await adminDb.execute(sql`
+    select
+      c.sid,
+      c.workspace,
+      c.campaign_id,
+      c.contact_id,
+      c.status::text as status,
+      c.date_created,
+      round(extract(epoch from (now() - c.date_created::timestamptz)) / 3600) as age_hours
+    from call c
+    where c.status::text in (${sql.join(
+      OPEN_CALL_STATUSES.map((status) => sql`${status}`),
+      sql`, `,
+    )})
+      and c.date_created::timestamptz < now() - make_interval(mins => ${minAgeMinutes})
+    order by c.date_created asc
+  `);
+  return rows as unknown as StuckRow[];
+}
+
+const initial = await listStuckCalls();
+
+if (initial.length === 0) {
+  console.log(`No call rows stuck longer than ${minAgeMinutes} minutes. Nothing to do.`);
+  process.exit(0);
+}
+
+console.log(
+  `${initial.length} call row(s) stuck in a non-terminal status for >${minAgeMinutes} minutes:\n`,
+);
+for (const row of initial) {
+  console.log(
+    `  ${row.sid}  ws=${row.workspace}  campaign=${row.campaign_id ?? "-"}  contact=${row.contact_id ?? "-"}  status=${row.status}  age=${row.age_hours}h`,
+  );
+}
+
+if (!apply) {
+  console.log("\nDry run (no --apply): nothing was changed.");
+  process.exit(0);
+}
+
+const workspaces = [...new Set(initial.map((row) => row.workspace))];
+console.log(`\nReconciling across ${workspaces.length} workspace(s)…`);
+
+for (let round = 1; round <= maxRounds; round++) {
+  const before = (await listStuckCalls()).length;
+  if (before === 0) break;
+  console.log(`\nRound ${round}: ${before} stuck row(s) remaining.`);
+
+  for (const workspaceId of workspaces) {
+    const result = await triggerTwilioOpenSync({
+      workspaceId,
+      callLimit: limit,
+      messageLimit: limit,
+      // Prefetch/404-grace window only — selection sweeps all open rows.
+      maxAgeMinutes: minAgeMinutes,
+    });
+    if (result.ok) {
+      console.log(`  ${workspaceId}: ${result.message}`);
+    } else {
+      // Credential problems (or Twilio outage) for one workspace shouldn't
+      // stop the rest; its rows will simply still be listed at the end.
+      console.error(`  ${workspaceId}: FAILED — ${result.error}`);
+    }
+  }
+
+  const after = (await listStuckCalls()).length;
+  if (after >= before) {
+    console.log(
+      `\nNo further progress (${after} row(s) remain — likely workspaces with unusable Twilio credentials, or rows younger than the 404 grace). Stopping.`,
+    );
+    break;
+  }
+}
+
+const remaining = await listStuckCalls();
+console.log(
+  remaining.length === 0
+    ? "\nAll stuck call rows reconciled."
+    : `\n${remaining.length} row(s) still stuck:\n${remaining
+        .map((row) => `  ${row.sid}  ws=${row.workspace}  status=${row.status}`)
+        .join("\n")}`,
+);
+process.exit(remaining.length === 0 ? 0 : 2);

--- a/test/integration-db/call-status-guard.test.ts
+++ b/test/integration-db/call-status-guard.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * The guarded status writes, exercised against a REAL database (#1289).
+ *
+ * `call.status` and `message.status` are Postgres ENUMs in every real
+ * database lineage, and `lower(<enum>)` does not exist — the un-cast
+ * `LOWER(${callTable.status})` guards in `updateCallBySid`,
+ * `claimTerminalCallStatus`, and `updateMessageBySid` therefore THREW on
+ * every status-bearing write instead of guarding. Every Twilio status
+ * callback and every open-sync repair failed, so call rows accumulated in
+ * 'queued' forever (19 of 50 rows on the dev environment when found).
+ *
+ * The unit tier mocks the db client and can never see a type-resolution
+ * error; this real-Postgres tier is the only place the guards' SQL actually
+ * runs. If someone later "simplifies" the `::text` casts away, these go red.
+ */
+
+// The realtime side channel is non-fatal in production and covered elsewhere;
+// stubbing keeps this suite to one subject (the guarded UPDATE statements).
+vi.mock("@/lib/workspace-events.server", () => ({
+  emitQueueEvent: vi.fn(async () => undefined),
+  emitPostgresChangeEvent: vi.fn(async () => undefined),
+  emitChatMessageEvent: vi.fn(async () => undefined),
+}));
+
+const DATABASE_URL = process.env.INTEGRATION_DB_URL ?? process.env.DATABASE_URL;
+
+if (!DATABASE_URL) {
+  process.stderr.write(
+    [
+      "",
+      "!".repeat(72),
+      "!! integration-db SKIPPED: no INTEGRATION_DB_URL / DATABASE_URL set.",
+      "!".repeat(72),
+      "",
+    ].join("\n"),
+  );
+}
+
+const suite = DATABASE_URL ? describe : describe.skip;
+
+const WORKSPACE_ID = "11111111-2222-4333-8444-555555555555";
+const CALL_SID = "CAintegration_status_guard_01";
+const MESSAGE_SID = "SMintegration_status_guard_01";
+
+suite("guarded status writes against a real database (#1289)", () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let sqlClient: any;
+  let updateCallBySid: any;
+  let claimTerminalCallStatus: any;
+  let updateMessageBySid: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(async () => {
+    process.env.DATABASE_URL = DATABASE_URL;
+    const postgres = (await import("postgres")).default;
+    sqlClient ??= postgres(DATABASE_URL as string, { max: 1 });
+    ({ updateCallBySid, claimTerminalCallStatus } = await import(
+      "@/lib/telephony-db.server"
+    ));
+    ({ updateMessageBySid } = await import("@/lib/message-db.server"));
+
+    await sqlClient`
+      insert into workspace (id, name, credits)
+      values (${WORKSPACE_ID}, 'Status Guard Integration Workspace', 0)
+      on conflict (id) do nothing
+    `;
+    await sqlClient`delete from call where sid = ${CALL_SID}`;
+    await sqlClient`delete from message where sid = ${MESSAGE_SID}`;
+    await sqlClient`
+      insert into call (sid, workspace, status, date_created)
+      values (${CALL_SID}, ${WORKSPACE_ID}, 'queued', now())
+    `;
+    await sqlClient`
+      insert into message (sid, workspace, status, date_created)
+      values (${MESSAGE_SID}, ${WORKSPACE_ID}, 'queued', now())
+    `;
+  });
+
+  afterAll(async () => {
+    if (!sqlClient) return;
+    await sqlClient`delete from call where sid = ${CALL_SID}`;
+    await sqlClient`delete from message where sid = ${MESSAGE_SID}`;
+    await sqlClient`delete from workspace where id = ${WORKSPACE_ID}`;
+    await sqlClient.end();
+  });
+
+  test("updateCallBySid moves an open call to a terminal status on the enum column", async () => {
+    const row = await updateCallBySid(WORKSPACE_ID, CALL_SID, {
+      status: "completed",
+      duration: "42",
+    });
+    expect(row?.status).toBe("completed");
+
+    const [check] = await sqlClient`
+      select status::text as status from call where sid = ${CALL_SID}
+    `;
+    expect(check.status).toBe("completed");
+  });
+
+  test("updateCallBySid keeps a terminal status when a non-terminal update races in late", async () => {
+    await updateCallBySid(WORKSPACE_ID, CALL_SID, { status: "completed" });
+    const row = await updateCallBySid(WORKSPACE_ID, CALL_SID, {
+      status: "ringing",
+    });
+    expect(row?.status).toBe("completed");
+  });
+
+  test("claimTerminalCallStatus claims once and refuses the duplicate delivery", async () => {
+    const first = await claimTerminalCallStatus(
+      WORKSPACE_ID,
+      CALL_SID,
+      "completed",
+    );
+    const duplicate = await claimTerminalCallStatus(
+      WORKSPACE_ID,
+      CALL_SID,
+      "completed",
+    );
+    expect(first).toBe(true);
+    expect(duplicate).toBe(false);
+  });
+
+  test("updateMessageBySid moves an open message to a terminal status on the enum column", async () => {
+    const row = await updateMessageBySid(WORKSPACE_ID, MESSAGE_SID, {
+      status: "delivered",
+    });
+    expect(row?.status).toBe("delivered");
+  });
+});

--- a/test/twilio-open-sync.server.test.ts
+++ b/test/twilio-open-sync.server.test.ts
@@ -105,6 +105,99 @@ describe("triggerTwilioOpenSync terminal recovery (TEL-04)", () => {
     );
   });
 
+  // #1289: rows stuck longer than maxAgeMinutes must still be swept, and a
+  // Twilio 404 on an old row is an answer (terminalize), not a retry.
+  test("sweeps open rows older than the window (no date_created lower bound)", async () => {
+    mocks.callFindMany.mockResolvedValue([]);
+    await triggerTwilioOpenSync({ workspaceId: "ws-1", maxAgeMinutes: 120 });
+
+    const where = mocks.callFindMany.mock.calls[0]?.[0]?.where;
+    // Selection must not filter on date_created — the old shape wrapped the
+    // status filter in and(status, gte(date_created, since)), which let a row
+    // stuck >2h escape the sweep forever. Drizzle where objects are circular,
+    // so walk them collecting referenced column names instead of serializing.
+    const columns = new Set<string>();
+    const seen = new Set<object>();
+    const walk = (node: unknown) => {
+      if (node == null || typeof node !== "object" || seen.has(node)) return;
+      seen.add(node);
+      const name = (node as { name?: unknown }).name;
+      const table = (node as { table?: unknown }).table;
+      if (typeof name === "string" && table != null) {
+        // A column reference: record it, but do NOT recurse into its .table —
+        // that would enumerate every column of the table and defeat the check.
+        columns.add(name);
+        return;
+      }
+      for (const value of Object.values(node)) walk(value);
+    };
+    walk(where);
+    expect([...columns]).toContain("status");
+    expect([...columns]).not.toContain("date_created");
+  });
+
+  test("terminalizes an old Twilio-404 call as failed through the canonical processor", async () => {
+    mocks.callFindMany.mockResolvedValue([
+      // Far older than any window.
+      { sid: "CA404", status: "queued", date_created: "2026-07-01T00:00:00Z", is_last: false },
+    ]);
+    mocks.callsList.mockResolvedValue([]);
+    mocks.callFetch.mockRejectedValue(
+      Object.assign(new Error("not found"), { status: 404, code: 20404 }),
+    );
+
+    const result = await triggerTwilioOpenSync({ workspaceId: "ws-1" });
+
+    expect(result.ok).toBe(true);
+    expect(mocks.processCallStatusWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ sid: "CA404", status: "failed" }),
+      expect.objectContaining({ workspaceId: "ws-1" }),
+    );
+  });
+
+  test("a young Twilio-404 call is skipped, not terminalized", async () => {
+    mocks.callFindMany.mockResolvedValue([
+      { sid: "CAyoung", status: "queued", date_created: new Date().toISOString(), is_last: false },
+    ]);
+    mocks.callsList.mockResolvedValue([]);
+    mocks.callFetch.mockRejectedValue(
+      Object.assign(new Error("not found"), { status: 404, code: 20404 }),
+    );
+
+    await triggerTwilioOpenSync({ workspaceId: "ws-1" });
+
+    expect(mocks.processCallStatusWebhook).not.toHaveBeenCalled();
+  });
+
+  test("a transient fetch failure on an old row skips (retries next run) rather than terminalizing", async () => {
+    mocks.callFindMany.mockResolvedValue([
+      { sid: "CAflaky", status: "queued", date_created: "2026-07-01T00:00:00Z", is_last: false },
+    ]);
+    mocks.callsList.mockResolvedValue([]);
+    mocks.callFetch.mockRejectedValue(
+      Object.assign(new Error("service unavailable"), { status: 503 }),
+    );
+
+    await triggerTwilioOpenSync({ workspaceId: "ws-1" });
+
+    expect(mocks.processCallStatusWebhook).not.toHaveBeenCalled();
+  });
+
+  test("a Twilio-404 message is never terminalized (billing side-effects risk)", async () => {
+    mocks.messageFindMany.mockResolvedValue([
+      { sid: "SM404", status: "queued", date_created: "2026-07-01T00:00:00Z", date_updated: null },
+    ]);
+    mocks.messagesList.mockResolvedValue([]);
+    mocks.messageFetch.mockRejectedValue(
+      Object.assign(new Error("not found"), { status: 404, code: 20404 }),
+    );
+
+    await triggerTwilioOpenSync({ workspaceId: "ws-1" });
+
+    expect(mocks.updateMessageBySid).not.toHaveBeenCalled();
+    expect(mocks.enqueueJob).not.toHaveBeenCalled();
+  });
+
   test("terminal message discovery updates the row and enqueues the billing side-effects job", async () => {
     mocks.messageFindMany.mockResolvedValue([
       { sid: "SM1", status: "sending", date_created: "2026-07-29T00:00:00Z", date_updated: null },


### PR DESCRIPTION
Closes #1289

## What this found

The investigation escalated twice past the filed symptom:

1. **The sweep already existed but was blind to its own target.** `twilio_open_sync` selected only rows created inside `maxAgeMinutes` (2h) — a row stuck *longer* than the window graduated permanently out of the sweep. And a Twilio 404 just incremented `callsSkipped`, refetching the same dead SID every run forever.

2. **The real accumulation mechanism: the status guards throw on every real database.** `call.status` / `message.status` are Postgres enums, and `lower(<enum>)` does not exist — the atomic transition guards in `updateCallBySid`, `claimTerminalCallStatus`, and `updateMessageBySid` have thrown (`function lower(call_status) does not exist`) on every status-bearing write since the #1176-era refactor. Status callbacks were *arriving* and failing at the UPDATE — which is why rows kept sticking even after #1283/#1284 fixed callback delivery, including one from the very day this was found. The unit tier mocks the db client, so no test ever executed the guards' SQL against a real column type.

## Changes

- `triggerTwilioOpenSync`: selection is now every locally-open row, oldest first (messages too); `maxAgeMinutes` only bounds the list() prefetch and the 404 grace. Calls 404ing past the grace terminalize as `failed` via the canonical processor (billing never debits a terminal call without duration); messages never 404-terminalize (the SMS side-effects job debits per SID — fabricating a terminal status risks billing a send that never happened). Transient errors still skip and retry.
- `::text` casts in all three `LOWER()` guards, with comments pinning why.
- `scripts/db/reconcile-stuck-calls.ts`: one-off backlog drain — dry-run by default, `--apply` runs the same `triggerTwilioOpenSync` path per affected workspace (no SQL writes of its own), rounds until no progress, exit 2 if rows remain.
- `test/integration-db/call-status-guard.test.ts`: all three guards against real Postgres — verified red on the uncast guards with the exact production error, green with the casts. Terminal-can't-regress and duplicate-delivery compare-and-set semantics covered.
- New unit tests: window-escape regression (where-clause must not filter `date_created`), 404-terminalization old/young/transient/message cases.

## Executed against dev

Dry-run listed all 19 stuck rows (ages 2h–449h, 11 workspaces). With the casts in place, `--apply` cleared everything in one round: **19 calls updated, 14 billed via the idempotent ledger path, 1 stuck message repaired, zero 404s** — every stuck row was a real completed call whose write had been failing. Dev now has zero non-terminal call rows. No registry changes: the deployed worker's existing `twilio_open_sync` schedule keeps future backlogs drained on its own.

## Gates

`test:node` 354 files / 2774 tests, `test:integration-db` 24/24 (after refreshing the compose DB — 6 pre-existing failures were stale local migrations), `typecheck`, `lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)