### PR TITLE
feat(iac): production v2 topology readiness — worker + per-env buckets

### DIFF
--- a/.railway/environments/production.ts
+++ b/.railway/environments/production.ts
@@ -1,4 +1,4 @@
-import { postgres, service, volume } from "railway/iac";
+import { bucket, postgres, service, volume } from "railway/iac";
 import { preservedVariables, source } from "../config/shared.js";
 
 const appVariables = [
@@ -24,21 +24,60 @@ const appVariables = [
   "TWILIO_SID",
 ] as const;
 
+// Worker vars mirror staging's; values land at the cutover window (#1303).
+const workerVariables = [
+  "BASE_URL",
+  "BETTER_AUTH_SECRET",
+  "DATABASE_URL",
+  "NODE_ENV",
+  "RAILWAY_DOCKERFILE_PATH",
+  "RESEND_API_KEY",
+  "S3_ACCESS_KEY_ID",
+  "S3_BUCKET",
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_SECRET_ACCESS_KEY",
+  "STRIPE_SECRET_KEY",
+  "TWILIO_APP_SID",
+  "TWILIO_AUTH_TOKEN",
+  "TWILIO_PHONE_NUMBER",
+  "TWILIO_SID",
+] as const;
+
 export function productionResources() {
   const app = service("callcaster", {
-    // Deploy branch renamed prod → production 2026-08-18 (#1300); the Railway
-    // service still points at the deleted `prod` until this is applied.
+    // The 2026-08-18 branch-repoint apply triggered a live redeploy — treat
+    // every config change to this service as deploy-triggering. Build config
+    // stays Supabase-era until the cutover window (#1303) flips it with the
+    // v2 promotion; do not "modernize" it in passing.
     source: source("production"),
     build: { buildEnvironment: "V2", builder: "NIXPACKS" },
     replicas: { "us-east4-eqdc4a": 1 },
     env: preservedVariables(appVariables),
   });
+  // v2 target database: standard template, schema-only since the July 30
+  // prep (verified 0 workspaces / 0 users on 2026-08-18); the cutover clone
+  // refreshes it. The legacy "Postgres" service is decommissioned post-soak.
   const database = postgres("Postgres-jAO4", { region: "us-east4-eqdc4a" });
   const legacyDatabase = postgres("Postgres", { region: "us-east4-eqdc4a" });
   const databaseVolume = volume("postgres-volume", {
     region: "us-east4-eqdc4a",
     sizeMB: 50000,
   });
+  // Created at apply time; builds from `production` FAIL until the v2
+  // promotion lands there (no Dockerfile.worker on the old tree) — expected
+  // and harmless, the instance just waits for the cutover.
+  const worker = service("callcaster-worker", {
+    source: source("production"),
+    build: {
+      buildEnvironment: "V3",
+      builder: "DOCKERFILE",
+      dockerfilePath: "Dockerfile.worker",
+    },
+    replicas: { "us-east4-eqdc4a": 1 },
+    env: preservedVariables(workerVariables),
+  });
+  const uploads = bucket("callcaster-production", { region: "iad" });
 
-  return [database, legacyDatabase, app, databaseVolume];
+  return [database, legacyDatabase, app, worker, databaseVolume, uploads];
 }

--- a/.railway/environments/staging.ts
+++ b/.railway/environments/staging.ts
@@ -1,4 +1,4 @@
-import { postgres, service, volume } from "railway/iac";
+import { bucket, postgres, service, volume } from "railway/iac";
 import { preservedVariables, source } from "../config/shared.js";
 
 // Staging is a Railway environment mirroring production (#1300): v2 topology,
@@ -82,6 +82,7 @@ export function stagingResources() {
     healthcheck: "/readyz",
     healthcheckTimeout: 30,
     replicas: { "us-east4-eqdc4a": 1 },
+    networking: { privateNetworkEndpoint: "callcaster" },
     env: preservedVariables(appVariables),
   });
   const worker = service("callcaster-worker", {
@@ -95,5 +96,7 @@ export function stagingResources() {
     env: preservedVariables(workerVariables),
   });
 
-  return [database, app, worker, databaseVolume];
+  const uploads = bucket("callcaster-staging", { region: "iad" });
+
+  return [database, app, worker, databaseVolume, uploads];
 }

