### PR TITLE
feat(iac): cut production worker over to master + preserve staged vars

### DIFF
--- a/.railway/environments/production.ts
+++ b/.railway/environments/production.ts
@@ -3,8 +3,26 @@ import { preservedVariables, source } from "../config/shared.js";
 
 const appVariables = [
   "BASE_URL",
+  // v2 vars pre-staged 2026-08-18 by scripts/railway/stage-production-vars.sh
+  // (--skip-deploys; the cutover build inherits them). They MUST be preserved
+  // here or a plan treats them as deletions — caught live 2026-08-19 when a
+  // plan proposed 14 destructive variable deletes.
+  "BETTER_AUTH_SECRET",
+  "BETTER_AUTH_URL",
+  "COHERE_API_KEY",
   "DATABASE_DIRECT_URL",
   "DATABASE_URL",
+  "ELEVENLABS_API_KEY",
+  "HOST",
+  "NODE_ENV",
+  "PORT",
+  "RUN_CLIENT_MIGRATIONS_ON_BOOT",
+  "S3_ACCESS_KEY_ID",
+  "S3_BUCKET",
+  "S3_ENDPOINT",
+  "S3_REGION",
+  "S3_SECRET_ACCESS_KEY",
+  "SIGNUP_OPEN",
   "OPENAI_API_KEY",
   "RESEND_API_KEY",
   "STRIPE_API_KEY",
@@ -64,11 +82,13 @@ export function productionResources() {
     region: "us-east4-eqdc4a",
     sizeMB: 50000,
   });
-  // Created at apply time; builds from `production` FAIL until the v2
-  // promotion lands there (no Dockerfile.worker on the old tree) — expected
-  // and harmless, the instance just waits for the cutover.
+  // Cut over early (2026-08-19, Nathaniel): the worker builds from `master`
+  // (the v2 code that will be promoted) so it runs and validates the staged
+  // production environment ahead of the app. It idles — postgres-production
+  // has no queued jobs, and the cutover clone resets its rows. The promotion
+  // change (#1303) flips this to source("production") alongside the app.
   const worker = service("callcaster-worker", {
-    source: source("production"),
+    source: source("master"),
     build: {
       buildEnvironment: "V3",
       builder: "DOCKERFILE",


### PR DESCRIPTION
Per Nathaniel's call: production's `callcaster-worker` builds from `master` now — the same v2 code staging runs and the promotion will ship — so it goes green, boots against the staged environment, and pre-validates it (idling: `postgres-production` has no queued jobs; the cutover clone resets its rows). The #1303 promotion flips it back to `source("production")` alongside the app.

**Near-miss worth reading**: the first plan proposed the source flip **plus 14 destructive variable deletions** — the entire pre-staged v2 environment — because the model's preserve-list predated `stage-production-vars.sh`. The staged vars are now modelled; the final plan is exactly one change:

```
Plan: 0 to add, 1 to change, 0 to destroy
  ~ Update callcaster-worker source.branch ("production" → "master")
```

Standing rule this reinforces: any variable added outside IaC must land in the preserve-list in the same breath, or the next apply eats it.

Part of #1300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)