### PR TITLE
docs: interactive SMS foundation — delivery plan, ADR-0032/33/34, build tracking

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,6 +103,29 @@ _Avoid_: Presence (use for the UI concept), state (use for the enum value)
 
 **Messaging Service**: Used for outbound SMS sender pool and compliance (A2P 10DLC, toll-free verification), NOT for inbound webhooks. Inbound voice/SMS routes through number-level `voiceUrl`/`smsUrl` on each purchased `workspace_number`.
 
+### Interactive messaging
+
+**Script Revision**: An immutable published snapshot of a Script's executable document, with a version number, checksum, policy/disclosure references, and conversion diagnostics. Interactions execute a pinned Revision; edits create a new draft/Revision and never mutate a published one.
+_Avoid_: Script instance, versioned steps
+
+**Campaign Run**: One immutable execution snapshot of a reusable Campaign — audience Queue Entries, sender, sending windows, Script Revision, disclosure/jurisdiction policy, and reserved budget. A Campaign may have many Runs; subsequent launches create new Runs.
+_Avoid_: Campaign execution, campaign instance
+
+**Interaction**: One Contact executing one Script Revision through a Campaign Run, from dispatch until completion, expiry, opt-out, supersession, or handoff closure. Distinct from the durable message thread (a Conversation). Has its own lifecycle (pending, active, paused, completed, expired, opted_out, failed, cancelled) and a current operation cursor.
+_Avoid_: Run, script session, conversation
+
+**Messaging Endpoint**: The channel address pair of a concrete workspace sender identity and a normalized recipient, plus channel. Interactive reply correlation and active-uniqueness key on it; a Messaging Service pool reserves the recipient before binding the concrete sender after Twilio accepts the message.
+_Avoid_: Conversation identity, sender pair
+
+**Messaging Consent**: A recipient-level, append-only record of grant, revocation (STOP), opt-in (START), import evidence, or override, with source, evidence reference, purpose, channel, and policy version. Contact `opt_out` is at most a compatibility projection during migration.
+_Avoid_: Subscription, marketing consent
+
+**Interaction Event**: An immutable, append-only semantic record of one state transition (command, actor, prior/new state, reason, provider/model/action correlation). The authoritative current state is a projection derived from the event history.
+_Avoid_: Step log, activity
+
+**Action Request**: A durable, idempotent result of a Script `action` operation, validated against an allow-listed domain action registry and settled by an executor; sensitive actions require exact recipient intent, confirmation, and human approval.
+_Avoid_: Webhook call, side effect
+
 ### Live transcription & coaching
 
 **Live Transcription**: Real-time, in-call speech-to-text delivered to the agent's browser via pg-realtime SSE. Built on Twilio Media Streams (unidirectional `<Start><Stream track="both_tracks">`) forked to the media-stream Bun service, which forwards 8kHz mulaw to Deepgram Nova-3 streaming. Gated per-workspace by `workspace.featureFlags.liveTranscription`. Distinct from post-call batch transcription (Cohere).

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,12 @@ ADRs live in [`adr/`](adr/) and document hard-to-reverse, surprising, trade-off-
 - [0029 — Post-call golden transcript via Cohere Transcribe batch](adr/0029-post-call-golden-transcript-cohere-batch-worker.md)
 - [0030 — Media-stream Bun service as third Railway process](adr/0030-media-stream-bun-service-third-railway-process.md)
 
+### Interactive messaging (ADR-0032–0034)
+
+- [0032 — ScriptDocument v2 as a channel-neutral interaction model in a new package](adr/0032-interactive-sms-script-document-v2.md)
+- [0033 — Immutable Script Revision, Campaign Run, and audited Interaction state](adr/0033-immutable-revision-run-and-audited-interaction-state.md)
+- [0034 — Recipient Messaging Consent ledger and fail-closed disclosure for automated SMS](adr/0034-recipient-messaging-consent-and-fail-closed-disclosure.md)
+
 ## Active docs
 
 - `design-system.md`

--- a/docs/adr/0032-interactive-sms-script-document-v2.md
+++ b/docs/adr/0032-interactive-sms-script-document-v2.md
@@ -1,0 +1,35 @@
+# ScriptDocument v2 as a channel-neutral interaction model in a new package
+
+Interactive SMS/MMS reuses the Script concept, but the existing `ScriptDocument` v1 (in
+`scriptkit-call-script-core`) is not channel-neutral: its block types are UI widgets
+(`textarea`, `select`, `radio`, `checkbox`), it embeds voice fields (`audioFile`,
+`speechType`, IVR `recorded`/`synthetic`/`say`), and its routing is split between
+`routingRules` and `option.next`. Reusing it for SMS would force voice and widget semantics
+into every channel. We therefore define a new `ScriptDocument v2` in a new
+`@chester-hill-solutions/scriptkit-interaction-core` package: typed channel-neutral
+operations (`send`, `collect`, `action`, `wait(timer)`, `handoff`, `complete`), typed
+transitions with bounded cycles, inline per-channel presentation overrides, and strict
+publish validation. The new package is provider- and framework-neutral (no Twilio,
+Drizzle, React, logging, or network). Existing call/IVR Scripts stay on v1; they enter v2
+only through an explicit, non-destructive `convertV1ToV2` that reports warnings and never
+auto-migrates or silently changes behavior.
+
+## Considered Options
+
+- **Extend v1 block types.** Kept one package and migration surface, but perpetuated
+  voice/UI coupling and ambiguous block semantics across all channels. Rejected.
+- **Separate SMS Script model.** Isolated SMS but broke the shared Script concept and
+  duplicated editor/runtime infrastructure. Rejected.
+- **Channel-specific Scripts sharing an editor.** Lost a single semantic model. Rejected.
+
+## Consequences
+
+Existing `scriptkit-call-script-*` packages stay unchanged. The app keeps Twilio, billing,
+consent, persistence, and worker concerns; the package owns document validation and reducer
+semantics. Vendored under `vendor/scriptkit/` until semver stabilizes. See delivery plan
+`docs/interactive-sms-delivery-plan.md`.
+
+## References
+
+- `vendor/scriptkit/scriptkit-call-script-core/src/types.ts`, `src/routing.ts`
+- `docs/script-json-format.md`