--- a/scripts/railway/sync-staging-vars.sh
+++ b/scripts/railway/sync-staging-vars.sh
@@ -7,7 +7,9 @@
 #   - DATABASE_URL          -> Railway reference to staging's own Postgres
 #   - BASE_URL              -> the staging app URL (argument)
 #   - BETTER_AUTH_URL       -> the staging app URL (argument)
-# DISABLE_2FA_ENFORCEMENT is dev-only and never copied.
+# DISABLE_2FA_ENFORCEMENT is dev-only and never copied. S3_* is never copied
+# either: staging has its own bucket (callcaster-staging) — populate S3 vars
+# from `railway bucket credentials --bucket callcaster-staging`, not dev.
 #
 # Usage:
 #   scripts/railway/sync-staging-vars.sh https://<staging-app-domain>
@@ -25,14 +27,12 @@ DB_REFERENCE='${{Postgres-mgzk.DATABASE_URL}}'
 APP_COPY_VARS=(
   BETTER_AUTH_SECRET COHERE_API_KEY ELEVENLABS_API_KEY HOST NODE_ENV PORT
   RESEND_API_KEY RUN_CLIENT_MIGRATIONS_ON_BOOT
-  S3_ACCESS_KEY_ID S3_BUCKET S3_ENDPOINT S3_REGION S3_SECRET_ACCESS_KEY
   SIGNUP_OPEN STRIPE_API_KEY STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET
   TWILIO_API_KEY TWILIO_API_SECRET TWILIO_APP_SID TWILIO_AUTH_TOKEN
   TWILIO_PHONE_NUMBER TWILIO_SID
 )
 WORKER_COPY_VARS=(
   BETTER_AUTH_SECRET NODE_ENV RAILWAY_DOCKERFILE_PATH RESEND_API_KEY
-  S3_ACCESS_KEY_ID S3_BUCKET S3_ENDPOINT S3_REGION S3_SECRET_ACCESS_KEY
   STRIPE_SECRET_KEY TWILIO_APP_SID TWILIO_AUTH_TOKEN TWILIO_PHONE_NUMBER
   TWILIO_SID
 )

--- a/scripts/railway/sync-staging-vars.sh
+++ b/scripts/railway/sync-staging-vars.sh
@@ -2,27 +2,28 @@
 # Copy dev's service variables into the staging environment (#1300 phase 2).
 #
 # Staging mirrors production with dev's values (Stripe keys in dev are already
-# test-mode; Twilio is the shared account). Three variables are NOT copied
-# verbatim:
-#   - DATABASE_URL          -> Railway reference to staging's own Postgres
-#   - BASE_URL              -> the staging app URL (argument)
-#   - BETTER_AUTH_URL       -> the staging app URL (argument)
+# test-mode; Twilio is the shared account). Environment-shaped variables are
+# set as Railway REFERENCE variables, never literals, so they follow domain
+# and service changes automatically:
+#   - DATABASE_URL          -> ${{Postgres-mgzk.DATABASE_URL}}
+#   - BASE_URL/BETTER_AUTH_URL (app) -> https://${{RAILWAY_PUBLIC_DOMAIN}}
+#   - BASE_URL (worker)     -> https://${{CallCaster.RAILWAY_PUBLIC_DOMAIN}}
 # DISABLE_2FA_ENFORCEMENT is dev-only and never copied. S3_* is never copied
 # either: staging has its own bucket (callcaster-staging) — populate S3 vars
 # from `railway bucket credentials --bucket callcaster-staging`, not dev.
 #
 # Usage:
-#   scripts/railway/sync-staging-vars.sh https://<staging-app-domain>
+#   scripts/railway/sync-staging-vars.sh
 #
 # Requires: railway CLI authenticated with account scope, jq.
 set -euo pipefail
