### PR TITLE
fix(iac): staging is a Railway env, not a branch stage

### DIFF
--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -1,18 +1,20 @@
 name: Railway IaC
 
-# Promotion pipeline (#1300): dev → master (staging) → production.
-# Each environment applies on pushes to its own branch and plans on PRs
-# targeting it; staging additionally plans on dev PRs for early drift checks.
+# Promotion (#1300): dev → production. Staging is not a branch — it is a
+# Railway environment mirroring production with test-mode Stripe keys, so it
+# plans/applies alongside production and additionally plans on dev PRs for
+# early drift checks. master is just the GitHub default branch; only the
+# legacy staging service still watches it until phase 2 replaces that.
 on:
   push:
-    branches: [dev, master, production]
+    branches: [dev, production]
     paths:
       - ".railway/**"
       - ".github/workflows/railway-iac.yml"
       - "package.json"
       - "package-lock.json"
   pull_request:
-    branches: [dev, master, production]
+    branches: [dev, production]
     paths:
       - ".railway/**"
       - ".github/workflows/railway-iac.yml"
@@ -66,14 +68,11 @@ jobs:
         if: github.event_name == 'push'
         run: railway config apply --file "$GITHUB_WORKSPACE/.railway/railway.ts" --yes
 
-  # Staging deploys from `master` (the promotion branch: dev → master →
-  # production). Applies on master pushes; plans on PRs to master and, as an
-  # early drift check, on PRs to dev.
   staging:
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/production') ||
       (github.event_name == 'pull_request' &&
-      (github.base_ref == 'dev' || github.base_ref == 'master') &&
+      (github.base_ref == 'dev' || github.base_ref == 'production') &&
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     environment: staging

--- a/.railway/environments/staging.ts
+++ b/.railway/environments/staging.ts
@@ -25,8 +25,10 @@ const appVariables = [
 export function stagingResources() {
   // Models staging exactly as it runs today: the Supabase-era app deployed
   // from `master`, no database services. Phase 2 of #1300 replaces this with
-  // the v2 topology (app + worker + PostgreSQL) via a reviewed, destructive
-  // apply — do not "align" it here as a side effect of an unrelated change.
+  // the v2 topology (app + worker + PostgreSQL) sourced from the `production`
+  // branch — staging is a Railway environment mirroring production with
+  // test-mode Stripe keys, not a promotion-branch stage. Destructive apply,
+  // human-reviewed only; do not "align" it as a side effect.
   const app = service("hearty-expression", {
     source: source("master"),
     build: { builder: "NIXPACKS" },


### PR DESCRIPTION
Design refinement from Nathaniel on #1300: staging is **not a promotion branch** — it's a Railway environment mirroring production with test-mode Stripe keys.

- Promotion is simply `dev` → `production`.
- The staging IaC job now plans on PRs to dev/production and applies on `production` pushes (previously keyed off `master`).
- `master` returns to being just the GitHub default branch; only the legacy `hearty-expression` service still deploys from it, until phase 2 rebuilds staging's topology sourced from the `production` branch.
- Staging model unchanged (still as-is); only comments updated to reflect the phase-2 target source.

Part of #1300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)