--- a/docs/adr/0033-immutable-revision-run-and-audited-interaction-state.md
+++ b/docs/adr/0033-immutable-revision-run-and-audited-interaction-state.md
@@ -1,0 +1,41 @@
+# Immutable Script Revision, Campaign Run, and audited Interaction state
+
+Interactive messaging requires that history never silently changes. The current Campaign
+row mixes reusable configuration with execution status, and Script stores only mutable
+`steps` JSON with no revision or published snapshot. We adopt an immutable-execution model:
+a Script is the stable authored identity with a mutable draft; each publish
+creates a monolithic immutable `Script Revision` pinned by a Campaign Run; and Campaign is
+reusable configuration while a first-class `Campaign Run` is an immutable snapshot
+(audience Queue Entries, sender, sending windows, Script Revision, disclosure/jurisdiction
+policy, and reserved continuation credits). An `Interaction` — one Contact executing one
+Revision — is modeled as an authoritative transactional state machine plus an append-only
+semantic `Interaction Event` stream used for audit and reconstruction (not full event
+sourcing). The universal Run/Revision/Interaction model is adopted in phases; release one
+applies it only to new interactive message campaigns, leaving existing calls/IVR on the
+legacy model until a separate migration.
+
+## Considered Options
+
+- **Full event sourcing.** Strongest replay/debugging, but imposes event-schema evolution,
+  replay tooling, and PII-retention obligations on every operational detail. Rejected in
+  favor of an authoritative state machine with an event audit.
+- **Mutable Campaign-as-execution.** Rejected: relaunch and analytics would depend on
+  mutating history and on whichever Revision was current at dispatch (ambiguous for
+  in-flight work).
+- **Per-run document snapshot without a Revision entity.** Rejected: no reusable,
+  reconcilable, reassignable immutable artifact.
+
+## Consequences
+
+Schema adds `script_revision`, `campaign_run`, `interaction`, `interaction_event`,
+`interaction_effect`; `campaign_queue` gains `run_id` with uniqueness `(run_id, contact_id)`.
+All tenant-scoped tables register under ADR-0004; routes use `createTenantDb`. A pure
+reducer produces deterministic effects with stable IDs; effects never write state; the
+transition service is the single writer. No triggers/DB behavior (ADR-0006); narrow
+PL/pgSQL only for queue claim and credit reservation (ADR-0003).
+
+## References
+
+- `app/db/schema.ts` (campaign, campaign_queue, script, message)
+- `docs/interactive-sms-delivery-plan.md`
+- ADR-0015 (domain IDs), ADR-0003, ADR-0004, ADR-0006

--- a/docs/adr/0034-recipient-messaging-consent-and-fail-closed-disclosure.md
+++ b/docs/adr/0034-recipient-messaging-consent-and-fail-closed-disclosure.md
@@ -1,0 +1,41 @@
+# Recipient Messaging Consent ledger and fail-closed disclosure for automated SMS
+
+Automated SMS must carry enforceable consent evidence and recipient-facing disclosure.
+A single `contact.opt_out` boolean cannot represent consent source, scope, or proof, and
+Twilio's Messaging Policy (2026) requires prior consent plus proof, initial opt-out
+language, and sender identification in every message except ongoing-conversation follow-ups.
+We adopt a recipient-level, append-only `Messaging Consent` ledger (grant, STOP revocation,
+START opt-in, import evidence, and audited override) as the authoritative eligibility
+source; Contact `opt_out` remains only a compatibility projection during rollout. Inbound
+STOP terminates all applicable Contact Interactions workspace-wide and suppresses pending
+sends in the same transaction; only recipient START (never a simulated UI/API control)
+restores eligibility. Automated messaging is fail-closed: strict publish requires sender
+identity, initial opt-out disclosure (tracked per Workspace–recipient), jurisdiction
+authorization evidence, consent policy per outbound transition, reachable terminals, and no
+unbounded loops. CallCaster provides controls and evidence, not a guarantee that any
+template confers legal compliance.
+
+## Considered Options
+
+- **Contact-global opt-out boolean + email-style unsubscribe.** Rejected: no consent proof,
+  no scope, no audit, and fails the carrier proof-of-consent requirement.
+- **Profile-based per-jurisdiction minimum.** Allows lower safeguards for political
+  exemptions but complicates policy and risks carrier/compliance exposure when message
+  subject changes. Rejected; universal fail-closed standard selected.
+- **Run-level testimonial attestation without per-recipient record.** Rejected: weaker
+  per-recipient proof and larger Workspace compliance burden.
+
+## Consequences
+
+`recipient_consent_event` (append-only) + `recipient_consent` (maintained projection, no
+trigger). STOP becomes a high-priority, fail-closed command. Disclosure split: initial
+opt-out per Workspace–recipient; sender identity in each Run opener plus jurisdiction
+authorization. Exact STOP/START handling stays deterministic and precedes any model
+classification. Sensitive political actions require exact intent + confirmation + human
+approval regardless of model confidence.
+
+## References
+
+- `app/db/schema.ts` (contact opt_out), `app/lib/chat-opt-out.ts`
+- `app/routes/api+/inbound-sms.action.server.ts`
+- `docs/interactive-sms-delivery-plan.md`