-
-STAGING_URL="${1:?usage: sync-staging-vars.sh <staging base url, e.g. https://staging.callcaster.ca>}"
 
 PROJECT_ID="32b36c6c-5f3d-463b-8c7f-bbcd70351e8f"
 APP_SERVICE_ID="d7a21d02-a448-4970-9989-ab2a7a2589ee"        # CallCaster
 WORKER_SERVICE_ID="9cba9fa7-f3d4-47d8-92a9-7317cea681bf"     # callcaster-worker
 DB_REFERENCE='${{Postgres-mgzk.DATABASE_URL}}'
+SELF_URL_REFERENCE='https://${{RAILWAY_PUBLIC_DOMAIN}}'
+APP_URL_REFERENCE='https://${{CallCaster.RAILWAY_PUBLIC_DOMAIN}}'
 
 APP_COPY_VARS=(
   BETTER_AUTH_SECRET COHERE_API_KEY ELEVENLABS_API_KEY HOST NODE_ENV PORT
@@ -59,14 +60,14 @@ sync_service() {
 echo "== CallCaster (app) =="
 sync_service "$APP_SERVICE_ID" "${APP_COPY_VARS[@]}"
 railway variable set "DATABASE_URL=$DB_REFERENCE" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
-railway variable set "BASE_URL=$STAGING_URL" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
-railway variable set "BETTER_AUTH_URL=$STAGING_URL" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
-echo "   DATABASE_URL (reference), BASE_URL, BETTER_AUTH_URL (staging URL)"
+railway variable set "BASE_URL=$SELF_URL_REFERENCE" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+railway variable set "BETTER_AUTH_URL=$SELF_URL_REFERENCE" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+echo "   DATABASE_URL, BASE_URL, BETTER_AUTH_URL (references)"
 
 echo "== callcaster-worker =="
 sync_service "$WORKER_SERVICE_ID" "${WORKER_COPY_VARS[@]}"
 railway variable set "DATABASE_URL=$DB_REFERENCE" --service "$WORKER_SERVICE_ID" --environment staging --skip-deploys >/dev/null
-railway variable set "BASE_URL=$STAGING_URL" --service "$WORKER_SERVICE_ID" --environment staging --skip-deploys >/dev/null
-echo "   DATABASE_URL (reference), BASE_URL (staging URL)"
+railway variable set "BASE_URL=$APP_URL_REFERENCE" --service "$WORKER_SERVICE_ID" --environment staging --skip-deploys >/dev/null
+echo "   DATABASE_URL, BASE_URL (references)"
 
 echo "Done. Redeploy staging services to pick up the variables."

--- a/scripts/railway/sync-staging-vars.sh
+++ b/scripts/railway/sync-staging-vars.sh
@@ -8,9 +8,10 @@
 #   - DATABASE_URL          -> ${{Postgres-mgzk.DATABASE_URL}}
 #   - BASE_URL/BETTER_AUTH_URL (app) -> https://${{RAILWAY_PUBLIC_DOMAIN}}
 #   - BASE_URL (worker)     -> https://${{CallCaster.RAILWAY_PUBLIC_DOMAIN}}
-# DISABLE_2FA_ENFORCEMENT is dev-only and never copied. S3_* is never copied
-# either: staging has its own bucket (callcaster-staging) — populate S3 vars
-# from `railway bucket credentials --bucket callcaster-staging`, not dev.
+#   - S3_*                  -> ${{callcaster-staging.*}} bucket references
+#     (ENDPOINT / ACCESS_KEY_ID / SECRET_ACCESS_KEY / REGION / BUCKET —
+#     BUCKET is the real S3 storage name; RAILWAY_BUCKET_NAME is the label)
+# DISABLE_2FA_ENFORCEMENT is dev-only and never copied.
 #
 # Usage:
 #   scripts/railway/sync-staging-vars.sh
@@ -24,6 +25,7 @@ WORKER_SERVICE_ID="9cba9fa7-f3d4-47d8-92a9-7317cea681bf"     # callcaster-worker
 DB_REFERENCE='${{Postgres-mgzk.DATABASE_URL}}'
 SELF_URL_REFERENCE='https://${{RAILWAY_PUBLIC_DOMAIN}}'
 APP_URL_REFERENCE='https://${{CallCaster.RAILWAY_PUBLIC_DOMAIN}}'
+BUCKET='callcaster-staging'
 
 APP_COPY_VARS=(
   BETTER_AUTH_SECRET COHERE_API_KEY ELEVENLABS_API_KEY HOST NODE_ENV PORT
@@ -62,12 +64,24 @@ sync_service "$APP_SERVICE_ID" "${APP_COPY_VARS[@]}"
 railway variable set "DATABASE_URL=$DB_REFERENCE" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
 railway variable set "BASE_URL=$SELF_URL_REFERENCE" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
 railway variable set "BETTER_AUTH_URL=$SELF_URL_REFERENCE" --service "$APP_SERVICE_ID" --environment staging --skip-deploys >/dev/null
-echo "   DATABASE_URL, BASE_URL, BETTER_AUTH_URL (references)"
+set_bucket_refs() {
+  local svc="$1"
+  railway variable set \
+    "S3_ENDPOINT=\${{${BUCKET}.ENDPOINT}}" \
+    "S3_ACCESS_KEY_ID=\${{${BUCKET}.ACCESS_KEY_ID}}" \
+    "S3_SECRET_ACCESS_KEY=\${{${BUCKET}.SECRET_ACCESS_KEY}}" \
+    "S3_REGION=\${{${BUCKET}.REGION}}" \
+    "S3_BUCKET=\${{${BUCKET}.BUCKET}}" \
+    --service "$svc" --environment staging --skip-deploys >/dev/null
+}
+set_bucket_refs "$APP_SERVICE_ID"
+echo "   DATABASE_URL, BASE_URL, BETTER_AUTH_URL, S3_* (references)"
 
 echo "== callcaster-worker =="
 sync_service "$WORKER_SERVICE_ID" "${WORKER_COPY_VARS[@]}"
 railway variable set "DATABASE_URL=$DB_REFERENCE" --service "$WORKER_SERVICE_ID" --environment staging --skip-deploys >/dev/null
 railway variable set "BASE_URL=$APP_URL_REFERENCE" --service "$WORKER_SERVICE_ID" --environment staging --skip-deploys >/dev/null
-echo "   DATABASE_URL, BASE_URL (references)"
+set_bucket_refs "$WORKER_SERVICE_ID"
+echo "   DATABASE_URL, BASE_URL, S3_* (references)"
 
 echo "Done. Redeploy staging services to pick up the variables."


### PR DESCRIPTION
Gets production structurally level with dev/staging ahead of the cutover (#1303): dev has app + worker + Postgres/volume + bucket — production was missing the worker and bucket.

- **`callcaster-worker` in production** — created by the IaC apply (the proven path). Builds from `production` fail until the v2 promotion lands there (no `Dockerfile.worker` on the old tree): expected and harmless, the instance waits for the cutover window.
- **Per-environment buckets** — bucket names are project-unique, so: dev keeps `callcaster`, staging gets `callcaster-staging`, production gets `callcaster-production` (both provisioned via `railway bucket create`, modelled here for zero-drift plans). Staging's S3 vars get repointed to its own bucket next, so uploads stop landing in dev's.
- **`Postgres-jAO4` documented as the v2 target DB** — standard template with public URL + TCP proxy already, schema-only from the July 30 prep (verified 0 workspaces / 0 users today); the cutover clone refreshes it.
- **Deploy-trigger warning encoded**: today's branch-repoint apply live-redeployed the production app (same commit, no harm, site verified 200). The model now carries a comment that every config change to that service is deploy-triggering — build config stays Supabase-era until the promotion flips it.

## Live plans (read-only, 2026-08-18)

| Env | Plan |
|---|---|
| staging | 0 changes |
| production | `+ Create service callcaster-worker` only |

Merging applies nothing; the production apply runs deliberately after merge.

Part of #1300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)