### PR TITLE
chore: environment-scoped Railway IaC, rebased + staging modelled

### DIFF
--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Plan Railway dev configuration
         run: |
           set +e
-          railway config plan --file .railway/railway.ts --detailed-exit-code --json > railway-dev-plan.json
+          railway config plan --file "$GITHUB_WORKSPACE/.railway/railway.ts" --detailed-exit-code --json > railway-dev-plan.json
           status=$?
           cat railway-dev-plan.json
           if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
@@ -64,7 +64,7 @@ jobs:
           fi
       - name: Apply Railway dev configuration
         if: github.event_name == 'push'
-        run: railway config apply --file .railway/railway.ts --yes
+        run: railway config apply --file "$GITHUB_WORKSPACE/.railway/railway.ts" --yes
 
   # Staging deploys from `master` (the promotion branch: dev → master →
   # production). Applies on master pushes; plans on PRs to master and, as an
@@ -99,7 +99,7 @@ jobs:
       - name: Plan Railway staging configuration
         run: |
           set +e
-          railway config plan --file .railway/railway.ts --detailed-exit-code --json > railway-staging-plan.json
+          railway config plan --file "$GITHUB_WORKSPACE/.railway/railway.ts" --detailed-exit-code --json > railway-staging-plan.json
           status=$?
           cat railway-staging-plan.json
           if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
@@ -111,7 +111,7 @@ jobs:
           fi
       - name: Apply Railway staging configuration
         if: github.event_name == 'push'
-        run: railway config apply --file .railway/railway.ts --yes
+        run: railway config apply --file "$GITHUB_WORKSPACE/.railway/railway.ts" --yes
 
   production:
     if: >-
@@ -142,7 +142,7 @@ jobs:
       - name: Plan Railway production configuration
         run: |
           set +e
-          railway config plan --file .railway/railway.ts --detailed-exit-code --json > railway-production-plan.json
+          railway config plan --file "$GITHUB_WORKSPACE/.railway/railway.ts" --detailed-exit-code --json > railway-production-plan.json
           status=$?
           cat railway-production-plan.json
           if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
@@ -154,4 +154,4 @@ jobs:
           fi
       - name: Apply Railway production configuration
         if: github.event_name == 'push'
-        run: railway config apply --file .railway/railway.ts --yes
+        run: railway config apply --file "$GITHUB_WORKSPACE/.railway/railway.ts" --yes

--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -1,15 +1,18 @@
 name: Railway IaC
 
+# Promotion pipeline (#1300): dev → master (staging) → production.
+# Each environment applies on pushes to its own branch and plans on PRs
+# targeting it; staging additionally plans on dev PRs for early drift checks.
 on:
   push:
-    branches: [dev, master]
+    branches: [dev, master, production]
     paths:
       - ".railway/**"
       - ".github/workflows/railway-iac.yml"
       - "package.json"
       - "package-lock.json"
   pull_request:
-    branches: [dev, master]
+    branches: [dev, master, production]
     paths:
       - ".railway/**"
       - ".github/workflows/railway-iac.yml"
@@ -62,13 +65,14 @@ jobs:
         if: github.event_name == 'push'
         run: railway config apply --file .railway/railway.ts --yes
 
-  # Staging has no branch of its own yet (issue #1300 phase 2 decides its
-  # promotion model), so this job only ever plans — drift shows up on PRs and
-  # dev pushes, and applies stay manual.
+  # Staging deploys from `master` (the promotion branch: dev → master →
+  # production). Applies on master pushes; plans on PRs to master and, as an
+  # early drift check, on PRs to dev.
   staging:
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'pull_request' &&
+      (github.base_ref == 'dev' || github.base_ref == 'master') &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     environment: staging
@@ -100,14 +104,17 @@ jobs:
             exit "$status"
           fi
           if jq -e '.changeSet.changes[]? | select(.severity == "destructive")' railway-staging-plan.json > /dev/null; then
-            echo "Destructive staging Railway plan detected. Review it manually."
+            echo "Refusing to apply a destructive staging Railway plan. Review it manually."
             exit 1
           fi
+      - name: Apply Railway staging configuration
+        if: github.event_name == 'push'
+        run: railway config apply --file .railway/railway.ts --yes
 
   production:
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'master' &&
+      (github.event_name == 'push' && github.ref == 'refs/heads/production') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'production' &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     environment: production

--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -62,6 +62,48 @@ jobs:
         if: github.event_name == 'push'
         run: railway config apply --file .railway/railway.ts --yes
 
