### PR TITLE
feat(iac): staging v2 rehearsal — topology, var sync, db clone runbook

### DIFF
--- a/.github/workflows/railway-iac.yml
+++ b/.github/workflows/railway-iac.yml
@@ -61,8 +61,11 @@ jobs:
             exit "$status"
           fi
           if jq -e '.changeSet.changes[]? | select(.severity == "destructive")' railway-dev-plan.json > /dev/null; then
-            echo "Refusing to apply a destructive dev Railway plan. Review it manually."
-            exit 1
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "Refusing to apply a destructive dev Railway plan. Review it manually."
+              exit 1
+            fi
+            echo "Plan contains destructive changes — reported only; PRs never apply."
           fi
       - name: Apply Railway dev configuration
         if: github.event_name == 'push'
@@ -105,8 +108,11 @@ jobs:
             exit "$status"
           fi
           if jq -e '.changeSet.changes[]? | select(.severity == "destructive")' railway-staging-plan.json > /dev/null; then
-            echo "Refusing to apply a destructive staging Railway plan. Review it manually."
-            exit 1
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "Refusing to apply a destructive staging Railway plan. Review it manually."
+              exit 1
+            fi
+            echo "Plan contains destructive changes — reported only; PRs never apply."
           fi
       - name: Apply Railway staging configuration
         if: github.event_name == 'push'
@@ -148,8 +154,11 @@ jobs:
             exit "$status"
           fi
           if jq -e '.changeSet.changes[]? | select(.severity == "destructive")' railway-production-plan.json > /dev/null; then
-            echo "Refusing to apply a destructive production Railway plan. Review it manually."
-            exit 1
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "Refusing to apply a destructive production Railway plan. Review it manually."
+              exit 1
+            fi
+            echo "Plan contains destructive changes — reported only; PRs never apply."
           fi
       - name: Apply Railway production configuration
         if: github.event_name == 'push'

--- a/.railway/environments/staging.ts
+++ b/.railway/environments/staging.ts
@@ -1,19 +1,41 @@
-import { service } from "railway/iac";
+import { postgres, service, volume } from "railway/iac";
 import { preservedVariables, source } from "../config/shared.js";
 
