### PR TITLE
fix(iac): staging models the Postgres that actually exists

### DIFF
--- a/.railway/environments/staging.ts
+++ b/.railway/environments/staging.ts
@@ -67,15 +67,13 @@ const workerVariables = [
 
 export function stagingResources() {
   const appSource = source("master");
-  // Same custom image as dev's database; the SDK type omits the option.
-  // @ts-expect-error Railway's runtime supports an image override for database helpers.
-  const database = postgres("PostgreSQL 18", {
-    image: "xlab/postgres-ssl-18:latest",
-    region: "us-east4-eqdc4a",
-  });
-  const databaseVolume = volume("postgresql-18-volume", {
-    alerts: { usage: { "100": {}, "80": {}, "95": {} } },
-    allowOnlineResize: true,
+  // Standard Railway Postgres template. The 2026-08-18 apply silently failed
+  // to create dev's custom-image database ("PostgreSQL 18" / xlab image —
+  // plans fine, never materializes), so staging got `railway add --database
+  // postgres` instead; this models what actually exists. Note for phase 3:
+  // do NOT model a custom-image database for a fresh environment.
+  const database = postgres("Postgres-mgzk", { region: "us-east4-eqdc4a" });
+  const databaseVolume = volume("postgres-volume-uPSP", {
     region: "us-east4-eqdc4a",
     sizeMB: 50000,
   });

--- a/scripts/railway/sync-staging-vars.sh
+++ b/scripts/railway/sync-staging-vars.sh
@@ -20,7 +20,7 @@ STAGING_URL="${1:?usage: sync-staging-vars.sh <staging base url, e.g. https://st
 PROJECT_ID="32b36c6c-5f3d-463b-8c7f-bbcd70351e8f"
 APP_SERVICE_ID="d7a21d02-a448-4970-9989-ab2a7a2589ee"        # CallCaster
 WORKER_SERVICE_ID="9cba9fa7-f3d4-47d8-92a9-7317cea681bf"     # callcaster-worker
-DB_REFERENCE='${{PostgreSQL 18.DATABASE_URL}}'
+DB_REFERENCE='${{Postgres-mgzk.DATABASE_URL}}'
 
 APP_COPY_VARS=(
   BETTER_AUTH_SECRET COHERE_API_KEY ELEVENLABS_API_KEY HOST NODE_ENV PORT


### PR DESCRIPTION
The #1304 apply created both app services but **silently skipped the database**: dev-style `postgres("PostgreSQL 18", {image: "xlab/postgres-ssl-18:latest"})` plans cleanly but never materializes (the image override rides in past the SDK types via ts-expect-error — creation just no-ops). Staging's database was provisioned with `railway add --database postgres` instead → `Postgres-mgzk` + template volume.

This PR makes the model match reality and points `sync-staging-vars.sh`'s `DATABASE_URL` reference at the real service, so staging plans clean again instead of wanting to re-create a database that can't be created.

Phase 3 lesson recorded in the model comment: fresh environments get the standard Postgres template, never a custom-image database via IaC apply.

Part of #1300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)