+  # Staging has no branch of its own yet (issue #1300 phase 2 decides its
+  # promotion model), so this job only ever plans — drift shows up on PRs and
+  # dev pushes, and applies stay manual.
+  staging:
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
+      - name: Install Railway CLI
+        run: npm install --global @railway/cli@5.30.4
+      - name: Link Railway staging environment
+        run: railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT_ID"
+      - name: Plan Railway staging configuration
+        run: |
+          set +e
+          railway config plan --file .railway/railway.ts --detailed-exit-code --json > railway-staging-plan.json
+          status=$?
+          cat railway-staging-plan.json
+          if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+            exit "$status"
+          fi
+          if jq -e '.changeSet.changes[]? | select(.severity == "destructive")' railway-staging-plan.json > /dev/null; then
+            echo "Destructive staging Railway plan detected. Review it manually."
+            exit 1
+          fi
+
   production:
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/master') ||

--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
       - name: Install Railway CLI
-        run: npm install --global @railway/cli@5.30.4
+        run: npm install --global @railway/cli@5.41.2
       - name: Plan Railway dev configuration
         run: |
           set +e
@@ -89,7 +89,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
       - name: Install Railway CLI
-        run: npm install --global @railway/cli@5.30.4
+        run: npm install --global @railway/cli@5.41.2
       - name: Plan Railway staging configuration
         run: |
           set +e
@@ -129,7 +129,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
       - name: Install Railway CLI
-        run: npm install --global @railway/cli@5.30.4
+        run: npm install --global @railway/cli@5.41.2
       - name: Plan Railway production configuration
         run: |
           set +e

--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -46,8 +46,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
       - name: Install Railway CLI
         run: npm install --global @railway/cli@5.30.4
-      - name: Link Railway dev environment
-        run: railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT_ID"
       - name: Plan Railway dev configuration
         run: |
           set +e
@@ -92,8 +90,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
       - name: Install Railway CLI
         run: npm install --global @railway/cli@5.30.4
-      - name: Link Railway staging environment
-        run: railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT_ID"
       - name: Plan Railway staging configuration
         run: |
           set +e
@@ -134,8 +130,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
       - name: Install Railway CLI
         run: npm install --global @railway/cli@5.30.4
-      - name: Link Railway production environment
-        run: railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT_ID"
       - name: Plan Railway production configuration
         run: |
           set +e

--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -34,6 +34,9 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
       RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      # npm's .bin symlinks are mode 777 on Linux, so the CLI's tamper check
+      # rejects the project runner; point it at the real file instead.
+      RAILWAY_IAC_TS_BIN: ${{ github.workspace }}/node_modules/railway/dist/iac/bin.js
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -78,6 +81,9 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
       RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      # npm's .bin symlinks are mode 777 on Linux, so the CLI's tamper check
+      # rejects the project runner; point it at the real file instead.
+      RAILWAY_IAC_TS_BIN: ${{ github.workspace }}/node_modules/railway/dist/iac/bin.js
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -118,6 +124,9 @@ jobs:
       RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
       RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      # npm's .bin symlinks are mode 777 on Linux, so the CLI's tamper check
+      # rejects the project runner; point it at the real file instead.
+      RAILWAY_IAC_TS_BIN: ${{ github.workspace }}/node_modules/railway/dist/iac/bin.js
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -1,0 +1,105 @@
+name: Railway IaC
+
+on:
+  push:
+    branches: [dev, master]
+    paths:
+      - ".railway/**"
+      - ".github/workflows/railway-iac.yml"
+      - "package.json"
+      - "package-lock.json"
+  pull_request:
+    branches: [dev, master]
+    paths:
+      - ".railway/**"
+      - ".github/workflows/railway-iac.yml"
+      - "package.json"
+      - "package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  dev:
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    environment: dev
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
+      - name: Install Railway CLI
+        run: npm install --global @railway/cli@5.30.4
+      - name: Link Railway dev environment
+        run: railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT_ID"
+      - name: Plan Railway dev configuration
+        run: |
+          set +e
+          railway config plan --file .railway/railway.ts --detailed-exit-code --json > railway-dev-plan.json
+          status=$?
+          cat railway-dev-plan.json
+          if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+            exit "$status"
+          fi
+          if jq -e '.changeSet.changes[]? | select(.severity == "destructive")' railway-dev-plan.json > /dev/null; then
+            echo "Refusing to apply a destructive dev Railway plan. Review it manually."
+            exit 1
+          fi
+      - name: Apply Railway dev configuration
+        if: github.event_name == 'push'
+        run: railway config apply --file .railway/railway.ts --yes
+
+  production:
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'master' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN || github.token }}
+      - name: Install Railway CLI
+        run: npm install --global @railway/cli@5.30.4
+      - name: Link Railway production environment
+        run: railway link --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT_ID"
+      - name: Plan Railway production configuration
+        run: |
+          set +e
+          railway config plan --file .railway/railway.ts --detailed-exit-code --json > railway-production-plan.json
+          status=$?
+          cat railway-production-plan.json
+          if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+            exit "$status"
+          fi
+          if jq -e '.changeSet.changes[]? | select(.severity == "destructive")' railway-production-plan.json > /dev/null; then
+            echo "Refusing to apply a destructive production Railway plan. Review it manually."
+            exit 1
+          fi
+      - name: Apply Railway production configuration
+        if: github.event_name == 'push'
+        run: railway config apply --file .railway/railway.ts --yes