--- a/docs/interactive-sms-build-tracking.md
+++ b/docs/interactive-sms-build-tracking.md
@@ -1,0 +1,77 @@
+# Interactive SMS/MMS — Build Orchestration & Tracking
+
+> **Branch:** `feat/interactive-sms` (worktree `../callcaster-interactive-sms`)
+> **Plan of record:** `docs/interactive-sms-delivery-plan.md`
+> **Tracker:** GitHub issues under `chester-hill-solutions/callcaster`
+> **Epic:** replaces/augments this doc once created (create Epic issue named
+> *"Interactive SMS/MMS campaigns — release one"*, type `Epic`).
+
+This file is the working surface for the EM+PM team during build. It mirrors the
+phases in the plan and tracks each work item's issue number, owner, and exit gate.
+Engineering-default decisions that require no product re-litigation are recorded here so
+implementers don't reopen them.
+
+---
+
+## Validated engineering defaults (do not re-open)
+
+These were settled during planning and are directionally safe. Flag only if a new fact
+(provider/policy/scale) contradicts them.
+
+- **State authority:** audited transactional state machine, not full event sourcing.
+- **`send` completion:** provider acceptance (Twilio returns SID). Late delivery failure → typed
+  event + pause/handoff unless a Script delivery-failure transition exists; never silent resend.
+- **Ambiguous provider outcome:** mark effect `ambiguous`, resolve via callback/operator; alert on aged.
+- **Duplicate/race ordering:** per-Interaction serialization with optimistic versioning; commit order wins
+  at a timeout boundary.
+- **Quiet window:** reply → state advances, outbound effect scheduled (deferred, not pre-answered).
+- **Unexpected input:** retained; non-advancing; platform escalation keywords + script aliases;
+  threshold (configurable) then handoff.
+- **Classifier contract:** provider-neutral; exact match first; model fallback gated per Script;
+  constrained to authored candidate transitions; model never writes state/effects; sensitive actions
+  exact + confirmation + human approval only.
+- **Consent:** recipient ledger authoritative; `contact.opt_out` compatibility projection during rollout.
+- **Shared phone:** endpoint correlation + preserved target Contact from Queue Entry.
+- **Model selection:** compare hosted vs self-hosted small English model on a de-identified corpus;
+  Command R7B / Command A benchmark candidates; exact-only beta needs no model.
+- **Template language:** unify on a single canonical syntax (decide ScriptKit `{{key}}` vs SMS
+  `{key|fallback}`; ship a compatibility layer if both inbound).
+- **API:** additive, role-gated, idempotency keys, doc-first OpenAPI + generated SDK; legacy `/api/sms`
+  compatibility adapter retained.
+
+---
+
+## Milestone board
+
+| Milestone | Work | Exit gate | Owner | Issues |
+|---|---|---|---|---|
+| **A. Prerequisites & consolidation** | ratify v2 contracts; message domain ID; inbound attribution; single dispatch coordinator (unify `/api/sms` + worker); credit reservation RPC; consent/disclosure+retention policy; feature flags+observability | both SMS dispatch adapters pass one contract suite; no policy divergence; local messages before SID; reservation concurrency tests pass; legacy API compat | EM | — |
+| **B. Vertical slice** | v2 core, conversion, publish validator; Revisions/Runs/Run queue; Interaction/event/effect persistence; opener→reply→exact→followup; endpoint correlation; editor/simulator/Run API/funnel | one flagged workspace authors/publishes/launches/completes exact-classifier SMS/MMS; no duplicate effects/billing; late failure visible; STOP suppresses; simulator==production | EM | — |
+| **C. Beta hardening** | model adapter; inbox handoff; full analytics/audit/ops; load+failure injection; MMS; SDK/docs/migration | no Sev-1/2 in 2-wk soak; ledger exact; SLOs; security/privacy+compliance copy; rollback proven | PM+EM | — |
+| **D. Follow-on migration** | migrate eligible message campaigns to v2; deprecate legacy `/api/sms` orchestration; remove obsolete queue assumptions | cloud: beta-stable then migrate; voice/IVR as separate project | PM | — |
+
+---
+
+## Orphaned prerequisite (must land before Phase B runtime)
+
+- **Consolidate the two campaign SMS dispatch paths.** Today [legacy `/api/sms`]
+  (`app/routes/api+/sms.action.server.ts`) enforces windows, quiet hours, opt-out, line type, duplicates,
+  templates, media, sender, throughput; the Bun worker (`app/lib/worker/handlers/campaign.server.ts`)
+  omits most of these. Build one dispatch coordinator used by both; keep the legacy endpoint backward
+  compatible (ADR-0018). This is the primary integrity risk and gates beta.
+- **Complete message domain-id PK** (ADR-0015 SMS portion): local domain id + nullable indexed
+  `twilio_sid`, rows created before provider dispatch.
+- **Normalize inbound Twilio attribution** (ADR-0011) off `workspace.twilio_data` JSON.
+- **`campaign_queue.run_id`** + uniqueness `(run_id, contact_id)`.
+
+---
+
+## Process conventions
+
+- Every work item gets a GitHub issue under the Epic: type `Task`/`User Story`/`Bug`; use native
+  parent/child + `blocked-by` edges (see `.agents/skills/github-issues`).
+- Pre-PR gate: `npm run ci:local`; + Postgres/MinIO E2E. Structural guards + codegen drift mandatory.
+- New tables → register in `app/db/workspace-scoped-tables.ts`; routes use `createTenantDb` (ADR-0004).
+- No triggers/DB behavior (ADR-0006); narrow PL/pgSQL only for claim + reservation (ADR-0003).
+- Migrations wired into production + compose bootstrap + migration ledger.
+- Mark issue + this board together when a milestone gate passes. Update `## Validated` only with new facts.

