### PR TITLE
fix(device): break the 31206 reconnect storm; never destroy a live call

### DIFF
--- a/app/hooks/call/useCampaignCallFlow.ts
+++ b/app/hooks/call/useCampaignCallFlow.ts
@@ -121,7 +121,13 @@ export function useCampaignCallFlow({
       // live here, force it closed so the SDK's own 'disconnect' handling
       // (including its built-in hangup tone) actually runs instead of the
       // call silently lingering. A no-op if the SDK already tore it down.
-      activeCall?.disconnect?.();
+      // Guarded: with a dead signaling transport this disconnect THROWS
+      // (31009), and this runs inside the workspace SSE fan-out (#1294).
+      try {
+        activeCall?.disconnect?.();
+      } catch (error) {
+        logger.debug("activeCall.disconnect after provider-terminal status failed", error);
+      }
     }
 
     // Also drive the legacy FSM for backward compat (all statuses).

--- a/app/hooks/call/useTwilioConnection.ts
+++ b/app/hooks/call/useTwilioConnection.ts
@@ -183,16 +183,26 @@ export function useTwilioConnection({
         onDeviceBusyChangeRef.current?.(false);
       };
 
-      const scheduleRetry = (reason: string) => {
+      const scheduleRetry = (reason: string, fixedDelayMs?: number) => {
         if (unmountedRef.current) return;
         const retries = retryCountRef.current;
         const BASE_DELAY_MS = 2000;
         const MAX_DELAY_MS = 60000;
-        const delay = Math.min(BASE_DELAY_MS * 2 ** retries, MAX_DELAY_MS);
+        const delay = fixedDelayMs ?? Math.min(BASE_DELAY_MS * 2 ** retries, MAX_DELAY_MS);
         logger.info(`Scheduling device reconnect (${reason}) in ${delay}ms`, { retry: retries + 1 });
         retryCountRef.current = retries + 1;
         retryTimerRef.current = setTimeout(() => {
-          if (!unmountedRef.current) reconnectRef.current();
+          if (unmountedRef.current) return;
+          // Rebuilding the device destroys its calls. If the agent is mid-call
+          // when the timer fires, killing the call to fix the phone is worse
+          // than waiting — defer until the call ends (#1294/31206 storm: the
+          // 2s retry after a signaling error tore down a LIVE call).
+          if ((deviceRef.current?.calls?.length ?? 0) > 0) {
+            logger.info("Deferring device reconnect: call in progress");
+            scheduleRetry(`${reason} (deferred: call in progress)`, delay);
+            return;
+          }
+          reconnectRef.current();
         }, delay);
       };
 
@@ -205,8 +215,14 @@ export function useTwilioConnection({
         // never opened, was disconnected (e.g. token expiry, network blip), or
         // the heartbeat timed out. Auto-recover by recreating the Device from
         // scratch instead of leaving it stuck in Error state until the user
-        // manually clicks "Reconnect phone".
+        // manually clicks "Reconnect phone" — unless a call is live: the
+        // rebuild destroys the call, so mid-call recovery waits for hangup.
         if (code === 31009 && !isReconnectingRef.current) {
+          if ((deviceRef.current?.calls?.length ?? 0) > 0) {
+            logger.info("TransportError (31009) mid-call; deferring device rebuild");
+            scheduleRetry("transport error (deferred: call in progress)");
+            return;
+          }
           isReconnectingRef.current = true;
           logger.info("TransportError (31009) detected, auto-reconnecting device");
           reconnectRef.current();
@@ -219,6 +235,17 @@ export function useTwilioConnection({
         setError(error);
         onErrorRef.current?.(error);
         onCallStateChangeRef.current?.("failed");
+
+        // RateExceededError (31206): Twilio is telling us we sent too much —
+        // the ICE-restart/re-invite loop of a failing call can trip this all
+        // by itself. Retrying on the normal 2s backoff walks straight back
+        // into the limit and (worse) the retry used to destroy the live call
+        // it fired under (#1294). Cool down hard instead.
+        const RATE_LIMIT_COOLDOWN_MS = 60000;
+        if (code === 31206) {
+          scheduleRetry("rate limited (31206 cooldown)", RATE_LIMIT_COOLDOWN_MS);
+          return;
+        }
         scheduleRetry("device error");
       };
 
@@ -281,6 +308,19 @@ export function useTwilioConnection({
     setError(null);
     setStatus("disconnected");
     if (stale) {
+      // destroy() internally runs disconnectAll(), whose hangup publish over a
+      // dead transport THROWS mid-teardown (31009) — leaving the old call's
+      // media handler ICE-restarting against nothing forever, and its
+      // signaling spam feeding the very rate limit (31206) that triggered the
+      // rebuild. Disconnect each call individually first, isolating throws,
+      // so one dead transport can't abort the rest of the teardown (#1294).
+      for (const call of stale.calls ?? []) {
+        try {
+          call.disconnect();
+        } catch (err) {
+          logger.debug("Stale call disconnect failed during reconnect:", err);
+        }
+      }
       try {
         stale.destroy();
       } catch (err) {

--- a/test/ui/twilio-connection-token-stability.test.tsx
+++ b/test/ui/twilio-connection-token-stability.test.tsx
@@ -132,3 +132,126 @@ describe("useTwilioConnection error recovery", () => {
     expect(result.current.status).toBe("disconnected");
   });
 });
+
+
+// #1294: a mid-call RateExceededError (31206) was fast-retried on the 2s
+// backoff — straight back into the rate limit — and the retry's reconnect()
+// destroyed the device with the agent's LIVE call still on it. destroy()'s
+// hangup publish then threw over the dead transport, orphaning the call's
+// ICE-restart loop (endless 31009 spam after hangup, feeding the same rate
+// limit). These pin the storm-breaking behaviors.
+describe("useTwilioConnection reconnect storm (#1294)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTwilioVoiceSdkMock();
+    mockTwilioDevice.calls = [];
+  });
+
+  function rateError(code: number, message: string) {
+    return Object.assign(new Error(message), { code });
+  }
+
+  test("31206 cools down for 60s instead of the 2s fast retry", async () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useTwilioConnection({ token: "tok-1" }));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockTwilioDevice.register).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        mockTwilioDevice.emit("error", rateError(31206, "rate exceeded"));
+      });
+
+      // The old 2s fast path must NOT fire.
+      await act(async () => {
+        vi.advanceTimersByTime(5_000);
+        await Promise.resolve();
+      });
+      expect(mockTwilioDevice.destroy).not.toHaveBeenCalled();
+
+      // After the full cooldown the rebuild happens.
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+        await Promise.resolve();
+      });
+      expect(mockTwilioDevice.destroy).toHaveBeenCalledTimes(1);
+      expect(mockTwilioDevice.register).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("a retry timer firing mid-call defers instead of destroying the live call", async () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useTwilioConnection({ token: "tok-1" }));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // A live call is on the device when the error fires and stays live
+      // through the first timer.
+      mockTwilioDevice.calls = [{ disconnect: vi.fn() }];
+      act(() => {
+        mockTwilioDevice.emit("error", rateError(99999, "some device error"));
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(2_000);
+        await Promise.resolve();
+      });
+      // Deferred: no rebuild while the call is live.
+      expect(mockTwilioDevice.destroy).not.toHaveBeenCalled();
+
+      // Call ends; the deferred timer fires and the rebuild proceeds.
+      mockTwilioDevice.calls = [];
+      await act(async () => {
+        vi.advanceTimersByTime(2_000);
+        await Promise.resolve();
+      });
+      expect(mockTwilioDevice.destroy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("31009 mid-call defers the rebuild instead of killing the call", async () => {
+    renderHook(() => useTwilioConnection({ token: "tok-1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    mockTwilioDevice.calls = [{ disconnect: vi.fn() }];
+    act(() => {
+      mockTwilioDevice.emit("error", rateError(31009, "no transport"));
+    });
+
+    // No immediate rebuild with a live call on the device.
+    expect(mockTwilioDevice.destroy).not.toHaveBeenCalled();
+  });
+
+  test("reconnect() disconnects every stale call, isolating dead-transport throws", async () => {
+    const throwing = {
+      disconnect: vi.fn(() => {
+        throw Object.assign(new Error("no transport"), { code: 31009 });
+      }),
+    };
+    const healthy = { disconnect: vi.fn() };
+    const { result } = renderHook(() => useTwilioConnection({ token: "tok-1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    mockTwilioDevice.calls = [throwing, healthy];
+    act(() => {
+      result.current.reconnect();
+    });
+
+    // The first call's throw must not stop the second disconnect or destroy.
+    expect(throwing.disconnect).toHaveBeenCalledTimes(1);
+    expect(healthy.disconnect).toHaveBeenCalledTimes(1);
+    expect(mockTwilioDevice.destroy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #1294

## What Sai's console capture showed (#1285)

Mid-call, the Voice SDK's ICE-restart loop re-invites over signaling until Twilio answers **RateExceededError (31206)** → the "Phone connection error" banner flashes. The device error path then amplified it: 31206 fast-retried on the 2s backoff (straight back into the limit), the retry **destroyed the device with the agent's live call on it**, and `destroy()`'s hangup publish threw over the dead transport mid-teardown — orphaning the call's ICE loop into the endless post-hangup 31009 spam, which feeds the same rate limit.

## Changes (`useTwilioConnection`)

- **31206 → 60s cooldown**, never the 2s fast path.
- **Any retry timer that fires while calls are live defers and reschedules** — a rebuild destroys the device's calls, and killing the call to fix the phone is worse than waiting.
- The **31009 auto-reconnect defers the same way** mid-call.
- `reconnect()` disconnects each stale call individually with per-call throw isolation **before** `destroy()`, so one dead-transport throw can't abort the teardown and orphan an ICE loop.
- Guards #1283's `activeCall?.disconnect?.()` in `useCampaignCallFlow` — it throws synchronously with a dead transport, inside the workspace SSE fan-out.

## Verification

- 4 new regression tests, each verified **red** against the unfixed hook (fast retry fired under 31206; mid-call timer destroyed the live call; 31009 rebuilt immediately mid-call; one throwing call aborted teardown) and green with the fix.
- `test:ui` 115 files / 704 tests, `typecheck`, `check:effects`, `lint` — green.
- `Device.calls` verified present on the real SDK (`get calls(): Call[]`), not just the test mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