--- a/.railway/README.md
+++ b/.railway/README.md
@@ -1,0 +1,45 @@
+# Railway configuration
+
+This project defines its Railway infrastructure in code.
+
+```txt
+.railway/railway.ts
+```
+
+Use this file to describe the Railway project you want: services, databases, buckets, custom domains, replicas, groups, and environment variables.
+
+## Common commands
+
+Create the configuration files:
+
+```bash
+railway config init
+```
+
+Import an existing Railway project into code:
+
+```bash
+railway config pull
+```
+
+Preview what Railway would change:
+
+```bash
+railway config plan
+```
+
+Apply the planned changes:
+
+```bash
+railway config apply
+```
+
+## Notes
+
+- `railway config plan` is safe and does not change Railway.
+- `railway config apply` previews changes and asks before applying unless you pass `--yes`.
+- Destructive changes in non-interactive or agent sessions require `railway config apply --confirm-destructive` after reviewing the plan.
+- Services already managed by `railway.json` must be migrated before `.railway/railway.ts` can manage them.
+- Use `replicas` for scaling; advanced placement can still specify region names.
+- Use `group("Name", [resources])` to keep large projects organized on the Railway canvas.
+- Secrets imported from Railway are rendered as `preserve()` so existing values are retained without writing secret values to source. Use `railway config pull --omit-preserved-variables` for a smaller import.