--- a/docs/interactive-sms-build-tracking.md
+++ b/docs/interactive-sms-build-tracking.md
@@ -3,8 +3,8 @@
 > **Branch:** `feat/interactive-sms` (worktree `../callcaster-interactive-sms`)
 > **Plan of record:** `docs/interactive-sms-delivery-plan.md`
 > **Tracker:** GitHub issues under `chester-hill-solutions/callcaster`
-> **Epic:** replaces/augments this doc once created (create Epic issue named
-> *"Interactive SMS/MMS campaigns — release one"*, type `Epic`).
+> **Epic:** [#1268](https://github.com/chester-hill-solutions/callcaster/issues/1268)
+> *"Interactive SMS/MMS campaigns — release one"* (type `Epic`, created 2026-08-15).
 
 This file is the working surface for the EM+PM team during build. It mirrors the
 phases in the plan and tracks each work item's issue number, owner, and exit gate.
@@ -45,8 +45,8 @@ These were settled during planning and are directionally safe. Flag only if a ne
 
 | Milestone | Work | Exit gate | Owner | Issues |
 |---|---|---|---|---|
-| **A. Prerequisites & consolidation** | ratify v2 contracts; message domain ID; inbound attribution; single dispatch coordinator (unify `/api/sms` + worker); credit reservation RPC; consent/disclosure+retention policy; feature flags+observability | both SMS dispatch adapters pass one contract suite; no policy divergence; local messages before SID; reservation concurrency tests pass; legacy API compat | EM | — |
-| **B. Vertical slice** | v2 core, conversion, publish validator; Revisions/Runs/Run queue; Interaction/event/effect persistence; opener→reply→exact→followup; endpoint correlation; editor/simulator/Run API/funnel | one flagged workspace authors/publishes/launches/completes exact-classifier SMS/MMS; no duplicate effects/billing; late failure visible; STOP suppresses; simulator==production | EM | — |
+| **A. Prerequisites & consolidation** | ratify v2 contracts; message domain ID; inbound attribution; single dispatch coordinator (unify `/api/sms` + worker); credit reservation RPC; consent/disclosure+retention policy; feature flags+observability | both SMS dispatch adapters pass one contract suite; no policy divergence; local messages before SID; reservation concurrency tests pass; legacy API compat | EM | [#1269 A1](https://github.com/chester-hill-solutions/callcaster/issues/1269), [#1270 A2](https://github.com/chester-hill-solutions/callcaster/issues/1270), [#1271 A3](https://github.com/chester-hill-solutions/callcaster/issues/1271) |
+| **B. Vertical slice** | v2 core, conversion, publish validator; Revisions/Runs/Run queue; Interaction/event/effect persistence; opener→reply→exact→followup; endpoint correlation; editor/simulator/Run API/funnel | one flagged workspace authors/publishes/launches/completes exact-classifier SMS/MMS; no duplicate effects/billing; late failure visible; STOP suppresses; simulator==production | EM | [#1272 B1](https://github.com/chester-hill-solutions/callcaster/issues/1272) — blocked by A1–A3 |
 | **C. Beta hardening** | model adapter; inbox handoff; full analytics/audit/ops; load+failure injection; MMS; SDK/docs/migration | no Sev-1/2 in 2-wk soak; ledger exact; SLOs; security/privacy+compliance copy; rollback proven | PM+EM | — |
 | **D. Follow-on migration** | migrate eligible message campaigns to v2; deprecate legacy `/api/sms` orchestration; remove obsolete queue assumptions | cloud: beta-stable then migrate; voice/IVR as separate project | PM | — |
 

--- a/docs/interactive-sms-delivery-plan.md
+++ b/docs/interactive-sms-delivery-plan.md
@@ -1,0 +1,362 @@
+# Interactive SMS/MMS Campaigns — Delivery Plan
+
+> **Status:** Plan of record (implementation not yet started)
+> **Branch:** `feat/interactive-sms`
+> **Owners:** PM + EM
+> **Last updated:** 2026-08-15
+
+This is the single planning artifact for interactive SMS/MMS campaigns in CallCaster,
+synthesized from product/domain decisions (grilled) and engineering analysis. It is
+the reference for all build orchestration. Voice and legacy runtime migration are
+**out of scope** for release one.
+
+---
+
+# Part A — PM Plan
+
+## A.1 Charter
+
+Enable workspaces to design, publish, launch, operate, hand off, and measure
+multi-step SMS interactions in which each targeted Contact executes a pinned Script
+Revision through a durable Campaign Run. Release one supports production-grade
+SMS and outbound MMS, deterministic behavior, consent safety, auditable outcomes,
+predictable credits, and human intervention.
+
+**First-release exclusions:** voice execution on v2; migration of legacy voice/IVR
+scripts or runtime; inbound MMS interpretation; multilingual intent (English only);
+open-ended agentic actions; unbounded loops; automatic resumption after handoff.
+
+## A.2 Locked decisions (do not reopen)
+
+| Area | Decision |
+|---|---|
+| Script model | `ScriptDocument v2` in a new `scriptkit-interaction-core` package. |
+| Compatibility | v1 requires explicit conversion; no silent conversion. |
+| Lifecycle | Script = stable/draft identity; monolithic immutable Script Revisions. |
+| Operations | `send`, `collect`, `action`, `wait(timer)`, `handoff`, `complete`. |
+| Graph | Typed transitions; bounded cycles only. |
+| Authoring groups | Authoring-only, never runtime operations. |
+| Channels | Inline per-channel overrides; strict publish validation. |
+| Campaign | Reusable configuration. |
+| Campaign Run | First-class immutable snapshot; universal model, phased adoption. |
+| Queue | Run owns snapshotted Queue Entries; pins revision/settings/budget. |
+| Interaction | Created at dispatch; one Contact executes one revision. |
+| Shared phones | Target Contact receives outcomes even when phone shared. |
+| Endpoint concurrency | One active Interaction per concrete sender+recipient; pool reservation. |
+| STOP | Inbound STOP terminates all applicable Contact Interactions workspace-wide. |
+| START | Eligibility restored only by recipient START. |
+| Consent | Recipient-level Messaging Consent ledger required before dispatch. |
+| Disclosure | Initial opt-out disclosure tracked per Workspace–recipient; sender identity in every Run opener; jurisdiction authorization required. |
+| MMS | Outbound only. |
+| Intent | Deterministic match first, then a small intent model. |
+| Language | English first. |
+| Ambiguity | One clarification, then handoff. |
+| Sensitive actions | Require exact intent + confirmation + human approval. |
+| Handoff | Existing inbox; pauses automation; explicit resume at cursor. |
+| Manual sends | Manual outbound auto-pauses automation. |
+| Windows | Automated replies obey windows. |
+| Collection | Each `collect` has a timeout. |
+| Unexpected input | Retained; threshold/escalation ends in handoff. |
+| Credits | Continuation credits reserved at Run launch. |
+| Actions | Controlled, allow-listed domain actions. |
+| Runtime authority | Authoritative state machine + immutable event audit. |
+| Surfaces | Full API, visual editor/simulator, full-funnel analytics. |
+
+## A.3 Users / JTBD
+
+- **Compliance admin** — prove eligibility, authorization, bounded cost, and that risky
+  actions cannot execute without approval; export audit/consent; kill switch.
+- **Campaign manager** — create reusable interaction, simulate all paths, launch to a
+  defined audience, understand where recipients end up.
+- **Content author** — express branching conversational logic without knowing the runtime.
+- **Inbox operator** — see why automation handed off, what it did, and safely take over/resume.
+- **Analyst/supervisor** — funnel, outcome, and cost reporting.
+- **API integrator** — same lifecycle via API, durable events, reconciliation.
+- **Recipient** — clear sender identity, respected choices/time, simple replies understood,
+  human connection when automation cannot help.
+
+## A.4 Success metrics
+
+**North-star:** qualified interaction completion rate
+`Interactions reaching a valid complete outcome ÷ eligible dispatched Interactions`.
+
+**Funnel:** targeted → eligible → reserved → opener attempted → opener delivered →
+replied → first collect resolved → clarified → handoff → handoff resolved →
+action approved/executed → completed with outcome.
+
+**Conversation quality:** delivered-to-response; deterministic-match; model-fallback;
+clarification rate & recovery; unexpected-rate; handoff rate; timeout rate; automated vs
+assisted completion; median messages & elapsed time.
+
+**Compliance targets:** post-STOP sends = 0; ineligible dispatch = 0; sensitive actions
+without all three safeguards = 0; sends outside enforced windows = 0; manual sends that
+failed to pause = 0.
+
+**Economics:** duplicate opener/effect sends; reservation conflict rate; stuck timers;
+credits reserved/consumed/released; credit per delivered/responded/completed/outcome;
+handoff queue age/SLA.
+
+## A.5 Delivery phases (PM milestones)
+
+0. **Definition & governance** — PRD, decision register, glossary, policy matrix,
+   sensitive-action registry, metric dictionary, beta segmentation.
+1. **Core contracts & prototypes** — v2 package contract, v1 conversion spec, publish
+   validator rules, Run/Interaction resource contracts, state machine + event schemas.
+2. **Authoring & simulation slice** — script library, draft/revision lifecycle, typed
+   editor, publication, simulator covering all paths.
+3. **Run & dispatch slice** — reusable Campaign, immutable Run snapshot, Run queue,
+   endpoint reservation, Interaction creation, deterministic execution, credit reserve,
+   STOP/START + consent ledger, provider idempotency + audit.
+4. **Intent, handoff, actions** — deterministic matcher, constrained model fallback,
+   one-clarification, inbox integration + auto-pause + explicit resume, action registry,
+   sensitive-action approval.
+5. **API, analytics, operations** — full API + webhooks, dashboard + funnel, exports,
+   reconciliation, alerts, kill switches, runbooks.
+6. **Alpha / beta / GA** — internal alpha → design-partner beta (deterministic only) →
+   beta 2 (+model/MMS/API) → GA.
+
+## A.6 Launch segmentation
+
+- **Alpha:** staff workspaces, synthetic/consenting recipients, deterministic intent only,
+  no sensitive actions, low concurrency, daily reconciliation.
+- **Beta 1:** allow-listed customers with approved messaging setup, clear consent,
+  simple English scripts, single sender, low-risk collection, monitored handoffs.
+- **Beta 2:** + model fallback, sender pools, outbound MMS, controlled non-sensitive actions,
+  API integrations.
+- **GA:** published policy/AUP, self-service readiness, validated SLOs, stable APIs,
+  real funnels + billing reconciliation, ≥2 successful beta cohorts, no unresolved P0/P1,
+  explicit owner sign-off.
+
+## A.7 Principal risks
+
+| Risk | Mitigation |
+|---|---|
+| STOP race with queued reply | Priority consent command, transactional suppression, cancel timers, race tests + alerts. |
+| Shared phone wrong attribution | Endpoint reservation preserves target Contact. |
+| Model unsafe transition | Constrain candidates to authored transitions; precision threshold; sensitive actions exact-only. |
+| Mutable config corrupts history | Immutable Revisions/Runs with hashes + copied settings. |
+| Credit exhaustion mid-interaction | Reserve continuation credits; pause before send; release unused reserve. |
+| Human/automation both reply | Manual send atomically pauses; explicit resume only. |
+| Timer sends during quiet hours | Timer wakes state machine; outbound rechecks windows and defers. |
+| Unexpected replies create loops | Bounded cycles, unexpected counter, one clarification, threshold handoff. |
+| Event/state divergence | Single command path, state versioning, reconciliation + repair tooling. |
+
+---
+
+# Part B — EM Technical Plan
+
+## B.1 Architecture
+
+**Runtime:** Bun web + worker (ADR-0001). Reuse generalized job infra (ADR-0007).
+**State:** authoritative transactional state machine + append-only semantic events, not
+full event sourcing. Pure reducer:
+
+```
+state' = reduce(state, event, revision) -> { nextState, effects[] }
+```
+
+Effects carry stable IDs and durable acknowledgements; executors never write state.
+Provider acceptance completes a `send`; later delivery failures are typed events, never
+implicit retries.
+
+**Transaction boundary (every accepted input):**
+1. lock Interaction by id/version → 2. dedupe source event → 3. append semantic event →
+4. pure reducer → 5. update projected state + version → 6. insert deterministic effects →
+7. commit. No provider/model/storage/webhook calls inside the transaction.
+Use Drizzle CRUD; narrow PL/pgSQL only for queue claim + credit reservation (ADR-0003).
+No triggers/DB-side behavior (ADR-0006).
+
+## B.2 Package boundaries
+
+- **`scriptkit-interaction-core` (v2):** provider/framework-neutral schemas, `convertV1ToV2`,
+  strict publish validator, pure reducer, stable effect-ID, exact classifier, model-classifier
+  contract, consensus/disclosure requirements, simulator engine, deterministic fixtures.
+  Vendored under `vendor/scriptkit/` until semver stabilizes. **No** Twilio/Drizzle/React/logging/env.
+- **Existing `scriptkit-call-script-*`:** unchanged, stays v1 voice/IVR.
+- **CallCaster app:** persistence/repos, Runs + Interaction orchestration, consent + billing
+  policy, Twilio adapters/webhooks, model adapter, OpenAPI/SDK, editor, inbox, analytics.
+  All new tables registered in `workspace-scoped-tables.ts` (ADR-0004); routes use `createTenantDb`.
+
+## B.3 Data model
+
+| Entity | Invariants |
+|---|---|
+| `script_revision` | Domain ID, workspace, script id, schema version, immutable JSON + checksum, conversion diagnostics. Never updates. |
+| `campaign_run` | Campaign, channel, phase, immutable revision, policy/disclosure version, lifecycle, schedule, counters. |
+| `campaign_queue.run_id` | Uniqueness `(run_id, contact_id)` for new SMS runs. |
+| `interaction` | Workspace/run/contact, endpoint, state JSON + version, status, handoff state, last activity. |
+| `interaction_event` | Append-only, sequence, source id, typed payload, actor + timestamp, unique source key. |
+| `interaction_effect` | Stable effect id, type, payload, status, attempts, ack, provider correlation, reservation id, lease. |
+| `interaction_endpoint` | Channel + normalized sender/recipient pair, active state, unique active correlation. |
+| `recipient_consent_event` | Append-only grant/revoke/opt-out/import evidence, purpose, channel, source, disclosure version, actor. |
+| `recipient_consent` | Maintained projection (no trigger). |
+| `credit_reservation` | Workspace, interaction/effect, estimate, state, expiry, settlement, idempotency key. |
+| `message` additions | Local domain id, nullable `twilio_sid`, `interaction_id`, `interaction_effect_id`. |
+
+## B.4 Migration strategy
+
+1. Expand (additive tables/columns/indexes/RPCs).
+2. Backfill Revisions via explicit v1 conversion; preserve original checksum + warnings.
+3. Backfill message identity (domain ids; keep SID in serializers).
+4. Freeze a legacy Run only when an existing message campaign first enters consolidated dispatcher.
+5. Attach eligible existing SMS queue rows to the legacy Run.
+6. Dual-read compatibility; old APIs keep reading existing fields.
+7. Only after beta stability: require `run_id` for new SMS queues, remove obsolete dispatch code.
+
+**Prerequisite migrations/packages:** message domain-id PK (ADR-0015 SMS portion),
+normalized Twilio attribution (ADR-0011), `campaign_queue.run_id` uniqueness,
+typed feature flags. All migrations wired into production + compose bootstrap + ledger.
+
+## B.5 Reducer, effects, idempotency, workers
+
+**Effect ID:** `interaction_id + causation_event_id + effect_ordinal + effect_type + revision_checksum`,
+guarded by a unique constraint. States `pending → claimed → attempted → accepted`
+(± retryable_failed / ambiguous / terminal_failed). "Accepted" = Twilio accepted
+`messages.create`.
+
+**Provider crash gap (no Twilio app idempotency key):** create local message/effect row
+before calling Twilio; put effect id in the status callback URL; never blindly retry an
+`attempted` send with unknown outcome — mark `ambiguous`, resolve via callback/reconcile/
+operated action; alert on aged ambiguous effects.
+
+**Classification:** normalize → deterministic match → (if permitted) `classify_with_model`
+effect → worker calls provider-neutral adapter → typed `classification_resolved`/`failed`
+event → reducer decides. The model never writes state or effects.
+
+## B.6 Twilio webhooks
+
+Extend signature-only Bun routes (ADR-0009). Inbound correlation order: workspace by
+`To`/Messaging Service → provider/effect correlation → active `interaction_endpoint` →
+exactly one → append event; zero → general inbox; multiple → fail-closed automation,
+route to inbox review. STOP writes consent-revoked, updates projection, suppresses
+pending sends, dequeues future work in one transaction; retain `contact.opt_out` as a
+compatibility projection during rollout.
+
+## B.7 Billing reservation
+
+Reserve exact estimated credits (segment/MMS from shared/pricing.ts) via atomic RPC
+before send. Available = `workspace.credits - active reservations`. Settlement on provider
+acceptance; terminal callback reconciles actual segments; cancelled/orphaned release holds;
+late delivery failure follows existing billable policy. Reconciliation jobs for expired/
+orphaned/double-settled/negative-available reservations.
+
+## B.8 Consent & disclosures — strict publish must require
+
+Sender identity; initial disclosure + opt-out; purpose/phase; expected automated frequency;
+locale + policy version; valid fallback/handoff; consent policy per outbound transition;
+reachable terminals; no unbounded loops; valid MMS/merge tags/choices/model policy.
+Consent record types: import evidence, explicit opt-in, inbound START, administrative
+override, STOP/revocation — with evidence refs + policy versions. CallCaster provides
+controls + evidence, not a legal-compliance guarantee.
+
+## B.9 API-first
+
+Add schemas in `app/lib/schemas/api/`, entries in `api-surface.ts`, export OpenAPI via
+`openapi.ts`, generate SDK (opens in ADR-0014/0018). Proposed surface: script/revision CRUD/
+conversion/publish; Run CRUD/lifecycle; Run queue preview/enroll/status; Interaction
+list/get/events; simulator sessions; handoff/claim/release/manual reply; analytics; consent.
+Additive + role-gated, granular API-key capabilities, idempotency keys, stable error codes.
+
+## B.10 Editor / simulator / inbox / analytics
+
+- **Editor:** separate v2 editor alongside current script editor; message/MMS nodes, exact
+  choices, model fallback, timers, branching, disclosures, handoff, terminal outcomes;
+  revision compare; strict validation panel; explicit Publish.
+- **Simulator:** same core reducer in-memory; synthetic context; mocked model; time advance;
+  effect transcript; credit estimates; no Twilio/test write.
+- **Inbox handoff:** extend existing chats surface; on `handoff_requested` suspend effects,
+  show Run/revision/path/classification/consent/SLA; atomic claim/release; manual replies
+  via shared effect executor; resume only via revision-defined handback event.
+- **Analytics:** event-derived funnel; do not overload current status-only campaign stats.
+
+## B.11 Observability / security / privacy
+
+Correlate request_id + workspace + run + interaction + event + effect + job + message id +
+Twilio SID. Never log bodies, prompts, media URLs, consent evidence, credentials. Metrics for
+queue lag, effect age, reservation age, correlation failure, ambiguous sends, model latency/
+error, late delivery failure. Reuse Sentry/ops, redaction, SSE for UI freshness (semantic events
+stay durable). Retention for bodies/MMS/classifier inputs/consent evidence; tenant-safe deletion
+workers preserve audit proof. Validate MMS MIME/size/ownership/signed retrieval. Uniform 404 /
+role 403.
+
+## B.12 Test strategy
+
+- Core: v1→v2 golden fixtures; publish validation; reducer determinism/property; effect-id
+  stability; classifier; loop/reachability; simulator parity.
+- Persistence/concurrency: tenant registry; optimistic conflict; event dedupe; effect unique
+  insert + lease; queue claim; reservation affordability/settle/expiry/reconcile.
+- Twilio: signature; correlation; duplicate callbacks; STOP/START; MMS; late failure;
+  crash-after-provider ambiguity.
+- API/UI/E2E: OpenAPI conformance + SDK smoke; publish permissions; Run lifecycle + flag
+  denial; editor revision history; simulator deterministic paths; inbox claim race; analytics
+  reconciliation; legacy `/api/sms` compat.
+- Release gate: `npm run ci:local` + Postgres/MinIO E2E.
+
+## B.13 Sequencing / milestones / exit criteria
+
+**Phase A — Prerequisites & consolidation (wk 1–4):**
+ratify v2 contracts + API surface; message domain identity; normalize inbound attribution;
+single dispatch coordinator (**prerequisite: unify the two divergent campaign SMS dispatch
+paths** — legacy `/api/sms` vs worker); credit reservation RPC; consent/disclosure policy +
+retention; feature flags + observability. Exit: both dispatch adapters pass one contract suite;
+no policy divergence; local messages before SID; reservation concurrency tests pass; legacy API
+compat.
+
+**Phase B — Vertical slice (wk 5–9):**
+v2 core, explicit conversion, publish validation; Revisions/Runs/Run queue; Interaction/event/
+effect persistence; opener → reply → exact classify → follow-up; endpoint correlation +
+acceptance semantics; basic editor/simulator/Run API/funnel. Exit: one flagged workspace authors,
+publishes, launches, completes an exact-classifier SMS/MMS interaction; no duplicate effects/
+billing; late failure visible without resend; STOP suppresses pending automation; simulator
+matches production.
+
+**Phase C — Beta hardening (wk 10–14):**
+model adapter + fallback; inbox handoff/claim/manual; full analytics/audit/retention/reconcile/
+ops tooling; load + failure injection; MMS hardening; SDK/docs/migration tooling. Exit: no
+Sev-1/2 integrity defect in 2-week soak; ledger reconciliation exact; ambiguity/stuck workflows;
+SLOs met; security/privacy review + compliance copy approved; rollback proven.
+
+**Phase D — Follow-on migration:** migrate eligible message campaigns to v2 after explicit
+review; deprecate legacy `/api/sms` orchestration (compat adapter); remove obsolete campaign-level
+queue assumptions; voice/IVR adoption as a separate project.
+
+## B.14 Staffing
+
+Architecture/core (TL, 1); persistence/queue/billing (2 senior BE); Twilio/webhooks/workers
+(1 senior BE shared); editor/simulator (1 senior FE); inbox/analytics (1 full-stack);
+OpenAPI/SDK/integration (0.5–1); SDET (1); security/privacy/SRE and consent policy (part-time).
+Effective team ~6–7 engineers + SDET. Below 4 engineers, run model, handoff, and advanced
+analytics sequentially.
+
+## B.15 Critical path
+
+1. Core v2 event/effect contract.
+2. Message identity + dispatch consolidation.
+3. Credit reservation + Run-owned queue schema.
+4. Interaction transaction/outbox.
+5. Twilio acceptance + inbound correlation.
+6. Strict publish + editor.
+7. Inbox/model/analytics hardening.
+
+Do not commit to beta until dispatch consolidation, message identity, and reservation
+semantics are complete — those are the integrity risks, not the editor.
+
+---
+
+# Decision register (validation items — optimize, don't re-litigate)
+
+- Default `collect` timeouts / timer presets.
+- Unexpected-message threshold defaults.
+- Confidence thresholds + acceptable false-positive rate.
+- Exact-match normalization/alias scope (case, whitespace, numeric, regex).
+- Sensitive-action catalog + approval roles.
+- Jurisdiction authorization evidence + disclosure wording (counsel-approved).
+- Handoff queue triage, ownership, response SLA.
+- Resume UX + operator context.
+- Budget reserve formula + low-credit warnings.
+- Beta segments for model-assisted intent.
+- Retention/export requirements for content, model inputs, events, media.
+- Pricing/packaging; held vs spent credits presentation.
+- Whether `action` catalog is closed or extensible (locked: closed core, extensible action catalog).
+- Full event sourcing vs audited state machine (locked: audited state machine).
+- Keyword handling: exact-only for launch (locked: deterministic first, model fallback).


### PR DESCRIPTION
Lands the interactive SMS/MMS foundation docs from the Aug 15 planning session so the epic's source of truth lives on dev instead of a side branch:

- `docs/interactive-sms-delivery-plan.md` — full delivery plan for the epic
- `docs/interactive-sms-build-tracking.md` — build tracking checklist
- ADR-0032 (script document v2), ADR-0033 (revision run + audited interaction state), ADR-0034 (messaging consent + fail-closed disclosure)
- `CONTEXT.md` / `docs/README.md` glossary and index updates

Docs-only; no application code. No file overlap with dev since the merge base, so it merges clean.

Part of #1268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)