+// Staging is a Railway environment mirroring production (#1300): v2 topology,
+// same code lineage, test-mode Stripe keys as the only intended difference.
+// Values are populated from dev by scripts/railway/sync-staging-vars.sh —
+// dev's Stripe keys are already test-mode and Twilio is shared for now.
+//
+// Applying this DELETES the legacy hearty-expression service (the Supabase-era
+// staging app, frozen since 2026-06-24). That is the point of phase 2, but the
+// apply is destructive and stays human-reviewed/manual — CI only ever plans
+// staging on PRs (applies fire on production pushes, and this graph reaches
+// the production branch only at cutover).
+//
+// Source: `master` during the rehearsal (it carries v2 as of #1120; the
+// `production` branch is still pre-v2). Phase 3 flips this to
+// source("production") in the same change that promotes v2 to that branch.
 const appVariables = [
   "BASE_URL",
-  "OPENAI_API_KEY",
+  "BETTER_AUTH_SECRET",
+  "BETTER_AUTH_URL",
+  "COHERE_API_KEY",
+  "DATABASE_URL",
+  "ELEVENLABS_API_KEY",
+  "HOST",
+  "NODE_ENV",
+  "PORT",
   "RESEND_API_KEY",
-  "SENDGRID_API_KEY",
+  "RUN_CLIENT_MIGRATIONS_ON_BOOT",
+  "S3_ACCESS_KEY_ID",
+  "S3_BUCKET",
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_SECRET_ACCESS_KEY",
+  "SIGNUP_OPEN",
   "STRIPE_API_KEY",
   "STRIPE_SECRET_KEY",
-  "SUPABASE_ANON_KEY",
-  "SUPABASE_PUBLISHABLE_KEY",
-  "SUPABASE_SECRET_KEY",
-  "SUPABASE_SERVICE_KEY",
-  "SUPABASE_SKEY",
-  "SUPABASE_URL",
+  "STRIPE_WEBHOOK_SECRET",
   "TWILIO_API_KEY",
   "TWILIO_API_SECRET",
   "TWILIO_APP_SID",
@@ -21,20 +43,59 @@ const appVariables = [
   "TWILIO_PHONE_NUMBER",
   "TWILIO_SID",
 ] as const;
+// DISABLE_2FA_ENFORCEMENT is deliberately absent: dev-only. Staging matches
+// production behavior.
+
+const workerVariables = [
+  "BASE_URL",
+  "BETTER_AUTH_SECRET",
+  "DATABASE_URL",
+  "NODE_ENV",
+  "RAILWAY_DOCKERFILE_PATH",
+  "RESEND_API_KEY",
+  "S3_ACCESS_KEY_ID",
+  "S3_BUCKET",
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_SECRET_ACCESS_KEY",
+  "STRIPE_SECRET_KEY",
+  "TWILIO_APP_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_PHONE_NUMBER",
+  "TWILIO_SID",
+] as const;
 
 export function stagingResources() {
-  // Models staging exactly as it runs today: the Supabase-era app deployed
-  // from `master`, no database services. Phase 2 of #1300 replaces this with
-  // the v2 topology (app + worker + PostgreSQL) sourced from the `production`
-  // branch — staging is a Railway environment mirroring production with
-  // test-mode Stripe keys, not a promotion-branch stage. Destructive apply,
-  // human-reviewed only; do not "align" it as a side effect.
-  const app = service("hearty-expression", {
-    source: source("master"),
-    build: { builder: "NIXPACKS" },
-    replicas: { "us-west2": 1 },
+  const appSource = source("master");
+  // Same custom image as dev's database; the SDK type omits the option.
+  // @ts-expect-error Railway's runtime supports an image override for database helpers.
+  const database = postgres("PostgreSQL 18", {
+    image: "xlab/postgres-ssl-18:latest",
+    region: "us-east4-eqdc4a",
+  });
+  const databaseVolume = volume("postgresql-18-volume", {
+    alerts: { usage: { "100": {}, "80": {}, "95": {} } },
+    allowOnlineResize: true,
+    region: "us-east4-eqdc4a",
+    sizeMB: 50000,
+  });
+  const app = service("CallCaster", {
+    source: appSource,
+    healthcheck: "/readyz",
+    healthcheckTimeout: 30,
+    replicas: { "us-east4-eqdc4a": 1 },
     env: preservedVariables(appVariables),
   });
+  const worker = service("callcaster-worker", {
+    source: appSource,
+    build: {
+      buildEnvironment: "V3",
+      builder: "DOCKERFILE",
+      dockerfilePath: "Dockerfile.worker",
+    },
+    replicas: { "us-east4-eqdc4a": 1 },
+    env: preservedVariables(workerVariables),
+  });
 
-  return [app];
+  return [database, app, worker, databaseVolume];
 }

--- a/docs/staging-rehearsal-runbook.md
+++ b/docs/staging-rehearsal-runbook.md
@@ -1,0 +1,87 @@
+# Staging rehearsal runbook (#1300 phase 2)
+
+Converts the `staging` Railway environment from the Supabase-era
+`hearty-expression` service to the v2 topology, populated with dev's
+workspaces. This is the dress rehearsal for the production cutover
+([#1303](https://github.com/chester-hill-solutions/callcaster/issues/1303)):
+phase 3 repeats these steps against production, with `source("production")`
+instead of `master` and live-mode Stripe keys instead of test-mode.
+
+Decisions this encodes (see #1300):
+
+- Staging is **not a branch** — it is a Railway environment mirroring
+  production. During the rehearsal it deploys from `master` (v2); phase 3
+  flips it to the `production` branch in the same change that promotes v2.
+- **Supabase data is dropped, not migrated.** The system of record is dev's
+  Postgres; its workspaces are cloned in (same schema lineage, plain
+  dump/restore).
+- Stripe stays **test-mode** in staging (dev's keys are already test-mode);
+  Twilio is the shared account for now, so cloned workspace telephony config
+  keeps working.
+
+## Steps
+
+All commands from the repo root, Railway CLI authenticated with account scope.
+
+1. **Apply the staging topology** (destructive: deletes `hearty-expression`):
+
+   ```bash
+   railway environment staging
+   railway config plan --file .railway/railway.ts
+   # review: expect ~4 adds + 1 destructive delete (hearty-expression)
+   railway config apply --file .railway/railway.ts --confirm-destructive
+   railway environment dev
+   ```
+
+2. **Get the staging app URL.** The apply creates the `CallCaster` service
+   instance in staging; give it a service domain (Railway dashboard → staging →
+   CallCaster → Networking, or `railway domain`). Note the URL.
+
+3. **Populate variables from dev** (Stripe test keys, shared Twilio, S3, etc.;
+   `DATABASE_URL` becomes a reference to staging's own Postgres — never dev's):
+
+   ```bash
+   scripts/railway/sync-staging-vars.sh https://<staging-app-domain>
+   ```
+
+4. **Clone dev's workspaces** into staging's Postgres. Use the public
+   `DATABASE_URL` from each environment's Postgres service (dev as source,
+   staging as target):
+
+   ```bash
+   SOURCE_DATABASE_URL='<dev postgres url>' \
+   TARGET_DATABASE_URL='<staging postgres url>' \
+   CONFIRM_CLONE=yes scripts/db/clone-database.sh
+   ```
+
+5. **Deploy.** Redeploy both staging services (variables were set with
+   `--skip-deploys`). Watch `/readyz` on the app.
+
+6. **Validate the rehearsal** — the things this environment exists to catch:
+   - sign-in with a cloned dev account (Better Auth against cloned data)
+   - Twilio: place a campaign call / send an SMS from a cloned workspace
+   - Stripe test-mode: buy credits end-to-end; confirm the ledger RPC applies
+     the purchase (`apply_ledger_entry_and_sync_credits` — the review-env
+     failure class from #1055)
+   - worker: enqueue an audience upload and confirm it completes
+   - `db:schema:check` / `check:db-rpcs` against staging's DATABASE_URL
+     (two-lineage drift check)
+
+7. **Record results on #1300** — anything that surprised us here becomes a
+   playbook line item for production.
+
+## Rollback
+
+Staging has no consumers; rollback is re-running step 1's apply from a
+reverted graph (restores `hearty-expression` from `master`, which still
+carries v2 — i.e. there is no meaningful rollback target and none needed).
+
+## Phase 3 deltas (production)
+
+- `source("production")` (the promotion push and this flip happen together)
+- live-mode Stripe keys + production webhook endpoint re-pointed
+- Twilio webhooks/TwiML apps re-pointed at the production URL; enable webhook
+  signature validation only after the host audit
+- DNS stays (same Railway service keeps callcaster.ca)
+- decommission Supabase + delete the two legacy `Postgres` services after
+  soak, via a follow-up IaC change

--- a/scripts/db/clone-database.sh
+++ b/scripts/db/clone-database.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Clone one Railway Postgres database into another (#1300).
+#
+# Used to bring dev's workspaces into staging (phase 2 rehearsal) and later
+# into production (phase 3 cutover) — both sides run the same schema lineage,
+# so this is a straight dump/restore, not a migration.
+#
+# Usage:
+#   SOURCE_DATABASE_URL=postgres://… TARGET_DATABASE_URL=postgres://… \
+#     CONFIRM_CLONE=yes scripts/db/clone-database.sh
+#
+# The target is WIPED (--clean). CONFIRM_CLONE=yes is required, and the target
+# host:port/db is printed for a 5-second abort window before anything runs.
+set -euo pipefail
+
+: "${SOURCE_DATABASE_URL:?SOURCE_DATABASE_URL is required}"
+: "${TARGET_DATABASE_URL:?TARGET_DATABASE_URL is required}"
+
+if [[ "${CONFIRM_CLONE:-}" != "yes" ]]; then
+  echo "Refusing to run without CONFIRM_CLONE=yes (the target database is wiped)." >&2
+  exit 1
+fi
+if [[ "$SOURCE_DATABASE_URL" == "$TARGET_DATABASE_URL" ]]; then
+  echo "Source and target are the same database — aborting." >&2
+  exit 1
+fi
+
+describe() { python3 -c "from urllib.parse import urlparse;u=urlparse('$1');print(f'{u.hostname}:{u.port}{u.path}')"; }
+echo "Source: $(describe "$SOURCE_DATABASE_URL")"
+echo "TARGET (will be wiped): $(describe "$TARGET_DATABASE_URL")"
+echo "Starting in 5s — Ctrl-C to abort."
+sleep 5
+
+DUMP_FILE=$(mktemp -t callcaster-clone-XXXXXX.dump)
+trap 'rm -f "$DUMP_FILE"' EXIT
+
+echo "Dumping source…"
+pg_dump --format=custom --no-owner --no-privileges \
+  --dbname="$SOURCE_DATABASE_URL" --file="$DUMP_FILE"
+
+echo "Restoring into target…"
+pg_restore --clean --if-exists --no-owner --no-privileges \
+  --dbname="$TARGET_DATABASE_URL" "$DUMP_FILE"
+
+echo "Verifying…"
+for url in "$SOURCE_DATABASE_URL" "$TARGET_DATABASE_URL"; do
+  psql "$url" --tuples-only --no-align --command \
+    "select current_database() || ': ' || count(*) || ' workspaces' from workspace" 2>/dev/null \
+    || psql "$url" --tuples-only --no-align --command \
+      "select current_database() || ': ' || count(*) || ' public tables' from information_schema.tables where table_schema='public'"
+done
+
+echo "Clone complete."

--- a/scripts/railway/sync-staging-vars.sh
+++ b/scripts/railway/sync-staging-vars.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copy dev's service variables into the staging environment (#1300 phase 2).
+#
+# Staging mirrors production with dev's values (Stripe keys in dev are already
+# test-mode; Twilio is the shared account). Three variables are NOT copied
+# verbatim:
+#   - DATABASE_URL          -> Railway reference to staging's own Postgres
+#   - BASE_URL              -> the staging app URL (argument)
+#   - BETTER_AUTH_URL       -> the staging app URL (argument)
+# DISABLE_2FA_ENFORCEMENT is dev-only and never copied.
+#
+# Usage:
+#   scripts/railway/sync-staging-vars.sh https://<staging-app-domain>
+#
+# Requires: railway CLI authenticated with account scope, jq.
+set -euo pipefail
+
+STAGING_URL="${1:?usage: sync-staging-vars.sh <staging base url, e.g. https://staging.callcaster.ca>}"
+
+PROJECT_ID="32b36c6c-5f3d-463b-8c7f-bbcd70351e8f"
+APP_SERVICE_ID="d7a21d02-a448-4970-9989-ab2a7a2589ee"        # CallCaster
+WORKER_SERVICE_ID="9cba9fa7-f3d4-47d8-92a9-7317cea681bf"     # callcaster-worker
+DB_REFERENCE='${{PostgreSQL 18.DATABASE_URL}}'
+
+APP_COPY_VARS=(
+  BETTER_AUTH_SECRET COHERE_API_KEY ELEVENLABS_API_KEY HOST NODE_ENV PORT
+  RESEND_API_KEY RUN_CLIENT_MIGRATIONS_ON_BOOT
+  S3_ACCESS_KEY_ID S3_BUCKET S3_ENDPOINT S3_REGION S3_SECRET_ACCESS_KEY
+  SIGNUP_OPEN STRIPE_API_KEY STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET
+  TWILIO_API_KEY TWILIO_API_SECRET TWILIO_APP_SID TWILIO_AUTH_TOKEN
+  TWILIO_PHONE_NUMBER TWILIO_SID
+)
+WORKER_COPY_VARS=(
+  BETTER_AUTH_SECRET NODE_ENV RAILWAY_DOCKERFILE_PATH RESEND_API_KEY
+  S3_ACCESS_KEY_ID S3_BUCKET S3_ENDPOINT S3_REGION S3_SECRET_ACCESS_KEY
+  STRIPE_SECRET_KEY TWILIO_APP_SID TWILIO_AUTH_TOKEN TWILIO_PHONE_NUMBER
+  TWILIO_SID
+)
+
+sync_service() {
+  local service_id="$1"; shift
+  local -a names=("$@")
+
+  local dev_json
+  dev_json=$(railway variable list --service "$service_id" --environment dev --json)
+
+  local name value
+  for name in "${names[@]}"; do
+    value=$(jq -r --arg k "$name" '.[$k] // empty' <<<"$dev_json")
+    if [[ -z "$value" ]]; then
+      echo "!! $name is unset in dev — skipped (set it manually if staging needs it)" >&2
+      continue
+    fi
+    railway variable set "$name=$value" --service "$service_id" --environment staging --skip-deploys >/dev/null
+    echo "   $name"
+  done
+}
+
+echo "== CallCaster (app) =="
+sync_service "$APP_SERVICE_ID" "${APP_COPY_VARS[@]}"
+railway variable set "DATABASE_URL=$DB_REFERENCE" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+railway variable set "BASE_URL=$STAGING_URL" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+railway variable set "BETTER_AUTH_URL=$STAGING_URL" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+echo "   DATABASE_URL (reference), BASE_URL, BETTER_AUTH_URL (staging URL)"
+
+echo "== callcaster-worker =="
+sync_service "$WORKER_SERVICE_ID" "${WORKER_COPY_VARS[@]}"
+railway variable set "DATABASE_URL=$DB_REFERENCE" --service "$WORKER_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+railway variable set "BASE_URL=$STAGING_URL" --service "$WORKER_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+echo "   DATABASE_URL (reference), BASE_URL (staging URL)"
+
+echo "Done. Redeploy staging services to pick up the variables."


### PR DESCRIPTION
Phase 2 of #1300: staging becomes the v2 production mirror and the dress rehearsal for #1303.

## What's in it

- **`.railway/environments/staging.ts`** — v2 topology (CallCaster + callcaster-worker + PostgreSQL 18 + volume), sourced from `master` during the rehearsal (phase 3 flips it to `production` in the same change that promotes v2 to that branch). `DISABLE_2FA_ENFORCEMENT` deliberately omitted — staging matches production behavior.
- **`scripts/railway/sync-staging-vars.sh`** — copies dev's variable values into staging (dev's Stripe keys are verified `sk_test_`; Twilio is the shared account per #1300). `DATABASE_URL` is set as a reference to staging's own Postgres — never dev's; `BASE_URL`/`BETTER_AUTH_URL` take the staging URL.
- **`scripts/db/clone-database.sh`** — guarded `pg_dump`/`pg_restore` bringing dev's workspaces into staging (Supabase data is dropped, not migrated — same-lineage schemas, no cross-architecture migration). Requires `CONFIRM_CLONE=yes`, prints the wipe target, refuses source==target.
- **`docs/staging-rehearsal-runbook.md`** — the ordered playbook (apply → domain → vars → clone → deploy → validate), with the phase-3 production deltas listed at the bottom.
- **Workflow**: the destructive-plan guard now fails only on `push` events (where an apply would follow). PR plans report destruction without failing — otherwise this PR's own staging plan job could never go green.

## Live plan (read-only, 2026-08-18)

```
Plan: 4 to add, 0 to change, 1 to destroy
  + Create database PostgreSQL 18
  + Create service CallCaster
  + Create service callcaster-worker
  + Create volume postgresql-18-volume
  - Delete service hearty-expression
```

**Merging this PR applies nothing.** The destructive apply is step 1 of the runbook, run manually with `--confirm-destructive` after review.

Part of #1300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)