--- a/.railway/README.md
+++ b/.railway/README.md
@@ -6,7 +6,7 @@ This project defines its Railway infrastructure in code.
 .railway/railway.ts
 ```
 
-Use this file to describe the Railway project you want: services, databases, buckets, custom domains, replicas, groups, and environment variables.
+Use this file to describe the Railway project you want: services, databases, buckets, replicas, groups, and environment variables. The root file selects a complete resource graph from `.railway/environments/` based on the target Railway environment.
 
 ## Common commands
 
@@ -43,3 +43,15 @@ railway config apply
 - Use `replicas` for scaling; advanced placement can still specify region names.
 - Use `group("Name", [resources])` to keep large projects organized on the Railway canvas.
 - Secrets imported from Railway are rendered as `preserve()` so existing values are retained without writing secret values to source. Use `railway config pull --omit-preserved-variables` for a smaller import.
+- Custom domains are managed separately with `railway domain`; the current CLI planner rejects custom-domain registration in IaC even though the SDK reference documents `domains`.
+- The GitHub Actions workflow applies only after pushes to `dev` or `master`; pull requests run plan-only checks.
+
+## GitHub Actions setup
+
+Create GitHub Environments named `dev` and `production`. In each environment configure:
+
+- Secret `RAILWAY_TOKEN`: a Railway project token for CallCaster.
+- Variable `RAILWAY_PROJECT_ID`: `32b36c6c-5f3d-463b-8c7f-bbcd70351e8f`.
+- Variable `RAILWAY_ENVIRONMENT_ID`: the matching Railway environment ID.
+
+Protect the `production` GitHub Environment with required reviewers. The workflow plans pull requests and applies only pushes to the matching branch.

--- a/.railway/config/shared.ts
+++ b/.railway/config/shared.ts
@@ -1,0 +1,11 @@
+import { github, preserve } from "railway/iac";
+
+export const repository = "chester-hill-solutions/callcaster";
+
+export function source(branch: string) {
+  return github(repository, { branch, checkSuites: false });
+}
+
+export function preservedVariables(names: readonly string[]) {
+  return Object.fromEntries(names.map((name) => [name, preserve()]));
+}

--- a/.railway/environments/dev.ts
+++ b/.railway/environments/dev.ts
@@ -1,0 +1,88 @@
+import { bucket, postgres, service, volume } from "railway/iac";
+import { preservedVariables, source } from "../config/shared.js";
+
+const appVariables = [
+  "BASE_URL",
+  "BETTER_AUTH_SECRET",
+  "BETTER_AUTH_URL",
+  "COHERE_API_KEY",
+  "DATABASE_URL",
+  "DISABLE_2FA_ENFORCEMENT",
+  "ELEVENLABS_API_KEY",
+  "HOST",
+  "NODE_ENV",
+  "PORT",
+  "RESEND_API_KEY",
+  "RUN_CLIENT_MIGRATIONS_ON_BOOT",
+  "S3_ACCESS_KEY_ID",
+  "S3_BUCKET",
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_SECRET_ACCESS_KEY",
+  "SIGNUP_OPEN",
+  "STRIPE_API_KEY",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "TWILIO_API_KEY",
+  "TWILIO_API_SECRET",
+  "TWILIO_APP_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_PHONE_NUMBER",
+  "TWILIO_SID",
+] as const;
+
+const workerVariables = [
+  "BASE_URL",
+  "BETTER_AUTH_SECRET",
+  "DATABASE_URL",
+  "NODE_ENV",
+  "RAILWAY_DOCKERFILE_PATH",
+  "RESEND_API_KEY",
+  "S3_ACCESS_KEY_ID",
+  "S3_BUCKET",
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_SECRET_ACCESS_KEY",
+  "STRIPE_SECRET_KEY",
+  "TWILIO_APP_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_PHONE_NUMBER",
+  "TWILIO_SID",
+] as const;
+
+export function devResources() {
+  const appSource = source("dev");
+  // The live dev database uses this custom image; the SDK type omits the option.
+  // @ts-expect-error Railway's runtime supports an image override for database helpers.
+  const database = postgres("PostgreSQL 18", {
+    image: "xlab/postgres-ssl-18:latest",
+    region: "us-east4-eqdc4a",
+  });
+  const databaseVolume = volume("postgresql-18-volume", {
+    alerts: { usage: { "100": {}, "80": {}, "95": {} } },
+    allowOnlineResize: true,
+    region: "us-east4-eqdc4a",
+    sizeMB: 50000,
+  });
+  const uploads = bucket("callcaster", { region: "iad" });
+  const app = service("CallCaster", {
+    source: appSource,
+    healthcheck: "/readyz",
+    healthcheckTimeout: 30,
+    replicas: { "us-east4-eqdc4a": 1 },
+    networking: { privateNetworkEndpoint: "callcaster-review" },
+    env: preservedVariables(appVariables),
+  });
+  const worker = service("callcaster-worker", {
+    source: appSource,
+    build: {
+      buildEnvironment: "V3",
+      builder: "DOCKERFILE",
+      dockerfilePath: "Dockerfile.worker",
+    },
+    replicas: { "us-east4-eqdc4a": 1 },
+    env: preservedVariables(workerVariables),
+  });
+
+  return [database, app, worker, databaseVolume, uploads];
+}

--- a/.railway/environments/production.ts
+++ b/.railway/environments/production.ts
@@ -26,7 +26,7 @@ const appVariables = [
 
 export function productionResources() {
   const app = service("callcaster", {
-    source: source("master"),
+    source: source("prod"),
     build: { buildEnvironment: "V2", builder: "NIXPACKS" },
     replicas: { "us-east4-eqdc4a": 1 },
     env: preservedVariables(appVariables),

--- a/.railway/environments/production.ts
+++ b/.railway/environments/production.ts
@@ -26,7 +26,9 @@ const appVariables = [
 
 export function productionResources() {
   const app = service("callcaster", {
-    source: source("prod"),
+    // Deploy branch renamed prod → production 2026-08-18 (#1300); the Railway
+    // service still points at the deleted `prod` until this is applied.
+    source: source("production"),
     build: { buildEnvironment: "V2", builder: "NIXPACKS" },
     replicas: { "us-east4-eqdc4a": 1 },
     env: preservedVariables(appVariables),

--- a/.railway/environments/production.ts
+++ b/.railway/environments/production.ts
@@ -1,0 +1,42 @@
+import { postgres, service, volume } from "railway/iac";
+import { preservedVariables, source } from "../config/shared.js";
+
+const appVariables = [
+  "BASE_URL",
+  "DATABASE_DIRECT_URL",
+  "DATABASE_URL",
+  "OPENAI_API_KEY",
+  "RESEND_API_KEY",
+  "STRIPE_API_KEY",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_PUBLISHABLE_KEY",
+  "SUPABASE_SECRET_KEY",
+  "SUPABASE_SERVICE_KEY",
+  "SUPABASE_SKEY",
+  "SUPABASE_URL",
+  "TWILIO_API_KEY",
+  "TWILIO_API_SECRET",
+  "TWILIO_APP_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_PHONE_NUMBER",
+  "TWILIO_SID",
+] as const;
+
+export function productionResources() {
+  const app = service("callcaster", {
+    source: source("master"),
+    build: { buildEnvironment: "V2", builder: "NIXPACKS" },
+    replicas: { "us-east4-eqdc4a": 1 },
+    env: preservedVariables(appVariables),
+  });
+  const database = postgres("Postgres-jAO4", { region: "us-east4-eqdc4a" });
+  const legacyDatabase = postgres("Postgres", { region: "us-east4-eqdc4a" });
+  const databaseVolume = volume("postgres-volume", {
+    region: "us-east4-eqdc4a",
+    sizeMB: 50000,
+  });
+
+  return [database, legacyDatabase, app, databaseVolume];
+}

--- a/.railway/environments/staging.ts
+++ b/.railway/environments/staging.ts
@@ -1,0 +1,38 @@
+import { service } from "railway/iac";
+import { preservedVariables, source } from "../config/shared.js";
+
+const appVariables = [
+  "BASE_URL",
+  "OPENAI_API_KEY",
+  "RESEND_API_KEY",
+  "SENDGRID_API_KEY",
+  "STRIPE_API_KEY",
+  "STRIPE_SECRET_KEY",
+  "SUPABASE_ANON_KEY",
+  "SUPABASE_PUBLISHABLE_KEY",
+  "SUPABASE_SECRET_KEY",
+  "SUPABASE_SERVICE_KEY",
+  "SUPABASE_SKEY",
+  "SUPABASE_URL",
+  "TWILIO_API_KEY",
+  "TWILIO_API_SECRET",
+  "TWILIO_APP_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_PHONE_NUMBER",
+  "TWILIO_SID",
+] as const;
+
+export function stagingResources() {
+  // Models staging exactly as it runs today: the Supabase-era app deployed
+  // from `master`, no database services. Phase 2 of #1300 replaces this with
+  // the v2 topology (app + worker + PostgreSQL) via a reviewed, destructive
+  // apply — do not "align" it here as a side effect of an unrelated change.
+  const app = service("hearty-expression", {
+    source: source("master"),
+    build: { builder: "NIXPACKS" },
+    replicas: { "us-west2": 1 },
+    env: preservedVariables(appVariables),
+  });
+
+  return [app];
+}

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -1,0 +1,72 @@
+import { bucket, defineRailway, github, postgres, preserve, project, service, volume } from "railway/iac";
+
+export default defineRailway(() => {
+  const callcaster = github("chester-hill-solutions/callcaster", { branch: "dev", checkSuites: false });
+
+  const PostgreSQL18 = postgres("PostgreSQL 18", { region: "us-east4-eqdc4a" });
+  const postgresql18Volume = volume("postgresql-18-volume", { alerts: { usage: { "100": {}, "80": {}, "95": {} } }, allowOnlineResize: true, region: "us-east4-eqdc4a", sizeMB: 50000 });
+  const callcasterBucket = bucket("callcaster", { region: "iad" });
+  const CallCaster = service("CallCaster", {
+    source: callcaster,
+    healthcheck: "/readyz",
+    healthcheckTimeout: 30,
+    replicas: { "us-east4-eqdc4a": 1 },
+    networking: { privateNetworkEndpoint: "callcaster-review" },
+    env: {
+      BASE_URL: preserve(),
+      BETTER_AUTH_SECRET: preserve(),
+      BETTER_AUTH_URL: preserve(),
+      COHERE_API_KEY: preserve(),
+      DATABASE_URL: preserve(),
+      DISABLE_2FA_ENFORCEMENT: preserve(),
+      ELEVENLABS_API_KEY: preserve(),
+      HOST: preserve(),
+      NODE_ENV: preserve(),
+      PORT: preserve(),
+      RESEND_API_KEY: preserve(),
+      RUN_CLIENT_MIGRATIONS_ON_BOOT: preserve(),
+      S3_ACCESS_KEY_ID: preserve(),
+      S3_BUCKET: preserve(),
+      S3_ENDPOINT: preserve(),
+      S3_REGION: preserve(),
+      S3_SECRET_ACCESS_KEY: preserve(),
+      SIGNUP_OPEN: preserve(),
+      STRIPE_API_KEY: preserve(),
+      STRIPE_SECRET_KEY: preserve(),
+      STRIPE_WEBHOOK_SECRET: preserve(),
+      TWILIO_API_KEY: preserve(),
+      TWILIO_API_SECRET: preserve(),
+      TWILIO_APP_SID: preserve(),
+      TWILIO_AUTH_TOKEN: preserve(),
+      TWILIO_PHONE_NUMBER: preserve(),
+      TWILIO_SID: preserve(),
+    },
+  });
+  const callcasterWorker = service("callcaster-worker", {
+    source: callcaster,
+    build: { buildEnvironment: "V3", builder: "DOCKERFILE", dockerfilePath: "Dockerfile.worker" },
+    replicas: { "us-east4-eqdc4a": 1 },
+    env: {
+      BASE_URL: preserve(),
+      BETTER_AUTH_SECRET: preserve(),
+      DATABASE_URL: preserve(),
+      NODE_ENV: preserve(),
+      RAILWAY_DOCKERFILE_PATH: preserve(),
+      RESEND_API_KEY: preserve(),
+      S3_ACCESS_KEY_ID: preserve(),
+      S3_BUCKET: preserve(),
+      S3_ENDPOINT: preserve(),
+      S3_REGION: preserve(),
+      S3_SECRET_ACCESS_KEY: preserve(),
+      STRIPE_SECRET_KEY: preserve(),
+      TWILIO_APP_SID: preserve(),
+      TWILIO_AUTH_TOKEN: preserve(),
+      TWILIO_PHONE_NUMBER: preserve(),
+      TWILIO_SID: preserve(),
+    },
+  });
+
+  return project("CallCaster", {
+    resources: [PostgreSQL18, CallCaster, callcasterWorker, postgresql18Volume, callcasterBucket],
+  });
+});

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -10,6 +10,7 @@ export default defineRailway(() => {
     source: callcaster,
     healthcheck: "/readyz",
     healthcheckTimeout: 30,
+    domains: ["dev.callcaster.ca"],
     replicas: { "us-east4-eqdc4a": 1 },
     networking: { privateNetworkEndpoint: "callcaster-review" },
     env: {

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -1,73 +1,11 @@
-import { bucket, defineRailway, github, postgres, preserve, project, service, volume } from "railway/iac";
+import { defineRailway, project } from "railway/iac";
+import { devResources } from "./environments/dev.js";
+import { productionResources } from "./environments/production.js";
 
-export default defineRailway(() => {
-  const callcaster = github("chester-hill-solutions/callcaster", { branch: "dev", checkSuites: false });
+export default defineRailway((ctx) => {
+  const resources = ctx.isEnvironment("production")
+    ? productionResources()
+    : devResources();
 
-  const PostgreSQL18 = postgres("PostgreSQL 18", { region: "us-east4-eqdc4a" });
-  const postgresql18Volume = volume("postgresql-18-volume", { alerts: { usage: { "100": {}, "80": {}, "95": {} } }, allowOnlineResize: true, region: "us-east4-eqdc4a", sizeMB: 50000 });
-  const callcasterBucket = bucket("callcaster", { region: "iad" });
-  const CallCaster = service("CallCaster", {
-    source: callcaster,
-    healthcheck: "/readyz",
-    healthcheckTimeout: 30,
-    domains: ["dev.callcaster.ca"],
-    replicas: { "us-east4-eqdc4a": 1 },
-    networking: { privateNetworkEndpoint: "callcaster-review" },
-    env: {
-      BASE_URL: preserve(),
-      BETTER_AUTH_SECRET: preserve(),
-      BETTER_AUTH_URL: preserve(),
-      COHERE_API_KEY: preserve(),
-      DATABASE_URL: preserve(),
-      DISABLE_2FA_ENFORCEMENT: preserve(),
-      ELEVENLABS_API_KEY: preserve(),
-      HOST: preserve(),
-      NODE_ENV: preserve(),
-      PORT: preserve(),
-      RESEND_API_KEY: preserve(),
-      RUN_CLIENT_MIGRATIONS_ON_BOOT: preserve(),
-      S3_ACCESS_KEY_ID: preserve(),
-      S3_BUCKET: preserve(),
-      S3_ENDPOINT: preserve(),
-      S3_REGION: preserve(),
-      S3_SECRET_ACCESS_KEY: preserve(),
-      SIGNUP_OPEN: preserve(),
-      STRIPE_API_KEY: preserve(),
-      STRIPE_SECRET_KEY: preserve(),
-      STRIPE_WEBHOOK_SECRET: preserve(),
-      TWILIO_API_KEY: preserve(),
-      TWILIO_API_SECRET: preserve(),
-      TWILIO_APP_SID: preserve(),
-      TWILIO_AUTH_TOKEN: preserve(),
-      TWILIO_PHONE_NUMBER: preserve(),
-      TWILIO_SID: preserve(),
-    },
-  });
-  const callcasterWorker = service("callcaster-worker", {
-    source: callcaster,
-    build: { buildEnvironment: "V3", builder: "DOCKERFILE", dockerfilePath: "Dockerfile.worker" },
-    replicas: { "us-east4-eqdc4a": 1 },
-    env: {
-      BASE_URL: preserve(),
-      BETTER_AUTH_SECRET: preserve(),
-      DATABASE_URL: preserve(),
-      NODE_ENV: preserve(),
-      RAILWAY_DOCKERFILE_PATH: preserve(),
-      RESEND_API_KEY: preserve(),
-      S3_ACCESS_KEY_ID: preserve(),
-      S3_BUCKET: preserve(),
-      S3_ENDPOINT: preserve(),
-      S3_REGION: preserve(),
-      S3_SECRET_ACCESS_KEY: preserve(),
-      STRIPE_SECRET_KEY: preserve(),
-      TWILIO_APP_SID: preserve(),
-      TWILIO_AUTH_TOKEN: preserve(),
-      TWILIO_PHONE_NUMBER: preserve(),
-      TWILIO_SID: preserve(),
-    },
-  });
-
-  return project("CallCaster", {
-    resources: [PostgreSQL18, CallCaster, callcasterWorker, postgresql18Volume, callcasterBucket],
-  });
+  return project("CallCaster", { resources });
 });

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -1,26 +1,31 @@
 import { defineRailway, project } from "railway/iac";
 import { devResources } from "./environments/dev.js";
 import { productionResources } from "./environments/production.js";
+import { stagingResources } from "./environments/staging.js";
 
 export default defineRailway((ctx) => {
   if (ctx.isEnvironment("production")) {
     return project("CallCaster", { resources: productionResources() });
   }
+  if (ctx.isEnvironment("staging")) {
+    return project("CallCaster", { resources: stagingResources() });
+  }
   if (ctx.isEnvironment("dev")) {
     return project("CallCaster", { resources: devResources() });
   }
 
-  // Only `dev` and `production` are modelled. Every other environment —
-  // `staging` and the ephemeral `callcaster-pr-*` review envs — must NOT fall
+  // Only `dev`, `staging`, and `production` are modelled. Every other
+  // environment — the ephemeral `callcaster-pr-*` review envs — must NOT fall
   // back to the dev topology. Planning one as a dev clone would create dev's
   // services AND delete whatever that environment actually runs: verified
   // 2026-08-07 that `staging` would have destroyed its `hearty-expression`
-  // service. Refuse instead of guessing; the CI workflow only ever links `dev`
-  // or `production`, so this never blocks an intended apply.
+  // service before it was modelled. Refuse instead of guessing; the CI
+  // workflow only ever links modelled environments, so this never blocks an
+  // intended apply.
   throw new Error(
-    `Railway IaC manages only the 'dev' and 'production' environments. ` +
-      `Refusing to plan '${ctx.environmentName ?? "unknown"}' to avoid ` +
-      `applying it as a dev clone. Model it explicitly in ` +
+    `Railway IaC manages only the 'dev', 'staging', and 'production' ` +
+      `environments. Refusing to plan '${ctx.environmentName ?? "unknown"}' ` +
+      `to avoid applying it as a dev clone. Model it explicitly in ` +
       `.railway/environments/ before managing it with IaC.`,
   );
 });

--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -3,9 +3,24 @@ import { devResources } from "./environments/dev.js";
 import { productionResources } from "./environments/production.js";
 
 export default defineRailway((ctx) => {
-  const resources = ctx.isEnvironment("production")
-    ? productionResources()
-    : devResources();
+  if (ctx.isEnvironment("production")) {
+    return project("CallCaster", { resources: productionResources() });
+  }
+  if (ctx.isEnvironment("dev")) {
+    return project("CallCaster", { resources: devResources() });
+  }
 
-  return project("CallCaster", { resources });
+  // Only `dev` and `production` are modelled. Every other environment —
+  // `staging` and the ephemeral `callcaster-pr-*` review envs — must NOT fall
+  // back to the dev topology. Planning one as a dev clone would create dev's
+  // services AND delete whatever that environment actually runs: verified
+  // 2026-08-07 that `staging` would have destroyed its `hearty-expression`
+  // service. Refuse instead of guessing; the CI workflow only ever links `dev`
+  // or `production`, so this never blocks an intended apply.
+  throw new Error(
+    `Railway IaC manages only the 'dev' and 'production' environments. ` +
+      `Refusing to plan '${ctx.environmentName ?? "unknown"}' to avoid ` +
+      `applying it as a dev clone. Model it explicitly in ` +
+      `.railway/environments/ before managing it with IaC.`,
+  );
 });

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "postcss": "^8.5.25",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.14",
+        "railway": "^3.8.1",
         "remix-flat-routes": "^0.8.5",
         "shadcn": "^4.13.1",
         "tailwindcss": "^4",
@@ -418,6 +419,8 @@
     "@floating-ui/vue": ["@floating-ui/vue@1.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.7.4", "@floating-ui/utils": "^0.2.10", "vue-demi": ">=0.13.0" } }, "sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ=="],
 
     "@fontsource/zilla-slab": ["@fontsource/zilla-slab@5.2.8", "", {}, "sha512-S4wZ1IpJNMFd+FEcS6lwci3Ine/JivSRaMb0SzhE43b/gOmDKnylNfXjIxc7GmAiqAJlz0jOauxiuy085DQdNw=="],
+
+    "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
     "@headlessui/tailwindcss": ["@headlessui/tailwindcss@0.2.2", "", { "peerDependencies": { "tailwindcss": "^3.0 || ^4.0" } }, "sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw=="],
 
@@ -1479,6 +1482,8 @@
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
+    "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
+
     "guess-json-indent": ["guess-json-indent@3.0.1", "", {}, "sha512-LWZ3Vr8BG7DHE3TzPYFqkhjNRw4vYgFSsv2nfMuHklAlOfiy54/EwiDQuQfFVLxENCVv20wpbjfTayooQHrEhQ=="],
 
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
@@ -2134,6 +2139,8 @@
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "radix-vue": ["radix-vue@1.9.17", "", { "dependencies": { "@floating-ui/dom": "^1.6.7", "@floating-ui/vue": "^1.1.0", "@internationalized/date": "^3.5.4", "@internationalized/number": "^3.5.3", "@tanstack/vue-virtual": "^3.8.1", "@vueuse/core": "^10.11.0", "@vueuse/shared": "^10.11.0", "aria-hidden": "^1.2.4", "defu": "^6.1.4", "fast-deep-equal": "^3.1.3", "nanoid": "^5.0.7" }, "peerDependencies": { "vue": ">= 3.2.0" } }, "sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ=="],
+
+    "railway": ["railway@3.10.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "graphql": "^16.10.0", "tsx": "^4.20.0" }, "bin": { "railway-iac-ts": "dist/iac/bin.js" } }, "sha512-yQtWGFkeGpIdyfwiQQOkWHLfXvSQH7gW6kz83nlre+ZeH9J1J8vX03pzL4zseTLbLKx2AhWs/e/6lZPASGogEw=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "postcss": "^8.5.25",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.14",
+        "railway": "^3.8.1",
         "remix-flat-routes": "^0.8.5",
         "shadcn": "^4.13.1",
         "tailwindcss": "^4",
@@ -1663,9 +1664,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1680,9 +1678,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2659,6 +2654,16 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@headlessui/tailwindcss": {
@@ -4863,9 +4868,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4880,9 +4882,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4897,9 +4896,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4914,9 +4910,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4931,9 +4924,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4948,9 +4938,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4965,9 +4952,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4982,9 +4966,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4999,9 +4980,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5016,9 +4994,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5033,9 +5008,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5050,9 +5022,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5067,9 +5036,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6044,9 +6010,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6064,9 +6027,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6084,9 +6044,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6104,9 +6061,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6986,9 +6940,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7003,9 +6954,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7020,9 +6968,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7037,9 +6982,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7054,9 +6996,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7071,9 +7010,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7088,9 +7024,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7105,9 +7038,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7122,9 +7052,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7139,9 +7066,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11969,6 +11893,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/guess-json-indent": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/guess-json-indent/-/guess-json-indent-3.0.1.tgz",
@@ -13520,9 +13454,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13537,9 +13468,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13554,9 +13482,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13994,9 +13919,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14018,9 +13940,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14042,9 +13961,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14066,9 +13982,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16905,6 +16818,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/railway": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/railway/-/railway-3.8.1.tgz",
+      "integrity": "sha512-Rjxa0RM2e2G2l4po6PCI0+f2dltNV4MkmaZY0mGtFwCKMrvotb5hvd08Vsmy3MXGLRBsnR4bpno1xmrjFRd9zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "graphql": "^16.10.0",
+        "tsx": "^4.20.0"
+      },
+      "bin": {
+        "railway-iac-ts": "dist/iac/bin.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/range-parser": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,8 @@
     "vitest": "^4.0.18",
     "@tailwindcss/vite": "^4",
     "tw-animate-css": "^1.4.0",
-    "shadcn": "^4.13.1"
+    "shadcn": "^4.13.1",
+    "railway": "^3.8.1"
   },
   "engines": {
     "node": "22.x",


### PR DESCRIPTION
Supersedes #1147 (rebased onto current dev, all five commits preserved) and extends it so **all three long-lived Railway environments are modelled**:

- `dev` — v2 stack (CallCaster + callcaster-worker + PostgreSQL 18), deploys from `dev`
- `staging` — **new**: modelled exactly as it runs today (Supabase-era `hearty-expression` from `master`, us-west2, no DB). Modelling reality first means IaC coverage lands with a zero-change plan; turning staging into a v2 mirror of dev is phase 2 of #1300 and will be its own reviewed, destructive apply.
- `production` — Supabase-era app from `prod` + both Postgres services (unchanged from #1147)
- everything else (`callcaster-pr-*`) still refuses to plan rather than falling back to a dev clone

CI: dev and production keep plan-on-PR / apply-on-push; the new `staging` job **plans only** (staging has no promotion branch yet, so applies stay manual).

## Validated read-only against live Railway (2026-08-18)

| Environment | `railway config plan` |
|---|---|
| `dev` | ✅ already up to date — 0 changes |
| `staging` | ✅ already up to date — 0 changes |
| `production` | ✅ already up to date — 0 changes |

## Still blocked on repo settings (maintainer action)

The plan/apply jobs need, per GitHub *environment* (`dev`, `production`, and now `staging`):
- secret `RAILWAY_TOKEN` (project token)
- vars `RAILWAY_PROJECT_ID` (`32b36c6c-5f3d-463b-8c7f-bbcd70351e8f`) and `RAILWAY_ENVIRONMENT_ID` (dev `18ef9173…`, staging `3dc12c7d…`, production `793b0ad1…`)

Until those exist the IaC jobs fail with `Unauthorized` — same blocker #1147 has carried since 2026-08-14.

Also note: `origin/prod` was deleted, so production **cannot currently redeploy from source**; the modelled `source("prod")` matches the service's configured branch but any redeploy will fail until the branch is restored or phase 3 of #1300 repoints it.

Part of #1300. Closes #1177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)